### PR TITLE
Bypass getShippingAndTaxEstimate if post code is invalid.

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -817,7 +817,12 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
      */
     public function getShippingAndTaxEstimate( $quote )
     {
-        $response = $this->getDefaultShippingAndTaxResponse();
+        $response = array(
+            'shipping_options' => array(),
+            'tax_result' => array(
+                "amount" => 0
+            ),
+        );
 
         Mage::helper('boltpay')->collectTotals(Mage::getModel('sales/quote')->load($quote->getId()));
 
@@ -879,18 +884,6 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         }
 
         return $response;
-    }
-
-    /**
-     * Returns default shipping and tax response.
-     */
-    public function getDefaultShippingAndTaxResponse() {
-        return array(
-            'shipping_options' => array(),
-            'tax_result' => array(
-                "amount" => 0
-            ),
-        );
     }
 
     /**

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -817,12 +817,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
      */
     public function getShippingAndTaxEstimate( $quote )
     {
-        $response = array(
-            'shipping_options' => array(),
-            'tax_result' => array(
-                "amount" => 0
-            ),
-        );
+        $response = $this->getDefaultShippingAndTaxResponse();
 
         Mage::helper('boltpay')->collectTotals(Mage::getModel('sales/quote')->load($quote->getId()));
 
@@ -884,6 +879,18 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         }
 
         return $response;
+    }
+
+    /**
+     * Returns default shipping and tax response.
+     */
+    public function getDefaultShippingAndTaxResponse() {
+        return array(
+            'shipping_options' => array(),
+            'tax_result' => array(
+                "amount" => 0
+            ),
+        );
     }
 
     /**

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -221,7 +221,12 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
             try {
                 /** @var Bolt_Boltpay_Helper_Api $helper */
                 $helper = Mage::helper('boltpay/api');
-                $estimateResponse = $helper->getShippingAndTaxEstimate($quote);
+
+                if (@$addressData['postcode']) {
+                    $estimateResponse = $helper->getShippingAndTaxEstimate($quote);
+                } else {
+                    $estimateResponse = $helper->getDefaultShippingAndTaxResponse();
+                }
 
                 $this->cacheShippingAndTaxEstimate($estimateResponse, $cacheIdentifier);
             } catch (Exception $e) {

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -212,25 +212,22 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
 
             $addressData = $this->mergeAddressData($geoLocationAddress, $shippingAddress);
 
-            $cacheIdentifier = $this->getPrefetchCacheIdentifier($quote, $addressData);
-            $this->saveAddressCache($addressData, $cacheIdentifier);
+            if (@$addressData['postcode']) {
+                $cacheIdentifier = $this->getPrefetchCacheIdentifier($quote, $addressData);
+                $this->saveAddressCache($addressData, $cacheIdentifier);
 
-            $quote->getShippingAddress()->addData($addressData);
-            $quote->getBillingAddress()->addData($addressData);
+                $quote->getShippingAddress()->addData($addressData);
+                $quote->getBillingAddress()->addData($addressData);
 
-            try {
-                /** @var Bolt_Boltpay_Helper_Api $helper */
-                $helper = Mage::helper('boltpay/api');
-
-                if (@$addressData['postcode']) {
+                try {
+                    /** @var Bolt_Boltpay_Helper_Api $helper */
+                    $helper = Mage::helper('boltpay/api');
                     $estimateResponse = $helper->getShippingAndTaxEstimate($quote);
-                } else {
-                    $estimateResponse = $helper->getDefaultShippingAndTaxResponse();
-                }
 
-                $this->cacheShippingAndTaxEstimate($estimateResponse, $cacheIdentifier);
-            } catch (Exception $e) {
-                $estimateResponse = null;
+                    $this->cacheShippingAndTaxEstimate($estimateResponse, $cacheIdentifier);
+                } catch (Exception $e) {
+                    $estimateResponse = null;
+                }
             }
         }
 


### PR DESCRIPTION
Here is the new branch and pull request for overriding shipping and tax estimate when prefetch makes request with invalid zip code.

See also: https://github.com/BoltApp/bolt-magento1/pull/55