### PR TITLE
Moved the logic to set quote_id to session after setting customer to session

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -68,12 +68,6 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
             /* @var Mage_Sales_Model_Quote $quote */
             $quote = Mage::getModel('sales/quote')->loadByIdWithoutStore($quoteId);
 
-            /***********************/
-            // Set session quote to real customer quote
-            $session = Mage::getSingleton('checkout/session');
-            $session->setQuoteId($quoteId);
-            /**************/
-
             /* @var Bolt_Boltpay_Model_ShippingAndTax $shippingAndTaxModel */
             $shippingAndTaxModel = Mage::getModel('boltpay/shippingAndTax');
             $addressData = $shippingAndTaxModel->applyShippingAddressToQuote($quote, $shippingAddress);
@@ -102,6 +96,12 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
                 }
             } else {
                 Mage::helper('boltpay')->setCustomerSessionById($quote->getCustomerId());
+
+                /***********************/
+                // Set session quote to real customer quote
+                $session = Mage::getSingleton('checkout/session');
+                $session->setQuoteId($quoteId);
+                /**************/
 
                 //Mage::log('Generating address from quote', null, 'shipping_and_tax.log');
                 //Mage::log('Live address: '.var_export($address_data, true), null, 'shipping_and_tax.log');

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -68,6 +68,14 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
             /* @var Mage_Sales_Model_Quote $quote */
             $quote = Mage::getModel('sales/quote')->loadByIdWithoutStore($quoteId);
 
+            Mage::helper('boltpay')->setCustomerSessionById($quote->getCustomerId());
+
+            /***********************/
+            // Set session quote to real customer quote
+            $session = Mage::getSingleton('checkout/session');
+            $session->setQuoteId($quoteId);
+            /**************/
+
             /* @var Bolt_Boltpay_Model_ShippingAndTax $shippingAndTaxModel */
             $shippingAndTaxModel = Mage::getModel('boltpay/shippingAndTax');
             $addressData = $shippingAndTaxModel->applyShippingAddressToQuote($quote, $shippingAddress);
@@ -95,14 +103,6 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
                     $cacheBoltHeader = 'MISS';
                 }
             } else {
-                Mage::helper('boltpay')->setCustomerSessionById($quote->getCustomerId());
-
-                /***********************/
-                // Set session quote to real customer quote
-                $session = Mage::getSingleton('checkout/session');
-                $session->setQuoteId($quoteId);
-                /**************/
-
                 //Mage::log('Generating address from quote', null, 'shipping_and_tax.log');
                 //Mage::log('Live address: '.var_export($address_data, true), null, 'shipping_and_tax.log');
                 $response = $shippingAndTaxModel->getShippingAndTaxEstimate($quote);


### PR DESCRIPTION
I found a bug when testing on Golf land. Parent quote is being removed when estimating the shipping with login customer.

When setting the customer to session, it will get a current customer quote which is parent quote and then merges the quote that being on the session and then remove the parent quote.