### PR TITLE
Include replace.js only when publishable key is defined

### DIFF
--- a/app/design/frontend/base/default/template/boltpay/replace.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace.phtml
@@ -22,7 +22,10 @@
 <?php /* @var $this Bolt_Boltpay_Block_Checkout_Boltpay */?>
 <?php
 
-if(!$this->isAllowedReplaceScriptOnCurrentPage() || !$this->canUseBolt() ) return;
+if(!$this->isAllowedReplaceScriptOnCurrentPage()
+   || !$this->canUseBolt()
+   || !$this->getPublishableKeyForRoute()
+) return;
 
 $additionalClasses = Mage::helper('boltpay')->getAdditionalButtonClasses();
 ?>


### PR DESCRIPTION
Payment-only merchant doesn't want replace.js is included in cart page