### PR TITLE
Allow for empty string to be set.

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Admin/Form/Color.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/Form/Color.php
@@ -20,7 +20,7 @@ class Bolt_Boltpay_Model_Admin_Form_Color extends Mage_Core_Model_Config_Data
     public function save()
     {
         $hexColor = $this->getValue();
-        if(!preg_match('/^#(([A-Fa-f0-9]{6})|([A-Fa-f0-9]{8}))$/', $hexColor)){
+        if(!empty($hexColor) && !preg_match('/^#(([A-Fa-f0-9]{6})|([A-Fa-f0-9]{8}))$/', $hexColor)){
             $this->setValue($this->getOldValue());
             Mage::getSingleton('core/session')->addError(Mage::helper('boltpay')->__('Invalid hex color value. Should be in the form #f00000 or #f00'));
         }


### PR DESCRIPTION
Proposal to allow empty string as a valid value to fall back to Bolt defaults.

If not, once a color is set, it can not be unset to allow for Bolt defined defaults.