### PR TITLE
Reset in use increment id complete solution

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -636,6 +636,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         $productMediaConfig = Mage::getModel('catalog/product_media_config');
         $cartSubmissionData = array(
             'order_reference' => $quote->getId(),
+            'display_id'      => $quote->getReservedOrderId(),
             'items'           => array_map(
                 function ($item) use ($quote, $productMediaConfig, &$calculatedTotal) {
                     $imageUrl = $productMediaConfig->getMediaUrl($item->getProduct()->getThumbnail());

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -1087,4 +1087,21 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
         return true;
     }
+
+
+    /**
+     * Gets a an order by quote id/order reference
+     *
+     * @param int|string $quoteId  The quote id which this order was created from
+     *
+     * @return Mage_Sales_Model_Order   If found, and order with all the details, otherwise a new object order
+     */
+    public function getOrderByQuoteId($quoteId) {
+        /* @var Mage_Sales_Model_Resource_Order_Collection $orderCollection */
+        $orderCollection = Mage::getResourceModel('sales/order_collection');
+
+        return $orderCollection
+                ->addFieldToFilter('quote_id', $quoteId)
+                ->getFirstItem();
+    }
 }

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -635,7 +635,6 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
         $productMediaConfig = Mage::getModel('catalog/product_media_config');
         $cartSubmissionData = array(
             'order_reference' => $quote->getId(),
-            'display_id'      => $quote->getReservedOrderId(),
             'items'           => array_map(
                 function ($item) use ($quote, $productMediaConfig, &$calculatedTotal) {
                     $imageUrl = $productMediaConfig->getMediaUrl($item->getProduct()->getThumbnail());

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -65,7 +65,6 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
             $boltHelperBase::$fromHooks = true;
 
             $transaction = $boltHelper->fetchTransaction($reference);
-            $orderId = @$transaction->order->cart->display_id;
             $quoteId = $transaction->order->cart->order_reference;
 
             $order =  $boltHelper->getOrderByQuoteId($quoteId);
@@ -115,28 +114,16 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
                     ->handleTransactionUpdate($orderPayment, $newTransactionStatus, $prevTransactionStatus, $transactionAmount);
 
 
-                if ( !$orderId ) {
-                    $this->getResponse()->setBody(
-                        json_encode(
-                            array(
-                                'status' => 'success',
-                                'created_objects' => array ('merchant_order_ref' => $order->getIncrementId()),
-                                'message' => "Order creation was successful"
-                            )
+                $this->getResponse()->setBody(
+                    json_encode(
+                        array(
+                            'status' => 'success',
+                            'display_id' => $order->getIncrementId(),
+                            'message' => "Updated existing order ".$order->getIncrementId()
                         )
-                    );
-                    $this->getResponse()->setHttpResponseCode(201);
-                } else {
-                    $this->getResponse()->setBody(
-                        json_encode(
-                            array(
-                                'status' => 'success',
-                                'message' => "Updated existing order $orderId."
-                            )
-                        )
-                    );
-                    $this->getResponse()->setHttpResponseCode(200);
-                }
+                    )
+                );
+                $this->getResponse()->setHttpResponseCode(200);
 
                 return;
             }
@@ -162,13 +149,13 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
                 return;
             }
 
-            $order = $boltHelper->createOrder($reference, $sessionQuoteId = null);
+            $order = $boltHelper->createOrder($reference, $sessionQuoteId = null, $transaction);
 
             $this->getResponse()->setBody(
                 json_encode(
                     array(
                         'status' => 'success',
-                        'created_objects' => array ('merchant_order_ref' => $order->getIncrementId()),
+                        'display_id' => $order->getIncrementId(),
                         'message' => "Order creation was successful"
                     )
                 )

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -56,6 +56,7 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
             $transactionId = @$bodyParams['transaction_id'] ?: $bodyParams['id'];
             $hookType = @$bodyParams['notification_type'] ?: $bodyParams['type'];
 
+            /** @var Bolt_Boltpay_Helper_Api $boltHelper */
             $boltHelper = Mage::helper('boltpay/api');
 
             $boltHelperBase = Mage::helper('boltpay');
@@ -67,13 +68,7 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
             $orderId = @$transaction->order->cart->display_id;
             $quoteId = $transaction->order->cart->order_reference;
 
-            /* @var Mage_Sales_Model_Resource_Order_Collection $orderCollection */
-            $orderCollection = Mage::getResourceModel('sales/order_collection');
-
-            /* @var Mage_Sales_Model_Order $order */
-            $order =  $orderCollection
-                ->addFieldToFilter('quote_id', $quoteId)
-                ->getFirstItem();
+            $order =  $boltHelper->getOrderByQuoteId($quoteId);
 
             if (!$order->isObjectNew()) {
                 //Mage::log('Order Found. Updating it', null, 'bolt.log');

--- a/app/code/community/Bolt/Boltpay/controllers/OrderController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OrderController.php
@@ -35,6 +35,7 @@ class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
                 Mage::throwException("OrderController::saveAction called with a non AJAX call");
             }
 
+            /** @var Bolt_Boltpay_Helper_Api $boltHelper */
             $boltHelper = Mage::helper('boltpay/api');
 
             $checkoutSession = Mage::getSingleton('checkout/session');
@@ -58,14 +59,7 @@ class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
             // have already created the order, we don't need to do anything
             // besides returning 200 OK, which happens automatically
             /////////////////////////////////////////////////////////
-
-            /* @var Mage_Sales_Model_Resource_Order_Collection $orderCollection */
-            $orderCollection = Mage::getResourceModel('sales/order_collection');
-
-            /* @var Mage_Sales_Model_Order $order */
-            $order = $orderCollection
-                ->addFieldToFilter('quote_id', $transaction->order->cart->order_reference)
-                ->getFirstItem();
+            $order = $boltHelper->getOrderByQuoteId($transaction->order->cart->order_reference);
 
             if ($order->isObjectNew()) {
                 $sessionQuote = $checkoutSession->getQuote();

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/ApiTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/ApiTest.php
@@ -108,6 +108,7 @@ class Bolt_Boltpay_Helper_ApiTest extends PHPUnit_Framework_TestCase
 
         $expected = array (
           'order_reference' => $_quote->getId(),
+          'display_id' => NULL,
           'items' =>
           array (
             0 =>

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/ApiTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/ApiTest.php
@@ -108,7 +108,6 @@ class Bolt_Boltpay_Helper_ApiTest extends PHPUnit_Framework_TestCase
 
         $expected = array (
           'order_reference' => $_quote->getId(),
-          'display_id' => NULL,
           'items' =>
           array (
             0 =>


### PR DESCRIPTION
Logic for removing display id from Bolt order creation and adding it to the first successful hook call per the spec defined at https://docs.bolt.com/v1/docs/hook-integration-1 under **Hook Responses**