### PR TITLE
Removes cart order token check for firecheckout, which uses promise

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -290,6 +290,20 @@ PROMISE;
         $onSuccessCallback = $this->buildOnSuccessCallback($successCustom, $checkoutType);
         $onCloseCallback = $this->buildOnCloseCallback($closeCustom, $checkoutType);
 
+        $standardCheck = ($checkoutType === self::CHECKOUT_TYPE_FIRECHECKOUT)
+            ? ""
+            : "
+                    if (!json_cart.orderToken) {
+                        if (typeof BoltPopup !== \"undefined\") {
+                            BoltPopup.addMessage(json_cart.error).show();
+                        } else {
+                            alert(json_cart.error);
+                        }
+                        return false;
+                    }
+            "
+        ;
+
         return ("
             var json_cart = $jsonCart;
             var json_hints = $jsonHints;
@@ -301,14 +315,7 @@ PROMISE;
                 json_hints,
                 {
                   check: function() {
-                    if (!json_cart.orderToken) {
-                        if (typeof BoltPopup !== \"undefined\") {
-                            BoltPopup.addMessage(json_cart.error).show();
-                        } else {
-                            alert(json_cart.error);
-                        }
-                        return false;
-                    }
+                    $standardCheck
                     $checkCustom
                     $onCheckCallback
                     return true;


### PR DESCRIPTION
Context:
Checking for the token is handled from the Promise in Firecheckout.  Therefore, the callback check should be removed as there will never be a token in the returned json_cart object.