### PR TITLE
immutable quotes set as inactive to not affect abandoned cart plugins

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -238,6 +238,7 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
         Mage::getSingleton('core/session')->setReservedOrderId($reservedOrderId);
 
         $clonedQuote
+            ->setIsActive(false)
             ->setCustomer($sourceQuote->getCustomer())
             ->setCustomerGroupId($sourceQuote->getCustomerGroupId())
             ->setCustomerIsGuest((($sourceQuote->getCustomerId()) ? false : true))


### PR DESCRIPTION
Because abandoned carts are identified as an active quote that exist after some set period of time, we need to set immutable quotes as inactive.  Additionally, we adjust all error checking for an inactive immutable quote and replace it with the same check on the parent quote.