### PR TITLE
Keep shipping data even if a required field in option address is missing

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -864,12 +864,6 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
 
                 }
 
-                foreach ($requiredAddressFields as $field) {
-                    if (empty($cartShippingAddress[$field])) {
-                        unset($cartSubmissionData['shipments']);
-                        break;
-                    }
-                }
             }
             ////////////////////////////////////////////////////////////////////////////////////
         }


### PR DESCRIPTION
In Magento 1, we've had some long standing code that checks for all the required shipping fields to exist.  If any are missing, it removes the address and the shipping method in entirety in order to pass Bolt validation.

https://github.com/BoltApp/bolt-magento1/blob/develop/app/code/community/Bolt/Boltpay/Helper/Api.php#L744-L753

https://github.com/BoltApp/bolt-magento1/blob/develop/app/code/community/Bolt/Boltpay/Helper/Api.php#L867-L872

I don't believe that this sort of code exist in any other plugins, and I believe that by including it, we create the scenario for orders to get placed on Bolt minus shipping address and shipping method info.  In such a case, it is much better to fail early rather than later and allow the BoltCheckout to indicate the missing field problem to the customer.

This patch removes the aforementioned code.

Edit:
@danac-gs  informed me that this logic also exist in Magento 2.  In all plugins where this logic exist, it should also be removed.

Edit 2:
Since "region", (i.e. state/province/etc.), is a required address field for Bolt, and internationally, not all countries have this concept or use it regularly, for non-US and Canadian orders, in a separate pull request, I will set this value to fallback to city/locality when it is not provided as Magento's standard form only requires state for those two countries.