### PR TITLE
Solves the parent quote missing issue

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -73,7 +73,13 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
             $transaction = $boltHelper->fetchTransaction($reference);
             $quoteId = $boltHelper->getImmutableQuoteIdFromTransaction($transaction);
 
-            $order =  $boltHelper->getOrderByQuoteId($quoteId);
+            /* If display_id has been confirmed and updated on Bolt, then we should look up the order by display_id */
+            $order = Mage::getModel('sales/order')->loadByIncrementId($transaction->order->cart->display_id);
+
+            /* If it hasn't been confirmed, or could not be found, we use the quoteId as fallback */
+            if ($order->isObjectNew()) {
+                $order =  $boltHelper->getOrderByQuoteId($quoteId);
+            }
 
             if (!$order->isObjectNew()) {
                 //Mage::log('Order Found. Updating it', null, 'bolt.log');


### PR DESCRIPTION
Uses display_id to look up order once it has been confirmed to be accurate.  

If not confirmed, the display_id will have a "|" and will never find an order.  Then, we use the quoteId.

If there is no "|", then we know the the display_id has been confirmed as accurate and we use it.  In this way, even if the quote has been deleted, the webhooks will still succeed as they no longer need the quote, only the order.

This is the code that is in production for one client that solved their problem.