### PR TITLE
Get the right modal object

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -98,7 +98,7 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function collectTotals($quote, $clearTotalsCollectedFlag = false)
     {
-        Mage::getSingleton('salesrule/validator')->resetRoundingDeltas();
+        Mage::getSingleton('boltpay/validator')->resetRoundingDeltas();
 
         if($clearTotalsCollectedFlag) {
             $quote->setTotalsCollectedFlag(false);


### PR DESCRIPTION
If there is other 3rd-party also extend the same modal, it would cause error, so it should be clarified