### PR TITLE
Updated missing quote error checks from bad merge

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -168,14 +168,9 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             /* @var Mage_Sales_Model_Quote $immutableQuote */
             $immutableQuote = Mage::getModel('sales/quote')->loadByIdWithoutStore($immutableQuoteId);
 
-            // make sure a quote for this session has not already been processed
+            // check that the order is in the system.  If not, we have an unexpected problem
             if ($immutableQuote->isEmpty()) {
-                throw new Exception("The order #".$immutableQuote->getReservedOrderId()." has already been processed.  This order request is deemed a duplicate and will not be processed.");
-            }
-
-            // make sure this quote has not already processed
-            if ($immutableQuote->isEmpty()) {
-                throw new Exception("This order has already been processed by Magento.");
+                throw new Exception("The expected quote is missing from the Magento system.  Were old quotes recently removed from the database?");
             }
 
             if(!$this->storeHasAllCartItems($immutableQuote)){


### PR DESCRIPTION
The error checks here for an empty quote are outdated, with the first one being very off as an empty quote will not have a reserved order id.

If the immutable quote is empty, then this is an unexpected problem that implies the quote was somehow deleted.  We currently do not delete these cloned quotes.