### PR TITLE
Parent id as order reference to enable bolt side duplicate order detection

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -355,7 +355,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
         ///////////////////////////////////////////////////////
         // Close out session by
-        // 1.) deactivating the immutable quote so it can no longer be uses
+        // 1.) deactivating the immutable quote so it can no longer be used
         // 2.) assigning the immutable quote as the parent of its parent quote
         //
         // This creates a circular reference so that we can use the parent quote

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -1126,7 +1126,12 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             return explode("|", $transaction->order->cart->display_id)[1];
         } else {
             /////////////////////////////////////////////////////////////////
-            // here we deal with older versus newer version
+            // Here we address legacy hook format for backward compatibility
+            // When placed into production in a merchant that previously used the old format,
+            // all their prior orders will have to be accounted for as there are potential
+            // hooks like refund, cancel, or order approval that will still be presented in 
+            // the old format.  
+            //
             // For $transaction->order->cart->order_reference
             //  - older version stores the immutable quote ID here, and parent ID in getParentQuoteId()
             //  - newer version stores the parent ID here, and immutable quote ID in getParentQuoteId()

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -65,7 +65,7 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
             $boltHelperBase::$fromHooks = true;
 
             $transaction = $boltHelper->fetchTransaction($reference);
-            $quoteId = $transaction->order->cart->order_reference;
+            $quoteId = $boltHelper->getImmutableQuoteIdFromTransaction($transaction);
 
             $order =  $boltHelper->getOrderByQuoteId($quoteId);
 

--- a/app/code/community/Bolt/Boltpay/controllers/OrderController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OrderController.php
@@ -59,7 +59,7 @@ class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
             // have already created the order, we don't need to do anything
             // besides returning 200 OK, which happens automatically
             /////////////////////////////////////////////////////////
-            $order = $boltHelper->getOrderByQuoteId($transaction->order->cart->order_reference);
+            $order = $boltHelper->getOrderByQuoteId($boltHelper->getImmutableQuoteIdFromTransaction($transaction));
 
             if ($order->isObjectNew()) {
                 $sessionQuote = $checkoutSession->getQuote();

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -76,7 +76,8 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
                 'telephone' => $shippingAddress->phone
             );
 
-            $quoteId = $requestData->cart->order_reference;
+            $mockTransaction = (object) array("order" => $requestData );
+            $quoteId = $boltHelper->getImmutableQuoteIdFromTransaction($mockTransaction);
 
             /* @var Mage_Sales_Model_Quote $quote */
             $quote = Mage::getModel('sales/quote')->loadByIdWithoutStore($quoteId);

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/ApiTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/ApiTest.php
@@ -78,6 +78,7 @@ class Bolt_Boltpay_Helper_ApiTest extends PHPUnit_Framework_TestCase
         $cart = $this->testHelper->addProduct(self::$productId, 2);
 
         $_quote = $cart->getQuote();
+        $_quote->reserveOrderId();
         $_items = $_quote->getAllItems();
         $_multipage = true;
         $item = $_items[0];
@@ -87,25 +88,25 @@ class Bolt_Boltpay_Helper_ApiTest extends PHPUnit_Framework_TestCase
         $imageUrl = $productMediaConfig->getMediaUrl($product->getThumbnail());
 
         $expected = array (
-          'order_reference' => $_quote->getId(),
-          'display_id' => NULL,
-          'items' =>
-          array (
-            0 =>
-            array (
-              'reference' => $_quote->getId(),
-              'image_url' => $imageUrl,
-              'name' => $item->getName(),
-              'sku' => $item->getSku(),
-              'description' => substr($product->getDescription(), 0, 8182) ?: '',
-              'total_amount' => round($item->getCalculationPrice() * 100 * $item->getQty()),
-              'unit_price' => round($item->getCalculationPrice() * 100),
-              'quantity' => $item->getQty(),
-            ),
-          ),
-          'currency' => $_quote->getQuoteCurrencyCode(),
-          'discounts' => array (),
-          'total_amount' => round($_quote->getSubtotal() * 100),
+            'order_reference' => $_quote->getParentQuoteId(),
+            'display_id' => $_quote->getReservedOrderId()."|".$_quote->getId(),
+            'items' =>
+                array (
+                    0 =>
+                        array (
+                            'reference' => $_quote->getId(),
+                            'image_url' => $imageUrl,
+                            'name' => $item->getName(),
+                            'sku' => $item->getSku(),
+                            'description' => substr($product->getDescription(), 0, 8182) ?: '',
+                            'total_amount' => round($item->getCalculationPrice() * 100 * $item->getQty()),
+                            'unit_price' => round($item->getCalculationPrice() * 100),
+                            'quantity' => $item->getQty(),
+                        ),
+                ),
+            'currency' => $_quote->getQuoteCurrencyCode(),
+            'discounts' => array (),
+            'total_amount' => round($_quote->getSubtotal() * 100),
         );
 
         $result = $this->currentMock->buildCart($_quote, $_items, $_multipage);


### PR DESCRIPTION
https://app.asana.com/0/544708310157130/752340529245956

Using the parent ID as the order_reference in Bolt order creation allows for the Bolt backend to provide for integrity constraints, enforcing a single order creation per session.

This addresses the problem of double billing the customer for the same order (i.e. one order created in Magento, while two transactions created at Bolt.)

This has already been implemented in Magento 2