### PR TITLE
Explicitly set quote belong to guest if customer id does not exist

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -259,6 +259,7 @@ class Bolt_Boltpay_Block_Checkout_Boltpay
 
                 $immutableQuote
                     ->setCustomer($sessionQuote->getCustomer())
+                    ->setCustomerIsGuest( (($sessionQuote->getCustomerId()) ? false : true) )
                     ->setReservedOrderId($reservedOrderId)
                     ->setStoreId($sessionQuote->getStoreId())
                     ->setParentQuoteId($sessionQuote->getId())

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -204,9 +204,9 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             $immutableQuote->save();
         }
         // explicitly set quote belong to guest if customer id does not exist
-        if (!$quote->getCustomerId()) {
-            $quote->setCustomerIsGuest(true);
-            $quote->save();
+        if (!$immutableQuote->getCustomerId()) {
+            $immutableQuote->setCustomerIsGuest(true);
+            $immutableQuote->save();
         }
 
         $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true)->save();

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -203,6 +203,11 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             $immutableQuote->setCustomerEmail($email);
             $immutableQuote->save();
         }
+        // explicitly set quote belong to guest if customer id does not exist
+        if (!$quote->getCustomerId()) {
+            $quote->setCustomerIsGuest(true);
+            $quote->save();
+        }
 
         $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true)->save();
         $immutableQuote->getBillingAddress()->setShouldIgnoreValidation(true)->save();

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -203,11 +203,12 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             $immutableQuote->setCustomerEmail($email);
             $immutableQuote->save();
         }
+        
         // explicitly set quote belong to guest if customer id does not exist
-        if (!$immutableQuote->getCustomerId()) {
-            $immutableQuote->setCustomerIsGuest(true);
-            $immutableQuote->save();
-        }
+        $parentQuote = Mage::getModel('sales/quote')->loadByIdWithoutStore($immutableQuote->getParentQuoteId());
+        $immutableQuote
+            ->setCustomerIsGuest( (($parentQuote->getCustomerId()) ? false : true) )
+            ->save();
 
         $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true)->save();
         $immutableQuote->getBillingAddress()->setShouldIgnoreValidation(true)->save();


### PR DESCRIPTION
when processing Magento order creation in API,  getCustomerIsGuest is false even the customer isnot logged in, so we need to explicitly set it to false for guest. to avoid misjudgement in thrid-party modules