### PR TITLE
Set total_amount to 0 when it's negative.

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -756,6 +756,11 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
         //Mage::log(var_export($cart_submission_data, true), null, "bolt.log");
 
+        // In some cases discount amount can cause total_amount to be negative. In this case we need to set it to 0.
+        if($cartSubmissionData['total_amount'] < 0) {
+            $cartSubmissionData['total_amount'] = 0;
+        }
+
         return $this->getCorrectedTotal($calculatedTotal, $cartSubmissionData);
     }
 


### PR DESCRIPTION
Found this when attempting to use store credit. Bolt needs us to send the full store credit (not just the amount that will be applied to the sub-total) to Bolt so that when we add shipping during the shipping method step, the store credit can be applied to it. However, in the case where the store credit is greater than the current grand total it causes the total amount to be negative which causes exceptions on the Bolt modal. So after a discussion with Kazuki we decided to set this to 0 if it's negative.