### PR TITLE
Firecheckout remove hard-coded selectors and implement via promise

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -78,7 +78,9 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
                                                 parameters: checkout.getFormData ? checkout.getFormData() : Form.serialize(checkout.form, true),
                                                 onSuccess: function(response) {
                                                     if(response.responseJSON.error) {
-                                                        reject(response.responseJSON.error);
+                                                        // BoltCheckout is currently not doing anything reasonable to alert the user of a problem, so we will do something
+                                                        alert(response.responseJSON.error_messages);
+                                                        reject(response.responseJSON.error_messages);
                                                     } else {
                                                         resolve(response.responseJSON.cart_data);
                                                     }                   

--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -77,10 +77,12 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
                                                 method:'post',
                                                 parameters: checkout.getFormData ? checkout.getFormData() : Form.serialize(checkout.form, true),
                                                 onSuccess: function(response) {
-                                                    if(response.responseJSON.error) {
-                                                        // BoltCheckout is currently not doing anything reasonable to alert the user of a problem, so we will do something
-                                                        alert(response.responseJSON.error_messages);
+                                                    if(response.responseJSON.error) {                                                        
                                                         reject(response.responseJSON.error_messages);
+                                                        
+                                                        // BoltCheckout is currently not doing anything reasonable to alert the user of a problem, so we will do something as a backup
+                                                        alert(response.responseJSON.error_messages);
+                                                        location.reload();
                                                     } else {
                                                         resolve(response.responseJSON.cart_data);
                                                     }                   

--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -83,7 +83,7 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
                                                         resolve(response.responseJSON.cart_data);
                                                     }                   
                                                 },
-                                                 onFailure: function(error) { alert('hello.'); reject(error) }
+                                                 onFailure: function(error) { reject(error) }
                                             });
                                             clearInterval(firecheckoutAjaxId);
                                          }
@@ -259,7 +259,7 @@ PROMISE;
         /* @var Bolt_Boltpay_Helper_Api $boltHelper */
         $boltHelper = Mage::helper('boltpay');
 
-        $jsonCart = (!is_string($cartData)) ? json_encode($cartData) : $cartData;
+        $jsonCart = (is_string($cartData)) ? $cartData : json_encode($cartData);
         $jsonHints = json_encode($hintData, JSON_FORCE_OBJECT);
 
         //////////////////////////////////////////////////////

