### PR TITLE
Add logic to tweak shipping label so it looks nicer

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -968,11 +968,6 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
             $this->applyShippingRate($quote, $rate->getCode());
 
-            $label = $rate->getCarrierTitle();
-            if ($rate->getMethodTitle()) {
-                $label = $label . ' - ' . $rate->getMethodTitle();
-            }
-
             $rateCode = $rate->getCode();
 
             if (empty($rateCode)) {
@@ -987,7 +982,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             $adjustedShippingAmount = $this->getAdjustedShippingAmount($originalDiscountedSubtotal, $quote);
 
             $option = array(
-                "service" => $label,
+                "service" => $this->getShippingLabel($rate),
                 "reference" => $rateCode,
                 "cost" => round($adjustedShippingAmount * 100),
                 "tax_amount" => abs(round($shippingAddress->getTaxAmount() * 100))
@@ -1181,5 +1176,31 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             $params["_secure"] = true;
         }
         return Mage::getUrl($route, $params);
+    }
+
+    /**
+     * Returns user-visible label for given shipping rate.
+     *
+     * @param   object rate
+     * @return  string
+     */
+    public function getShippingLabel($rate) {
+        $carrier = $rate->getCarrierTitle();
+        $title = $rate->getMethodTitle();
+        if (!$title) {
+            return $carrier;
+        }
+
+        // Apply adhoc rules to return concise string.
+        if ($carrier === "Shipping Table Rates") {
+            return $title;
+        }
+        if ($carrier === "United Parcel Service" && substr( $title, 0, 3 ) === "UPS") {
+            return $title;
+        }
+        if (strncasecmp( $carrier, $title, strlen($carrier) ) === 0) {
+            return $title;
+        }
+        return $carrier . " - " . $title;
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/ApiTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/ApiTest.php
@@ -251,4 +251,56 @@ class Bolt_Boltpay_Helper_ApiTest extends PHPUnit_Framework_TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testShippingLabel()
+    {
+        $rate = $this->getMockBuilder('Mage_Sales_Model_Quote_Address_Rate')
+            ->setMethods(array('getCarrierTitle', 'getMethodTitle'))
+            ->getMock();
+        $rate->method('getCarrierTitle')->willReturn('United Parcel Service');
+        $rate->method('getMethodTitle')->willReturn('2 Day Shipping');
+
+        $label = $this->currentMock->getShippingLabel($rate);
+
+        $this->assertEquals('United Parcel Service - 2 Day Shipping', $label);
+    }
+
+    public function testShippingLabel_notShowShippingTableLatePrefix()
+    {
+        $rate = $this->getMockBuilder('Mage_Sales_Model_Quote_Address_Rate')
+            ->setMethods(array('getCarrierTitle', 'getMethodTitle'))
+            ->getMock();
+        $rate->method('getCarrierTitle')->willReturn('Shipping Table Rates');
+        $rate->method('getMethodTitle')->willReturn('Free shipping (5 - 7 business days)');
+
+        $label = $this->currentMock->getShippingLabel($rate);
+
+        $this->assertEquals('Free shipping (5 - 7 business days)', $label);
+    }
+
+    public function testShippingLabel_notDuplicateCommonPrefix()
+    {
+        $rate = $this->getMockBuilder('Mage_Sales_Model_Quote_Address_Rate')
+            ->setMethods(array('getCarrierTitle', 'getMethodTitle'))
+            ->getMock();
+        $rate->method('getCarrierTitle')->willReturn('USPS');
+        $rate->method('getMethodTitle')->willReturn('USPS Two days');
+
+        $label = $this->currentMock->getShippingLabel($rate);
+
+        $this->assertEquals('USPS Two days', $label);
+    }
+
+    public function testShippingLabel_notDuplicateUPS()
+    {
+        $rate = $this->getMockBuilder('Mage_Sales_Model_Quote_Address_Rate')
+            ->setMethods(array('getCarrierTitle', 'getMethodTitle'))
+            ->getMock();
+        $rate->method('getCarrierTitle')->willReturn('United Parcel Service');
+        $rate->method('getMethodTitle')->willReturn('UPS Business 2 Days');
+
+        $label = $this->currentMock->getShippingLabel($rate);
+
+        $this->assertEquals('UPS Business 2 Days', $label);
+    }
 }


### PR DESCRIPTION
Add some adhoc rules to account for common store settings that caused non-optimal UI. 

 - Remove 'Shipping Table Rates' prefix
 - Remove 'United Parcel Service' prefix if title already contains 'UPS'
 - Remove carrier name if the same text is included in method title