### PR TITLE
Fix off-by-one rounding issue for item total_amount

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -671,7 +671,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
                         'name'         => $item->getName(),
                         'sku'          => $product->getData('sku'),
                         'description'  => substr($product->getDescription(), 0, 8182) ?: '',
-                        'total_amount' => round($item->getCalculationPrice() * 100 * $item->getQty()),
+                        'total_amount' => round($item->getCalculationPrice() * 100) * $item->getQty(),
                         'unit_price'   => round($item->getCalculationPrice() * 100),
                         'quantity'     => $item->getQty(),
                         'type'         => $type


### PR DESCRIPTION
item price can be factional with discount. Previous logic can cause off-by-one error.

Example:
```
round(3.9777 * 100 * 4) => 1591
round(3.9777 * 100) * 4 => 1592
```