### PR TITLE
Added billing address region_id to billing address. Currently it is null

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -127,6 +127,7 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
                 'company' => $billingAddress->getCompany() ?: $shippingAddress->company,
                 'city' => $billingAddress->getCity() ?: $shippingAddress->locality,
                 'region' => $billingAddress->getRegion() ?: $region,
+                'region_id' => $billingAddress->getRegionId() ?: $regionId,
                 'postcode' => $billingAddress->getPostcode() ?: $shippingAddress->postal_code,
                 'country_id' => $billingAddress->getCountryId() ?: $shippingAddress->country_code,
                 'telephone' => $billingAddress->getTelephone() ?: $shippingAddress->phone


### PR DESCRIPTION
Found this bug today on StriVectin. Our billing address region_id is always null.