### PR TITLE
Corrects BoltCheckout error check logic

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -246,8 +246,10 @@ PROMISE;
         );
 
         // If there was an unexpected API error, then it was stored in the registry
-        if (Mage::registry("api_error")) {
-            $cartData['error'] = Mage::registry("api_error");
+        if (Mage::registry("bolt_api_error")) {
+            $cartData['error'] = Mage::registry("bolt_api_error");
+        } else if (@$orderCreationResponse->error) {
+            $cartData['error'] = $orderCreationResponse->error;
         }
 
         return $cartData;
@@ -299,12 +301,12 @@ PROMISE;
                 json_hints,
                 {
                   check: function() {
-                    $checkCustom
-                    $onCheckCallback
                     if (!json_cart.orderToken) {
                         alert(json_cart.error);
                         return false;
                     }
+                    $checkCustom
+                    $onCheckCallback
                     return true;
                   },
                   

--- a/app/code/community/Bolt/Boltpay/Helper/Api.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Api.php
@@ -564,7 +564,8 @@ class Bolt_Boltpay_Helper_Api extends Bolt_Boltpay_Helper_Data
             Mage::throwException($message);
         } elseif (self::isResponseError($response)) {
             if (property_exists($response, 'errors')) {
-                Mage::register("api_error", $response->errors[0]->message);
+                Mage::unregister("bolt_api_error");
+                Mage::register("bolt_api_error", $response->errors[0]->message);
             }
 
             $message = Mage::helper('boltpay')->__("BoltPay Gateway error for %s: Request: %s, Response: %s", $url, $request, json_encode($response, true));

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -106,7 +106,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         $testBoltResponse->token = md5('bolt');
 
         $apiErrorMessage = 'Some error from api.';
-        Mage::register('api_error', $apiErrorMessage);
+        Mage::register('bolt_api_error', $apiErrorMessage);
 
         $result = $this->currentMock->buildCartData($testBoltResponse);
 

--- a/tests/unit/testsuite/Bolt/Boltpay/TestHelper.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/TestHelper.php
@@ -146,12 +146,12 @@ class Bolt_Boltpay_TestHelper
                 json_hints,
                 {
                   check: function() {
-                    $checkCustom
-                    $onCheckCallbackAdmin
                     if (!json_cart.orderToken) {
                         alert(json_cart.error);
                         return false;
                     }
+                    $checkCustom
+                    $onCheckCallbackAdmin
                     return true;
                   },
                   


### PR DESCRIPTION
Fixes 
1.) The json cart creation error always taking precedence over all other custom and contextual checks
2.) Merchant-side plugin defined errors also being included. (Before only Bolt-server side errors were displayed.
3.) Fixes "Mage registry key "api_error" already exists" error that can be found in bugsnag