### PR TITLE
Catch and report post success forward errors

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/OnepageController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OnepageController.php
@@ -14,79 +14,43 @@
  * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-
 require_once 'Mage/Checkout/controllers/OnepageController.php';
 
 /**
  * Class Bolt_Boltpay_OnepageController
  *
- * @deprecated This will be removed after the skip payment option is resolved.
  */
 class Bolt_Boltpay_OnepageController extends Mage_Checkout_OnepageController
 {
-    public function saveShippingMethodAction() 
+
+    /**
+     * Order success action
+     */
+    public function successAction()
     {
-        try {
-            if ($this->_expireAjax()) {
-                return;
-            }
-
-            if ($this->getRequest()->isPost()) {
-                $data = $this->getRequest()->getPost('shipping_method', '');
-                $result = $this->getOnepage()->saveShippingMethod($data);
-                // $result will contain error data if shipping method is empty
-                if (!$result) {
-                    if (Mage::getStoreConfig('payment/boltpay/skip_payment')) {
-                        try {
-                            $data = array('method' => Bolt_Boltpay_Model_Payment::METHOD_CODE);
-                            $result = $this->getOnepage()->savePayment($data);
-                        } catch (Mage_Payment_Exception $e) {
-                            if ($e->getFields()) {
-                                $result['fields'] = $e->getFields();
-                            }
-
-                            $result['error'] = $e->getMessage();
-                            Mage::helper('boltpay/bugsnag')->notifyException($e);
-                        } catch (Mage_Core_Exception $e) {
-                            $result['error'] = $e->getMessage();
-                            Mage::helper('boltpay/bugsnag')->notifyException($e);
-                        } catch (Exception $e) {
-                            //Mage::logException($e);
-                            $result['error'] = $this->__('Unable to set Payment Method.');
-                            Mage::helper('boltpay/bugsnag')->notifyException($e);
-                        }
-                    }
-
-                    if (!$result) {
-                        Mage::dispatchEvent(
-                            'checkout_controller_onepage_save_shipping_method',
-                            array(
-                                'request' => $this->getRequest(),
-                            'quote' => $this->getOnepage()->getQuote())
-                        );
-                        Mage::helper('boltpay')->collectTotals($this->getOnepage()->getQuote());
-                        $this->getResponse()->setBody(Mage::helper('core')->jsonEncode($result));
-                        if (Mage::getStoreConfig('payment/boltpay/skip_payment')) {
-                            $this->loadLayout('checkout_onepage_review');
-                            $result['goto_section'] = 'review';
-                            $result['update_section'] = array(
-                                'name' => 'review',
-                                'html' => $this->_getReviewHtml());
-                        } else {
-                            $result['goto_section'] = 'payment';
-                            $result['update_section'] = array(
-                                'name' => 'payment-method',
-                                'html' => $this->_getPaymentMethodsHtml());
-                        }
-                    }
-                }
-
-                Mage::helper('boltpay')->collectTotals($this->getOnepage()->getQuote())->save();
-                $this->getResponse()->setBody(Mage::helper('core')->jsonEncode($result));
-            }
-        } catch (Exception $e) {
-            Mage::helper('boltpay/bugsnag')->notifyException($e);
-            throw $e;
+        $session = $this->getOnepage()->getCheckout();
+        if (!$session->getLastSuccessQuoteId()) {
+            $this->_redirect('checkout/cart');
+            return;
         }
+
+        $lastQuoteId = $session->getLastQuoteId();
+        $lastOrderId = $session->getLastOrderId();
+        $lastRecurringProfiles = $session->getLastRecurringProfileIds();
+        if (!$lastQuoteId || (!$lastOrderId && empty($lastRecurringProfiles))) {
+            $this->_redirect('checkout/cart');
+            return;
+        }
+
+        $session->clear();
+        $this->loadLayout();
+        $this->_initLayoutMessages('checkout/session');
+
+        try {
+            Mage::dispatchEvent('checkout_onepage_controller_success_action', array('order_ids' => array($lastOrderId)));
+        } catch ( Exception $e ) {
+            Mage::helper('boltpay/bugsnag')->notifyException($e);
+        }
+        $this->renderLayout();
     }
 }

--- a/app/code/community/Bolt/Boltpay/controllers/OnepageController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OnepageController.php
@@ -50,6 +50,10 @@ class Bolt_Boltpay_OnepageController extends Mage_Checkout_OnepageController
             Mage::dispatchEvent('checkout_onepage_controller_success_action', array('order_ids' => array($lastOrderId)));
         } catch ( Exception $e ) {
             Mage::helper('boltpay/bugsnag')->notifyException($e);
+            
+            if (strtolower($this->_getOrder()->getPayment()->getMethod()) !== Bolt_Boltpay_Model_Payment::METHOD_CODE) {
+                throw $e;
+            }
         }
         $this->renderLayout();
     }

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -20,7 +20,7 @@
 
   <modules>
     <Bolt_Boltpay>
-      <version>1.1.5</version> <!-- version number should be incremented appropriately  -->
+      <version>1.1.5.2</version> <!-- commit 57f237e8562138760e41c20c6d6d7952f263d17c -->
     </Bolt_Boltpay>
   </modules>
 
@@ -54,14 +54,12 @@
       </boltpay>
     </helpers>
 
-    <!--
     <rewrite>
       <bolt_boltpay_onepage>
         <from><![CDATA[#^/checkout/onepage/#]]></from>
         <to>/boltpay/onepage/</to>
       </bolt_boltpay_onepage>
     </rewrite>
-    -->
 
     <resources>
       <bolt_boltpay_setup>

--- a/app/design/frontend/base/default/template/boltpay/track.phtml
+++ b/app/design/frontend/base/default/template/boltpay/track.phtml
@@ -15,7 +15,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 ?>
-<? /* @var $this Bolt_Boltpay_Block_Checkout_Boltpay */?>
+<?php /* @var $this Bolt_Boltpay_Block_Checkout_Boltpay */ ?>
 <?php
 $versionElm =  Mage::getConfig()->getModuleConfig("Bolt_Boltpay")->xpath("version");
 $version = (string)$versionElm[0];


### PR DESCRIPTION
After the order is saved to Bolt and Magento, the browser is then forwarded to the success page.  Before this, Magento triggers a `checkout_onepage_controller_success_action` event which several plugins may hook into and in some cases fail.

Instead of allowing the program to crash, for Bolt orders, we catch the exception and report it to Bugsnag.