### PR TITLE
Renaming addMetaData to addBreadcrumb

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -450,17 +450,14 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         //Mage::log('KEY: ' . Mage::helper('core')->decrypt($key), null, 'bolt.log');
 
         $context_info = Mage::helper('boltpay/bugsnag')->getContextInfo();
-        $header_info = array(
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
             'Content-Type: application/json',
             'Content-Length: ' . strlen($params),
             'X-Api-Key: ' . Mage::helper('core')->decrypt($key),
             'X-Nonce: ' . rand(100000000, 999999999),
             'User-Agent: BoltPay/Magento-' . $context_info["Magento-Version"],
             'X-Bolt-Plugin-Version: ' . $context_info["Bolt-Plugin-Version"]
-            );
-        curl_setopt($ch, CURLOPT_HTTPHEADER, $header_info);
-        $apiRequestData = array_merge($header_info,$data);
-        Mage::helper('boltpay/bugsnag')->addMetaData(['BOLT API REQUEST' => $apiRequestData]);
+            ));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, true);
 
@@ -480,7 +477,6 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         $this->setCurlResultWithHeader($ch, $result);
 
         $resultJSON = $this->getCurlJSONBody();
-        Mage::helper('boltpay/bugsnag')->addMetaData(['BOLT API RESPONSE' => $resultJSON]);
         $jsonError = $this->handleJSONParseError();
         if ($jsonError != null) {
             curl_close($ch);

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -286,7 +286,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         try {
             $service->submitAll();
         } catch (Exception $e) {
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     'transaction'   => json_encode((array)$transaction),
                     'quote_address' => var_export($quote->getShippingAddress()->debug(), true)
@@ -379,7 +379,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         $quote->setTotalsCollectedFlag(false)->collectTotals()->save();
 
         if($this->isDiscountRoundingDeltaError($transaction, $quote)) {
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     'transaction'  => $transaction,
                     'quote'  => var_export($quote->debug(), true),
@@ -393,7 +393,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
     protected function validateSubmittedOrder($order, $quote) {
         if(empty($order)) {
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     'quote'  => var_export($quote->debug(), true),
                     'quote_address'  => var_export($quote->getShippingAddress()->debug(), true),
@@ -450,17 +450,17 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         //Mage::log('KEY: ' . Mage::helper('core')->decrypt($key), null, 'bolt.log');
 
         $context_info = Mage::helper('boltpay/bugsnag')->getContextInfo();
-
-        curl_setopt(
-            $ch, CURLOPT_HTTPHEADER, array(
+        $header_info = array(
             'Content-Type: application/json',
             'Content-Length: ' . strlen($params),
             'X-Api-Key: ' . Mage::helper('core')->decrypt($key),
             'X-Nonce: ' . rand(100000000, 999999999),
             'User-Agent: BoltPay/Magento-' . $context_info["Magento-Version"],
             'X-Bolt-Plugin-Version: ' . $context_info["Bolt-Plugin-Version"]
-            )
-        );
+            );
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $header_info);
+        $apiRequestData = array_merge($header_info,$data);
+        Mage::helper('boltpay/bugsnag')->addMetaData(['BOLT API REQUEST' => $apiRequestData]);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, true);
 
@@ -480,6 +480,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         $this->setCurlResultWithHeader($ch, $result);
 
         $resultJSON = $this->getCurlJSONBody();
+        Mage::helper('boltpay/bugsnag')->addMetaData(['BOLT API RESPONSE' => $resultJSON]);
         $jsonError = $this->handleJSONParseError();
         if ($jsonError != null) {
             curl_close($ch);

--- a/app/code/community/Bolt/Boltpay/Helper/Bugsnag.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Bugsnag.php
@@ -164,14 +164,4 @@ class Bolt_Boltpay_Helper_Bugsnag extends Mage_Core_Helper_Abstract
         return null;
     }
 
-    /* add metaData for to create new tab
-    *
-    * @param array $metaData
-    *
-    */
-    public function addMetaData(array $metaData)
-    {
-        $this->metaData = array_merge($this->metaData, $metaData);
-    }
-
 }

--- a/app/code/community/Bolt/Boltpay/Helper/Bugsnag.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Bugsnag.php
@@ -37,7 +37,7 @@ class Bolt_Boltpay_Helper_Bugsnag extends Mage_Core_Helper_Abstract
 
     private $boltTraceId;
 
-    public function addMetaData($metaData) 
+    public function addBreadcrumb($metaData) 
     {
         $this->metaData['breadcrumbs_'] = array_merge($metaData, $this->metaData['breadcrumbs_']);
     }
@@ -85,7 +85,7 @@ class Bolt_Boltpay_Helper_Bugsnag extends Mage_Core_Helper_Abstract
         $traceId = $this->getBoltTraceId();
 
         if(!empty($traceId) && !array_key_exists('bolt_trace_id', $this->metaData)) {
-            $this->addMetaData(
+            $this->addBreadcrumb(
                 array(
                 "bolt_trace_id" => $traceId
                 )
@@ -163,4 +163,15 @@ class Bolt_Boltpay_Helper_Bugsnag extends Mage_Core_Helper_Abstract
 
         return null;
     }
+
+    /* add metaData for to create new tab
+    *
+    * @param array $metaData
+    *
+    */
+    public function addMetaData(array $metaData)
+    {
+        $this->metaData = array_merge($this->metaData, $metaData);
+    }
+
 }

--- a/app/code/community/Bolt/Boltpay/Model/Api2/Order/Rest/Admin/V1.php
+++ b/app/code/community/Bolt/Boltpay/Model/Api2/Order/Rest/Admin/V1.php
@@ -174,7 +174,7 @@ class Bolt_Boltpay_Model_Api2_Order_Rest_Admin_V1 extends Bolt_Boltpay_Model_Api
             //Mage::log("Late queue event. Returning as OK", null, 'bolt.log');
 
 
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     "API HOOKS late queue event" => array (
                         "message" => $error,
@@ -189,7 +189,7 @@ class Bolt_Boltpay_Model_Api2_Order_Rest_Admin_V1 extends Bolt_Boltpay_Model_Api
             $error = $e->getMessage();
             //Mage::log($error, null, 'bolt.log');
 
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     "API HOOKS Exception" => array (
                         "message" => $error,

--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -418,7 +418,7 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
             $error = array('error' => $e->getMessage());
             //Mage::log($error, null, 'bolt.log');
 
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     "handle order update" => array (
                         "message" => $error['error'],
@@ -538,7 +538,7 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
             $error = array('error' => $e->getMessage());
             //Mage::log($error, null, 'bolt.log');
 
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     "handle transaction update" => array (
                         "message" => $error['error'],
@@ -574,7 +574,7 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
 
     protected function validateCaptureAmount($captureAmount) {
         if(!isset($captureAmount) || !is_numeric($captureAmount) || $captureAmount < 0) {
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     'capture_amount'  => $captureAmount,
                 )

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -124,7 +124,7 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
             /* @var Mage_Sales_Model_Quote $quote */
             $quote = Mage::getModel('sales/quote')->loadByIdWithoutStore($quoteId);
 
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                 'reference'  => $reference,
                 'quote_id'   => $quoteId,

--- a/app/code/community/Bolt/Boltpay/controllers/OrderController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OrderController.php
@@ -49,7 +49,7 @@ class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
 
             $reference = $this->getRequest()->getPost('reference');
 
-            Mage::helper('boltpay/bugsnag')->addMetaData(
+            Mage::helper('boltpay/bugsnag')->addBreadcrumb(
                 array(
                     "Save Action reference" => array (
                         "reference" => $reference,


### PR DESCRIPTION
I think there are other code that makes http request. can you update other places too?

@daisy1754 most of BOLT request call from using API helper Transmit method, 
all other http request data already added to Bugsnag Breadcrumb
Ex. bolt hook request we added reference and quote id in Breadcrumb