### PR TITLE
Reducing exception from fatal to notification on shipping method problem

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -793,7 +793,8 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
         foreach ($rates as $rate) {
             if ($rate->getErrorMessage()) {
-                throw new Exception("Error getting shipping option for " .  $rate->getCarrierTitle() . ": " . $rate->getErrorMessage());
+                Mage::helper('boltpay/bugsnag')->notifyException( new Exception("Error getting shipping option for " .  $rate->getCarrierTitle() . ": " . $rate->getErrorMessage()) );
+                continue;
             }
 
             $quote->getShippingAddress()->setShippingMethod($rate->getCode());


### PR DESCRIPTION
We do not want the code to completely fail if there is a problem with a single shipping option.

Reasoning:
The idea of our plugin is to increase conversions.  It is not to make sure that FedEx, or ShippingHQ, or UPS, or whatever plugin is working.  There can be any number of reasons why one maybe down, like internet problems, or strict address validation for a particular region, whereas other shipping methods will not fail.

If any given shipping method fails for whatever reason, it is good to note it, but we must present the customer with all available shipping options so that they can check out of Bolt successfully and increase our conversion rates.

When making a decision like this, it may be good to consider what the underlying system would do.  In this instance, we can ask ourselves, "If FedEx was down, would the Magento one page checkout completely breakdown and leave the customer with no way to checkout, or would it give the customer all the available options that it is aware of?"

Options are better than no options in this instance.