### PR TITLE
Generate new increment id if detected as already in use

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -274,11 +274,12 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             $preExistingOrder = Mage::getModel('sales/order')->loadByIncrementId($parentQuote->getReservedOrderId());
 
             ############################
-            # First check if this order matches the transaction and therefore duplicated.
+            # First check if this order matches the transaction and therefore already created
             ############################
             $preExistingTransactionReference = $preExistingOrder->getPayment()->getAdditionalInformation('bolt_reference');
             if ( $preExistingTransactionReference === $reference ) {
-                throw new Exception("The order #".$preExistingOrder->getIncrementId()." has already been processed for this quote." );
+                Mage::helper('boltpay/bugsnag')->notifyException( new Exception("The order #".$preExistingOrder->getIncrementId()." has already been processed for this quote." ), array(), 'warning' );
+                return $preExistingOrder;
             }
             ############################
 

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -267,6 +267,22 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
             Mage::helper('boltpay')->collectTotals($immutableQuote, true)->save();
 
+            ////////////////////////////////////////////////////////////////////////////
+            // reset increment id if needed
+            ////////////////////////////////////////////////////////////////////////////
+            /* @var Mage_Sales_Model_Order $preExistingOrder */
+            $preExistingOrder = Mage::getModel('sales/order')->loadByIncrementId($parentQuote->getReservedOrderId());
+
+            if (!$preExistingOrder->isObjectNew()) {
+                $parentQuote
+                    ->setReservedOrderId(null)
+                    ->reserveOrderId()
+                    ->save();
+
+                $immutableQuote->setReservedOrderId($parentQuote->getReservedOrderId());
+            }
+            ////////////////////////////////////////////////////////////////////////////
+
             // a call to internal Magento service for order creation
             $service = Mage::getModel('sales/service_quote', $immutableQuote);
 

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -273,6 +273,15 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             /* @var Mage_Sales_Model_Order $preExistingOrder */
             $preExistingOrder = Mage::getModel('sales/order')->loadByIncrementId($parentQuote->getReservedOrderId());
 
+            ############################
+            # First check if this order matches the transaction and therefore duplicated.
+            ############################
+            $preExistingTransactionReference = $preExistingOrder->getPayment()->getAdditionalInformation('bolt_reference');
+            if ( $preExistingTransactionReference === $reference ) {
+                throw new Exception("The order #".$preExistingOrder->getIncrementId()." has already been processed for this quote." );
+            }
+            ############################
+
             if (!$preExistingOrder->isObjectNew()) {
                 $parentQuote
                     ->setReservedOrderId(null)

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -20,7 +20,7 @@
 
   <modules>
     <Bolt_Boltpay>
-      <version>1.1.5</version> <!-- version number should be incremented appropriately  -->
+      <version>1.1.6</version> <!-- version number should be incremented appropriately  -->
     </Bolt_Boltpay>
   </modules>
 

--- a/app/design/frontend/base/default/template/boltpay/track.phtml
+++ b/app/design/frontend/base/default/template/boltpay/track.phtml
@@ -15,7 +15,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 ?>
-<? /* @var $this Bolt_Boltpay_Block_Checkout_Boltpay */?>
+<?php /* @var $this Bolt_Boltpay_Block_Checkout_Boltpay */ ?>
 <?php
 $versionElm =  Mage::getConfig()->getModuleConfig("Bolt_Boltpay")->xpath("version");
 $version = (string)$versionElm[0];

--- a/create_release.sh
+++ b/create_release.sh
@@ -10,6 +10,7 @@ rm -fr /tmp/bolt_magento_plugin
 
 mkdir /tmp/bolt_magento_plugin
 cp -r app /tmp/bolt_magento_plugin/.
+cp -r js /tmp/bolt_magento_plugin/.
 cp -r lib /tmp/bolt_magento_plugin/.
 cp -r skin /tmp/bolt_magento_plugin/.
 cp CHANGELOG.md /tmp/bolt_magento_plugin/.


### PR DESCRIPTION
Several times we have observed that the reserved order id (increment id) can be used even though a quote has "reserved" it.  This is also implied as an expectation in core Magento code in class `Mage_Sales_Model_Quote`

```
    /**
     * Generate new increment order id and associate it with current quote
     *
     * @return Mage_Sales_Model_Quote
     */
    public function reserveOrderId()
    {
        if (!$this->getReservedOrderId()) {
            $this->setReservedOrderId($this->_getResource()->getReservedOrderId($this));
        } else {
            //checking if reserved order id was already used for some order
            //if yes reserving new one if not using old one
            if ($this->_getResource()->isOrderIncrementIdUsed($this->getReservedOrderId())) {
                $this->setReservedOrderId($this->_getResource()->getReservedOrderId($this));
            }
        }
        return $this;
    }
```

This fix is needed for SwissGear and would benefit the Magento 1 plugin on the whole.

***NOTE:***
_The complete solution calls for a simple, and reliable way to reset display_id on Bolt.
If it requires not setting the display id until we are sure of what it will be, then we should 
do this in the Magento 1 code, and enable it in the Bolt side code for Magento 1_

**_These means that my proposal is to remove sending display_id from the Bolt order creation routine, then to send it to Bolt in the response of the first webhook call, and finally have this feature enabled in Magento 1 like in all other plugins._**