### PR TITLE
Correct the price and tax calculation for group customer

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -259,6 +259,7 @@ class Bolt_Boltpay_Block_Checkout_Boltpay
 
                 $immutableQuote
                     ->setCustomer($sessionQuote->getCustomer())
+                    ->setCustomerGroupId($sessionQuote->getCustomerGroupId())
                     ->setCustomerIsGuest( (($sessionQuote->getCustomerId()) ? false : true) )
                     ->setReservedOrderId($reservedOrderId)
                     ->setStoreId($sessionQuote->getStoreId())

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -88,6 +88,8 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
             /**************/
 
             if ($quote->getCustomerId()) {
+                $customerSession = Mage::getSingleton('customer/session');
+                $customerSession->setCustomerGroupId($quote->getCustomerGroupId());
                 $customer = Mage::getModel("customer/customer")->load($quote->getCustomerId());
                 $address = $customer->getPrimaryShippingAddress();
 


### PR DESCRIPTION
This is background for this PR

When I run test on merchant site, I found a strange issue. This merchant site has some customer groups that would have a discount (actually it is a customer group price) on the products of some categories, then I try to checkout as a logged customer in such a customer group, two products in the cart, one is configurable product and another is simple product. and on the shipping method tab, the tax is always wrong. and I found that the price of configurable product would be changed to its original price while the simple product keep correct during quote->collectTotals() process especially when address->collectTotals() every time, that's why the tax is wrong. 

and I dig into it
1. when address->collectTotals() it would collect each total object, and for this issue, it is Mage_Sales_Model_Quote_Address_Total_Subtotal, in its process, it would call getFinalPrice for each item in the cart. 
2. This merchant site has a third-party module that extend Mage_Catalog_Model_Product_Type_Configurable_Price, and in its getFinalPrice function it would load chosen subproduct of configurable product and get the final price of this simple product again. 
3. For normal simple product, when get its final price, there is a step to get its getGroupPrice, and there it would try to load customer group id from 'customer/session'. 
4. since we do not set customer group id for 'customer/session' when loading shipping and tax. it would cause this issue

so I first set customer group id for the immutable quote when create it. and then setCustomerGroupId for 'customer/session' when load shipping and tax