--- a/app/code/community/Bolt/Boltpay/controllers/OrderController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OrderController.php
@@ -106,12 +106,10 @@ class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
      */
     public function firecheckoutcreateAction()
     {
-
         try {
             if (!$this->getRequest()->isAjax()) {
                 Mage::throwException(Mage::helper('boltpay')->__("OrderController::createAction called with a non AJAX call"));
             }
-
 
             $checkout = Mage::getSingleton('firecheckout/type_standard');
             $quote = $checkout->getQuote();
@@ -179,7 +177,7 @@ class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
 
             $result = array();
 
-            $result['cart_data'] = $block->getCartDataJs('one-page');
+            $result['cart_data'] = $block->getCartDataJs('firecheckout');
 
             if (!$result['cart_data']) {
                 $result['success'] = false;

--- a/app/code/community/Bolt/Boltpay/controllers/OrderController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OrderController.php
@@ -126,6 +126,7 @@ class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
                 $result['success'] = false;
                 $result['error']   = true;
                 if ($result['message'] === $checkout->getCustomerEmailExistsMessage()) {
+                    $result['error_messages'] = $result['message'];
                     unset($result['message']);
                     $result['body'] = array(
                         'id'      => 'emailexists',

--- a/app/code/community/Bolt/Boltpay/controllers/OrderController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OrderController.php
@@ -173,11 +173,14 @@ class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
 
             Mage::helper('boltpay')->collectTotals($quote)->save();
 
+            /** @var Bolt_Boltpay_Block_Checkout_Boltpay $block */
             $block = $this->getLayout()->createBlock('boltpay/checkout_boltpay');
 
             $result = array();
 
-            $result['cart_data'] = $block->getCartDataJs('firecheckout');
+            /** @var Mage_Sales_Model_Quote $immutableQuote */
+            $immutableQuote = Mage::helper('boltpay')->cloneQuote($quote, false);
+            $result['cart_data'] = $block->buildCartData(($block->getBoltOrderToken($immutableQuote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ONE_PAGE)));
 
             if (!$result['cart_data']) {
                 $result['success'] = false;

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -243,7 +243,7 @@
         <payment_action>authorize</payment_action>
         <currency>USD</currency>
         <enable_merchant_scoped_account>0</enable_merchant_scoped_account>
-        <selectors><![CDATA[.btn-proceed-checkout, .minicart-actions .checkout-button]]></selectors>
+        <selectors><![CDATA[.btn-proceed-checkout, .minicart-actions .checkout-button, body.firecheckout-index-index .button.btn-checkout]]></selectors>
 
         <selector_styles>.btn-proceed-checkout {
   .bolt-checkout-button.with-cards {

--- a/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
@@ -16,9 +16,9 @@
  */
 
 /********************************************************************
- * Bolt replace button JavaScript / CSS that's added to the shopping cart page
+ * Bolt replace button JavaScript / CSS that's added to the firecheckout cart page
  ********************************************************************/
-
+/** @var Bolt_Boltpay_Block_Checkout_Boltpay $this */
 if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getStoreConfig('payment/boltpay/hide_on_checkout') ) return;
 
 ?>
@@ -63,7 +63,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
 
                 if (responseJSON.cart_data) {
                     eval(responseJSON.cart_data);
-                    var bolt_button = document.querySelectorAll('.bolt-checkout-button-button')[0];
+                    var bolt_button = document.querySelectorAll('[data-tid=bolt-checkout-button], div.bolt-checkout-button > div')[0];
                     bolt_button.click();
                 } else {
                     this.setResponse(response);
@@ -73,13 +73,20 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
 
             var i, length;
 
-            var place_order_button = document.querySelectorAll('.button.btn-checkout')[0];
+            var place_order_buttons = document.querySelectorAll('<?=Mage::getStoreConfig('payment/boltpay/selectors');?>');
 
-            var bolt_button =  document.createElement("div");
-            bolt_button.setAttribute("class", "bolt-checkout-button with-cards <?=$this->getCssSuffix(); ?> <?=$this->getTheme(); ?>");
-            bolt_button.style.display = "none";
+            place_order_buttons.forEach(
+                function(place_order_button) {
+                    var bolt_button =  document.createElement("div");
+                    bolt_button.setAttribute("class", "bolt-checkout-button with-cards <?=$this->getCssSuffix(); ?> <?=$this->getTheme(); ?>");
+                    bolt_button.style.display = "none";
 
-            place_order_button.parentNode.insertBefore(bolt_button, place_order_button);
+                    place_order_button.parentNode.insertBefore(bolt_button, place_order_button);
+                }
+            );
+
+            var bolt_buttons = document.querySelectorAll('.bolt-checkout-button');
+
             // Render Bolt button.
             BoltCheckout.configure({}, {}, {});
 
@@ -89,11 +96,27 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
              */
             var toggleBoltButton = function () {
                 if (this.id == "p_method_boltpay") {
-                    bolt_button.style.display="";
-                    place_order_button.style.display="none";
+                    bolt_buttons.forEach(
+                        function (bolt_button) {
+                            bolt_button.style.display="";
+                        }
+                    );
+                    place_order_buttons.forEach(
+                        function (place_order_button) {
+                            place_order_button.style.display="none";
+                        }
+                    );
                 } else {
-                    bolt_button.style.display="none";
-                    place_order_button.style.display="";
+                    bolt_buttons.forEach(
+                        function (bolt_button) {
+                            bolt_button.style.display="none";
+                        }
+                    );
+                    place_order_buttons.forEach(
+                        function (place_order_button) {
+                            place_order_button.style.display="";
+                        }
+                    );
                 }
             };
 
@@ -139,6 +162,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
 
                 var replaceRetries  = 10;
                 var replaceInterval = 500;
+                var areOverlaysSet = false;
 
                 var tryInterval = setInterval(
 
@@ -154,29 +178,30 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
 
                         if (replaceRetries > 5) replaceRetries = 5;
 
-                        var bolt_button_overlay = document.getElementById('bolt_button_overlay');
+                        var bolt_buttons = document.querySelectorAll('.bolt-checkout-button');
+                        bolt_buttons.forEach(
+                            function (bolt_button) {
 
-                        if (bolt_button_overlay) {
+                                bolt_button_overlay = document.createElement("div");
+                                bolt_button_overlay.setAttribute("class", "bolt_button_overlay");
+                                bolt_button_overlay.style.cssText = 'cursor:pointer;top:6px;left:0px;position:absolute;width:100%;height:44px;opacity:0.0;z-index:10000;background:#fff;';
+
+                                bolt_button.appendChild(bolt_button_overlay);
+
+                                bolt_button_overlay.onclick = function() {
+
+                                    clearInterval(tryInterval);
+
+                                    checkout.createBoltOrder();
+                                };
+                                areOverlaysSet = true;
+                            }
+                        );
+
+                        if (areOverlaysSet) {
                             clearInterval(tryInterval);
                             return;
                         }
-
-                        var bolt_button = document.querySelectorAll('.bolt-checkout-button')[0];
-
-                        if (! bolt_button) return;
-
-                        bolt_button_overlay = document.createElement("div");
-                        bolt_button_overlay.setAttribute("id", "bolt_button_overlay");
-                        bolt_button_overlay.style.cssText = 'cursor:pointer;top:6px;left:0px;position:absolute;width:100%;height:44px;opacity:0.0;z-index:10000;background:#fff;';
-
-                        bolt_button.appendChild(bolt_button_overlay);
-
-                        bolt_button_overlay.onclick = function() {
-
-                            clearInterval(tryInterval);
-
-                            checkout.createBoltOrder();
-                        };
                     },
                     replaceInterval
                 );

--- a/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
@@ -24,226 +24,126 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
 ?>
 <script>
 
-    var onloadCallback = function(){
+    var isFireCheckoutFormValid = false;
+    var initializeBolt = function(){
 
-        /****************************************************************************************************
-         * Fire Checkout extension
-         ****************************************************************************************************/
-        var fireCheckout = function() {
+        // checkout.setLoadWaiting(false);
 
-            if (typeof FireCheckout !== "function") return false;
+        var place_order_buttons = document.querySelectorAll('<?=Mage::getStoreConfig('payment/boltpay/selectors');?>');
 
-            FireCheckout.prototype.createBoltOrder = function() {
+        place_order_buttons.forEach(
+            function(place_order_button) {
+                var bolt_button =  document.createElement("div");
+                bolt_button.setAttribute("class", "bolt-checkout-button with-cards <?=$this->getCssSuffix(); ?> <?=$this->getTheme(); ?>");
+                bolt_button.style.display = "none";
 
-                if (this.loadWaiting != false) {
-                    return;
-                }
-
-                if (!this.validate()) {
-                    return;
-                }
-
-                var params = this.getFormData ? this.getFormData() : Form.serialize(this.form, true);
-
-                checkout.setLoadWaiting(true);
-
-                new Ajax.Request('<?php echo Mage::helper('boltpay/api')->getMagentoUrl('boltpay/order/firecheckoutcreate');?>', {
-                    method:'post',
-                    parameters:params,
-                    onSuccess: this.setBoltResponse.bind(this),
-                    onFailure: this.ajaxFailure.bind(this)
-                });
-            };
-
-            FireCheckout.prototype.setBoltResponse = function(response){
-
-                checkout.setLoadWaiting(false);
-
-                var responseJSON = response.responseJSON;
-
-                if (responseJSON.cart_data) {
-                    eval(responseJSON.cart_data);
-                    var bolt_button = document.querySelectorAll('[data-tid=bolt-checkout-button], div.bolt-checkout-button > div')[0];
-                    bolt_button.click();
-                } else {
-                    this.setResponse(response);
-                    window.location.href = "<?php echo Mage::helper('boltpay/api')->getMagentoUrl('checkout/cart');?>";
-                }
-            };
-
-            var i, length;
-
-            var place_order_buttons = document.querySelectorAll('<?=Mage::getStoreConfig('payment/boltpay/selectors');?>');
-
-            place_order_buttons.forEach(
-                function(place_order_button) {
-                    var bolt_button =  document.createElement("div");
-                    bolt_button.setAttribute("class", "bolt-checkout-button with-cards <?=$this->getCssSuffix(); ?> <?=$this->getTheme(); ?>");
-                    bolt_button.style.display = "none";
-
-                    place_order_button.parentNode.insertBefore(bolt_button, place_order_button);
-                }
-            );
-
-            var bolt_buttons = document.querySelectorAll('.bolt-checkout-button');
-
-            // Render Bolt button.
-            BoltCheckout.configure({}, {}, {});
-
-            /**
-             * Click event to payment method radio buttons that toggle
-             * display of the bolt button
-             */
-            var toggleBoltButton = function () {
-                if (this.id == "p_method_boltpay") {
-                    bolt_buttons.forEach(
-                        function (bolt_button) {
-                            bolt_button.style.display="";
-                        }
-                    );
-                    place_order_buttons.forEach(
-                        function (place_order_button) {
-                            place_order_button.style.display="none";
-                        }
-                    );
-                } else {
-                    bolt_buttons.forEach(
-                        function (bolt_button) {
-                            bolt_button.style.display="none";
-                        }
-                    );
-                    place_order_buttons.forEach(
-                        function (place_order_button) {
-                            place_order_button.style.display="";
-                        }
-                    );
-                }
-            };
-
-            /**
-             * Attaches click event to all radio buttons
-             *
-             * @param   An option list passed in by an observer if this function is called in that context
-             *          This can be omitted.
-             */
-            var attachClickEvents = function(mutationList) {
-
-                var payment_radios = document.querySelectorAll('[name="payment[method]"]');
-                for (i = 0, length = payment_radios.length; i < length; i++) {
-
-                    var payment_radio = payment_radios[i];
-
-                    payment_radio.onclick = toggleBoltButton;
-
-                    <?php if ($this->isBoltOnlyPayment()): ?>
-                    if (payment_radio.id == "p_method_boltpay") {
-                        payment_radio.click();
-                    } else {
-                        payment_radio.parentNode.style.display = "none";
-                    }
-                    <?php endif; ?>
-
-                    if (payment_radio.checked) payment_radio.click();
-                }
-
+                place_order_button.parentNode.insertBefore(bolt_button, place_order_button);
             }
+        );
 
-            attachClickEvents();
+        var bolt_buttons = document.querySelectorAll('.bolt-checkout-button');
 
-            //////////////////////////////////////////////////////////////////////
-            // Watch for changes in the payment methods to re-attach click events
-            //////////////////////////////////////////////////////////////////////
-            var paymentMethodsContainer = document.getElementById('checkout-payment-method-load');
-            var paymentMethodObserver = new MutationObserver(attachClickEvents);
-            paymentMethodObserver.observe(paymentMethodsContainer, { childList: true });
-            //////////////////////////////////////////////////////////////////////
+        // Render Bolt button.
+        <?=$this->getCartDataJs('firecheckout'); ?>
 
-            var setOverlay = function() {
-
-                var replaceRetries  = 10;
-                var replaceInterval = 500;
-                var areOverlaysSet = false;
-
-                var tryInterval = setInterval(
-
-                    function() {
-
-                        replaceRetries -= 1;
-                        if (replaceRetries <= 0) clearInterval(tryInterval);
-
-                        if (typeof BoltCheckout === "undefined") {
-                            replaceRetries = 10;
-                            return;
-                        }
-
-                        if (replaceRetries > 5) replaceRetries = 5;
-
-                        var bolt_buttons = document.querySelectorAll('.bolt-checkout-button');
-                        bolt_buttons.forEach(
-                            function (bolt_button) {
-
-                                bolt_button_overlay = document.createElement("div");
-                                bolt_button_overlay.setAttribute("class", "bolt_button_overlay");
-                                bolt_button_overlay.style.cssText = 'cursor:pointer;top:6px;left:0px;position:absolute;width:100%;height:44px;opacity:0.0;z-index:10000;background:#fff;';
-
-                                bolt_button.appendChild(bolt_button_overlay);
-
-                                bolt_button_overlay.onclick = function() {
-
-                                    clearInterval(tryInterval);
-
-                                    checkout.createBoltOrder();
-                                };
-                                areOverlaysSet = true;
-                            }
-                        );
-
-                        if (areOverlaysSet) {
-                            clearInterval(tryInterval);
-                            return;
-                        }
-                    },
-                    replaceInterval
+        /**
+         * Click event to payment method radio buttons that toggle
+         * display of the bolt button
+         */
+        var toggleBoltButton = function () {
+            if (this.id == "p_method_boltpay") {
+                bolt_buttons.forEach(
+                    function (bolt_button) {
+                        bolt_button.style.display="";
+                    }
                 );
-            };
-
-            var bolt_checkout_close = setOverlay;
-
-            setOverlay();
-
-            var autoSelectShipping = function () {
-
-                var shipping_selected = false;
-                var shipping_methods  = document.querySelectorAll('input[name=shipping_method]');
-
-                for (i = 0, length = shipping_methods.length; i < length; i++) {
-                    var shipping_method = shipping_methods[i];
-                    if (shipping_method.checked) {
-                        shipping_selected = true;
-                        shipping_method.click();
+                place_order_buttons.forEach(
+                    function (place_order_button) {
+                        place_order_button.style.display="none";
                     }
-                }
-
-                if (!shipping_selected)  document.querySelectorAll('input[name=shipping_method]')[0].click();
-            };
-            if (window.addEventListener) {
-                window.addEventListener("load", autoSelectShipping, false);
-            } else if (window.attachEvent) {
-                window.attachEvent("onload", autoSelectShipping);
+                );
             } else {
-                window.onload = autoSelectShipping;
+                bolt_buttons.forEach(
+                    function (bolt_button) {
+                        bolt_button.style.display="none";
+                    }
+                );
+                place_order_buttons.forEach(
+                    function (place_order_button) {
+                        place_order_button.style.display="";
+                    }
+                );
             }
-
-            return true;
         };
 
-        fireCheckout();
+
+        /**
+         * Attaches click event to all radio buttons
+         *
+         * @param   An option list passed in by an observer if this function is called in that context
+         *          This can be omitted.
+         */
+        var attachClickEvents = function(mutationList) {
+
+            var payment_radios = document.querySelectorAll('[name="payment[method]"]');
+            for (var i = 0, var length = payment_radios.length; i < length; i++) {
+
+                var payment_radio = payment_radios[i];
+
+                payment_radio.onclick = toggleBoltButton;
+
+                <?php if ($this->isBoltOnlyPayment()): ?>
+                if (payment_radio.id == "p_method_boltpay") {
+                    payment_radio.click();
+                } else {
+                    payment_radio.parentNode.style.display = "none";
+                }
+                <?php endif; ?>
+
+                if (payment_radio.checked) payment_radio.click();
+            }
+
+        }
+
+        attachClickEvents();
+
+        //////////////////////////////////////////////////////////////////////
+        // Watch for changes in the payment methods to re-attach click events
+        //////////////////////////////////////////////////////////////////////
+        var paymentMethodsContainer = document.getElementById('checkout-payment-method-load');
+        var paymentMethodObserver = new MutationObserver(attachClickEvents);
+        paymentMethodObserver.observe(paymentMethodsContainer, { childList: true });
+        //////////////////////////////////////////////////////////////////////
+
+        var autoSelectShipping = function () {
+
+            var shipping_selected = false;
+            var shipping_methods  = document.querySelectorAll('input[name=shipping_method]');
+
+            for (var i = 0, var length = shipping_methods.length; i < length; i++) {
+                var shipping_method = shipping_methods[i];
+                if (shipping_method.checked) {
+                    shipping_selected = true;
+                    shipping_method.click();
+                }
+            }
+
+            if (!shipping_selected)  document.querySelectorAll('input[name=shipping_method]')[0].click();
+        };
+
+        if (window.addEventListener) {
+            window.addEventListener("load", autoSelectShipping, false);
+        } else if (window.attachEvent) {
+            window.attachEvent("onload", autoSelectShipping);
+        } else {
+            window.onload = autoSelectShipping;
+        }
     };
 
     if (window.addEventListener) {
-        window.addEventListener("load", onloadCallback, false);
+        window.addEventListener("load", initializeBolt, false);
     } else if (window.attachEvent) {
-        window.attachEvent("onload", onloadCallback);
+        window.attachEvent("onload", initializeBolt);
     } else {
         window.onload = onloadCallback;
     }

--- a/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
@@ -39,7 +39,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
             function(place_order_button) {
                 var bolt_button =  document.createElement("div");
                 bolt_button.setAttribute("class", "bolt-checkout-button with-cards <?=$this->getCssSuffix(); ?> <?=$this->getTheme(); ?>");
-                bolt_button.style.display = "none";
+                bolt_button.style.display = "none!important";
 
                 place_order_button.parentNode.insertBefore(bolt_button, place_order_button);
             }
@@ -69,7 +69,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
             } else {
                 bolt_buttons.forEach(
                     function (bolt_button) {
-                        bolt_button.style.display="none";
+                        bolt_button.style.display="none!important";
                     }
                 );
                 place_order_buttons.forEach(

--- a/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
@@ -25,6 +25,10 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
 <script>
 
     var isFireCheckoutFormValid = false;
+    var initBoltButtons = function() {
+        <?=$this->getCartDataJs(Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_FIRECHECKOUT); ?>
+    }
+
     var initializeBolt = function(){
 
         // checkout.setLoadWaiting(false);
@@ -44,7 +48,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
         var bolt_buttons = document.querySelectorAll('.bolt-checkout-button');
 
         // Render Bolt button.
-        <?=$this->getCartDataJs('firecheckout'); ?>
+        initBoltButtons();
 
         /**
          * Click event to payment method radio buttons that toggle
@@ -86,7 +90,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
         var attachClickEvents = function(mutationList) {
 
             var payment_radios = document.querySelectorAll('[name="payment[method]"]');
-            for (var i = 0, var length = payment_radios.length; i < length; i++) {
+            for (i = 0, length = payment_radios.length; i < length; i++) {
 
                 var payment_radio = payment_radios[i];
 
@@ -120,7 +124,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
             var shipping_selected = false;
             var shipping_methods  = document.querySelectorAll('input[name=shipping_method]');
 
-            for (var i = 0, var length = shipping_methods.length; i < length; i++) {
+            for (i = 0, length = shipping_methods.length; i < length; i++) {
                 var shipping_method = shipping_methods[i];
                 if (shipping_method.checked) {
                     shipping_selected = true;

--- a/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
@@ -39,7 +39,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
             function(place_order_button) {
                 var bolt_button =  document.createElement("div");
                 bolt_button.setAttribute("class", "bolt-checkout-button with-cards <?=$this->getCssSuffix(); ?> <?=$this->getTheme(); ?>");
-                bolt_button.style.display = "none!important";
+                bolt_button.style.cssText = "display: none !important";
 
                 place_order_button.parentNode.insertBefore(bolt_button, place_order_button);
             }
@@ -58,7 +58,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
             if (this.id == "p_method_boltpay") {
                 bolt_buttons.forEach(
                     function (bolt_button) {
-                        bolt_button.style.display="";
+                        bolt_button.style.cssText = "";
                     }
                 );
                 place_order_buttons.forEach(
@@ -69,7 +69,7 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
             } else {
                 bolt_buttons.forEach(
                     function (bolt_button) {
-                        bolt_button.style.display="none!important";
+                        bolt_button.style.cssText = "display: none !important";
                     }
                 );
                 place_order_buttons.forEach(

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -354,7 +354,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
                 order.submit();
              }";
 
-        $result = /*$this->currentMock->buildOnCloseCallback($closeCustom, $checkoutType)*/"A bad habit.";
+        $result = $this->currentMock->buildOnCloseCallback($closeCustom, $checkoutType);
 
         $this->assertEquals($expect, $result);
     }

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -231,7 +231,8 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
     public function testBuildOnCheckCallbackIfAdminArea()
     {
         $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ADMIN;
-        $checkCallback = "if ((typeof editForm !== 'undefined') && (typeof editForm.validate === 'function')) {
+        $checkCallback = "
+             if ((typeof editForm !== 'undefined') && (typeof editForm.validate === 'function')) {
                 var bolt_hidden = document.getElementById('boltpay_payment_button');
                 bolt_hidden.classList.remove('required-entry');
 
@@ -249,11 +250,12 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
 
                 bolt_hidden.classList.add('required-entry');
                 return is_valid;
-            }";
+            }
+        ";
 
         $result = $this->currentMock->buildOnCheckCallback($checkoutType);
 
-        $this->assertEquals($checkCallback, $result);
+        $this->assertEquals(preg_replace('/\s/', '', $checkCallback), preg_replace('/\s/', '', $result));
     }
 
     /**
@@ -326,17 +328,15 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ONE_PAGE;
         $closeCustom = '';
 
-        $expect = "if (typeof bolt_checkout_close === 'function') {
-                   // used internally to set overlay in firecheckout
-                   bolt_checkout_close();
-                }
-                if (order_completed) {
+        $expect = "
+            if (order_completed) {
                    location.href = '$successUrl';
-            }";
+            }
+        ";
 
         $result = $this->currentMock->buildOnCloseCallback($closeCustom, $checkoutType);
 
-        $this->assertEquals($expect, $result);
+        $this->assertEquals(preg_replace('/\s/', '', $expect), preg_replace('/\s/', '', $result));
     }
 
     /**
@@ -347,16 +347,18 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ADMIN;
         $closeCustom = '';
 
-        $expect = "if (order_completed && (typeof order !== 'undefined' ) && (typeof order.submit === 'function')) {
+        $expect = "
+             if (order_completed && (typeof order !== 'undefined' ) && (typeof order.submit === 'function')) {
                 $closeCustom
                 var bolt_hidden = document.getElementById('boltpay_payment_button');
                 bolt_hidden.classList.remove('required-entry');
                 order.submit();
-             }";
-
+             }
+        ";
+        
         $result = $this->currentMock->buildOnCloseCallback($closeCustom, $checkoutType);
 
-        $this->assertEquals($expect, $result);
+        $this->assertEquals(preg_replace('/\s/', '', $expect), preg_replace('/\s/', '', $result));
     }
 
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -354,7 +354,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
                 order.submit();
              }";
 
-        $result = $this->currentMock->buildOnCloseCallback($closeCustom, $checkoutType);
+        $result = /*$this->currentMock->buildOnCloseCallback($closeCustom, $checkoutType)*/"A bad habit.";
 
         $this->assertEquals($expect, $result);
     }

--- a/tests/unit/testsuite/Bolt/Boltpay/TestHelper.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/TestHelper.php
@@ -137,12 +137,13 @@ class Bolt_Boltpay_TestHelper
 
         return ("
             var json_cart = $jsonCart;
+            var json_hints = {};
             var quote_id = '{$immutableQuoteId}';
             var order_completed = false;
 
             BoltCheckout.configure(
                 json_cart,
-                $jsonHints,
+                json_hints,
                 {
                   check: function() {
                     $checkCustom


### PR DESCRIPTION
This is a revision of the Firecheckout code that removes reliance on hard-coded classes, bolt classes that will no longer be supported in the future, and implements loading the order token via a Promise.