### PR TITLE
adds clearing of cart in observer before displaying success page

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Observer.php
+++ b/app/code/community/Bolt/Boltpay/Model/Observer.php
@@ -117,6 +117,16 @@ class Bolt_Boltpay_Model_Observer
         }
     }
 
+    /**
+     * Clears the Shopping Cart after the success page
+     *
+     * Event: checkout_onepage_controller_success_action
+     */
+    public function clearShoppingCart() {
+        $cartHelper = Mage::helper('checkout/cart');
+        $cartHelper->getCart()->truncate()->save();
+    }
+
     public function sendCompleteAuthorizeRequest($request)
     {
         return $this->getBoltApiHelper()->transmit('complete_authorize', $request);

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -85,7 +85,17 @@
           </bolt_boltpay_update_bolt_transaction_status>
         </observers>
       </sales_order_save_after>
-      <!-- Call after order has been saved -->
+      <checkout_onepage_controller_success_action> <!-- Call after order has been saved and fowarded to success page -->
+        <observers>
+          <bolt_boltpay_clear_shopping_cart>
+            <class>Bolt_Boltpay_Model_Observer</class>
+            <method>clearShoppingCart</method>
+            <depends>
+              <ZZZZZ_Bolt />  <!--  psuedo module to place execution at the back of event queue -->
+            </depends>
+          </bolt_boltpay_clear_shopping_cart>
+        </observers>
+      </checkout_onepage_controller_success_action>
       <bolt_boltpay_save_order_after>
         <observers>
           <bolt_boltpay_verify_order_contents>


### PR DESCRIPTION
Currently, for logged in users, the shopping cart is not being emptied after successful orders.

This commit makes sure that the cart is emptied.