### PR TITLE
Removed check for canCreditMemo as Magento already checks this and it…

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -291,10 +291,6 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
             $paymentInfo = $this->getInfoInstance();
             $order = $paymentInfo->getOrder();
 
-            if (!$order->canCreditmemo() || !($payment->getCreditmemo()->getInvoice()->canRefund())) {
-                $message = 'Impossible to issue a refund transaction on this invoice';
-                Mage::throwException($message);
-            }
             $transId = $payment->getAdditionalInformation('bolt_merchant_transaction_id');
             if ($transId == null) {
                 $message = 'Waiting for a transaction update from Bolt. Please retry after 60 seconds.';


### PR DESCRIPTION
This bug was caused because Magento sets the orders total_refunded amount (see here https://www.screencast.com/t/YEXUnX4twp6r) prior to the code calling canCreditMemo (see here https://www.screencast.com/t/kVIV7ua3Ebl). This causes Magento to return false because the total refunded already equals the total paid (see here https://www.screencast.com/t/qqNUVs0L) so Magento thinks it can't refund and always returns false on a full refund and this code errors out. I also confirmed that Magento already handles this case and throws an error if a refund is attempted when there is nothing left to refund.