### PR TITLE
Make publishable key unencrypted

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -120,17 +120,6 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * Decrypt key
-     *
-     * @param $key
-     * @return string
-     */
-    private function decryptKey($key)
-    {
-        return Mage::helper('core')->decrypt($key);
-    }
-
-    /**
      * Get publishable key used in cart page.
      *
      * @return string
@@ -138,7 +127,7 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
     public function getPublishableKeyMultiPage()
     {
         $key = Mage::getStoreConfig('payment/boltpay/publishable_key_multipage');
-        return $this->decryptKey($key);
+        return $key;
     }
 
     /**
@@ -149,7 +138,7 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
     public function getPublishableKeyOnePage()
     {
         $key = Mage::getStoreConfig('payment/boltpay/publishable_key_onepage');
-        return $this->decryptKey($key);
+        return $key;
     }
 
     /**
@@ -160,7 +149,7 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
     public function getPublishableKeyBackOffice()
     {
         $key = Mage::getStoreConfig('payment/boltpay/publishable_key_admin');
-        return $this->decryptKey($key);
+        return $key;
     }
 
     /**

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -20,7 +20,7 @@
 
   <modules>
     <Bolt_Boltpay>
-      <version>1.1.4</version> <!-- version number should be incremented appropriately  -->
+      <version>1.1.5</version> <!-- version number should be incremented appropriately  -->
     </Bolt_Boltpay>
   </modules>
 

--- a/app/code/community/Bolt/Boltpay/etc/system.xml
+++ b/app/code/community/Bolt/Boltpay/etc/system.xml
@@ -68,8 +68,7 @@
             </api_key>
             <publishable_key_onepage translate="label">
               <label> Publishable Key - One Page Checkout</label>
-              <frontend_type>obscure</frontend_type>
-              <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
+              <frontend_type>text</frontend_type>
               <sort_order>11</sort_order>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
@@ -77,8 +76,7 @@
             </publishable_key_onepage>
             <publishable_key_multipage translate="label">
               <label> Publishable Key - Multi-Page Checkout</label>
-              <frontend_type>obscure</frontend_type>
-              <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
+              <frontend_type>text</frontend_type>
               <sort_order>12</sort_order>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
@@ -86,8 +84,7 @@
             </publishable_key_multipage>
             <publishable_key_admin translate="label">
               <label> Publishable Key - Backoffice</label>
-              <frontend_type>obscure</frontend_type>
-              <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
+              <frontend_type>text</frontend_type>
               <sort_order>13</sort_order>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>

--- a/app/code/community/Bolt/Boltpay/sql/bolt_boltpay_setup/upgrade-1.1.4-1.1.4.9.php
+++ b/app/code/community/Bolt/Boltpay/sql/bolt_boltpay_setup/upgrade-1.1.4-1.1.4.9.php
@@ -15,7 +15,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 /**
- * This installer adds an index for sales_flat_quote->parent_quote_id
+ * This installer unencrypt publishable key
  *
 /** @var Mage_Core_Model_Resource_Setup $installer */
 $installer = $this;

--- a/app/code/community/Bolt/Boltpay/sql/bolt_boltpay_setup/upgrade-1.1.4-1.1.4.9.php
+++ b/app/code/community/Bolt/Boltpay/sql/bolt_boltpay_setup/upgrade-1.1.4-1.1.4.9.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Bolt magento plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+/**
+ * This installer adds an index for sales_flat_quote->parent_quote_id
+ *
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$setup = new Mage_Eav_Model_Entity_Setup('core_setup');
+
+Mage::log('Installing Bolt 1.1.4.9 updates', null, 'bolt_install.log');
+
+$configTable = $installer->getTable('core/config_data');
+/** @var Magento_Db_Adapter_Pdo_Mysql $connection */
+$connection = $installer->getConnection();
+$query = $connection->query("SELECT * FROM $configTable WHERE path LIKE 'payment/boltpay/publishable_key_%'");
+
+$resultData = $query->fetchAll();
+
+if (count($resultData)) {
+    $coreHelper = Mage::helper('core');
+    foreach ($resultData as $row) {
+        $keyValue = $row['value'];
+        $configId = $row['config_id'];
+        $decryptedKey = $coreHelper->decrypt($keyValue);
+
+        if ($decryptedKey && $configId) {
+            $connection->query("UPDATE $configTable SET value=? WHERE config_id=?", array($decryptedKey, $configId));
+        } else {
+            Mage::log('Something happened with config', null, 'bolt_install.log');
+            Mage::log($row, null, 'bolt_install.log');
+        }
+    }
+} else {
+    Mage::log('Bolt 1.1.4.9: does not find any publishable keys', null, 'bolt_install.log');
+}
+
+Mage::log('Bolt 1.1.4.9 updates installation completed', null, 'bolt_install.log');
+
+$installer->endSetup();

--- a/app/design/frontend/base/default/template/boltpay/track.phtml
+++ b/app/design/frontend/base/default/template/boltpay/track.phtml
@@ -28,6 +28,6 @@ $version = (string)$versionElm[0];
             src="<?= $this->getTrackJsUrl(); ?>"
             data-publishable-key="<?=$this->getPublishableKey((Mage::app()->getRequest()->getControllerName() === 'cart') ? 'multi-page' : 'one-page'); ?>">
     </script>
-    <script>console.log("Bolt Version: <?=$version?>");');</script>
+    <script>console.log("Bolt Version: <?=$version?>");</script>
 <?php endif; ?>
 


### PR DESCRIPTION
Currently, plugin stores "publishable key" as encrypted data but there is no need (it is publishable). Let's not encrypt.