### PR TITLE
Dispatch order save after events

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -390,7 +390,7 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
         Mage::dispatchEvent(
             'checkout_submit_all_after',
-            array('order' => $order, 'quote' => $this->getQuote(), 'recurring_profiles' => $service->getRecurringPaymentProfiles())
+            array('order' => $order, 'quote' => $immutableQuote, 'recurring_profiles' => $service->getRecurringPaymentProfiles())
         );
         ///////////////////////////////////////////////////////
 

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -383,7 +383,16 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
         Mage::getModel('boltpay/payment')->handleOrderUpdate($order);
 
+        ///////////////////////////////////////////////////////
+        /// Dispatch order save events
+        ///////////////////////////////////////////////////////
         Mage::dispatchEvent('bolt_boltpay_save_order_after', array('order'=>$order, 'quote'=>$immutableQuote, 'transaction' => $transaction));
+
+        Mage::dispatchEvent(
+            'checkout_submit_all_after',
+            array('order' => $order, 'quote' => $this->getQuote(), 'recurring_profiles' => $service->getRecurringPaymentProfiles())
+        );
+        ///////////////////////////////////////////////////////
 
         if ($sessionQuoteId) {
             $checkoutSession = Mage::getSingleton('checkout/session');


### PR DESCRIPTION
Magento issues a standard event `checkout_submit_all_after` after order creation that we currently do not dispatch.  

We should dispatch this event so that plugins that rely on it can function properly