### PR TITLE
Correct the way of handling the duplicated webhook exception v2

### DIFF
--- a/app/code/community/Bolt/Boltpay/DuplicateTransitionException.php
+++ b/app/code/community/Bolt/Boltpay/DuplicateTransitionException.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Bolt magento plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Class Bolt_Boltpay_DuplicateTransitionException
+ *
+ * This exception is thrown when a transaction is trying to process order creation while a previous transaction already started before its arrival 
+ */
+class Bolt_Boltpay_DuplicateTransitionException extends Exception
+{
+    private $_processedBoltReference;
+    /**
+     * Bolt_Boltpay_InvalidTransitionException constructor.
+     *
+     * @param string $message           [optional] The Exception message to throw.
+     * @param int $code                 [optional] The Exception code.
+     * @param Throwable|null $previous  [optional] The previous throwable used for the exception chaining.
+     */
+    public function __construct($processedBoltReference, $message = "", $code = 0, Throwable $previous = null)
+    {
+        $this->_processedBoltReference = $processedBoltReference;
+        parent::__construct($message, $code, $previous);
+    }
+    
+    public function getProcessedBoltReference()
+    {
+        return $this->_processedBoltReference;
+    }
+}

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -79,12 +79,11 @@ class Bolt_Boltpay_Model_Order extends Mage_Core_Model_Abstract
                         $immutableQuote->getParentQuoteId() )
                 );
             } else if (!$parentQuote->getIsActive() ) {
-                throw new Exception(
-                    Mage::helper('boltpay')->__("The parent quote %s for immutable quote %s is currently being processed or has been processed for order #%s. Check quote %s for details.",
-                        $parentQuote->getId(), $immutableQuote->getId(), $parentQuote->getReservedOrderId(), $parentQuote->getParentQuoteId() )
-                );
+                $parentQuoteBoltReference = $parentQuote->getBoltReference();
+                throw new Bolt_Boltpay_DuplicateTransitionException($parentQuoteBoltReference, Mage::helper('boltpay')->__("The parent quote %s is currently being processed or has been processed by bolt transaction %s.",
+                                                $immutableQuote->getParentQuoteId(), $parentQuoteBoltReference ));
             } else {
-                $parentQuote->setIsActive(false)->save();
+                $parentQuote->setIsActive(false)->setBoltReference($reference)->save();
             }
 
             // adding guest user email to order

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -188,6 +188,27 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
             $parentQuote->removeAllItems()->save();
             //////////////////////////////////////////////
 
+        } catch (Bolt_Boltpay_DuplicateTransitionException $boltPayDuplicateTransitionException) {
+            //In this case, the parent quote is currently being processed or has been processed,
+            //and if this Duplicate transaction has the same reference with the processed transaction, then it should be ignored
+            //and if not, there should report an error
+            if($boltPayDuplicateTransitionException->getProcessedBoltReference() == $reference){
+                Mage::helper('boltpay/bugsnag')->notifyException( new Exception($boltPayDuplicateTransitionException->getMessage()) );
+                $this->getResponse()->setHttpResponseCode(422)
+                    ->setBody(json_encode(array('status' => 'failure', 'error' => array('code' => '6009', 'message' => $boltPayDuplicateTransitionException->getMessage()))));
+            }
+            else{
+                $errMsg = Mage::helper('boltpay')->__("%s Therefore, this redundant bolt transaction %s will not be processed as an order in Magento.",
+                                                $boltPayDuplicateTransitionException->getMessage(), $reference );
+                Mage::helper('boltpay/bugsnag')->notifyException( new Exception($errMsg) );
+                $this->getResponse()->setHttpResponseCode(503)
+                    ->setHeader("Retry-After", "86400")
+                    ->setBody(json_encode(array(
+                        'status' => 'failure',
+                        'error' => array(
+                            'code' => '6009',
+                            'message' => $errMsg ))));
+            }            
         } catch (Bolt_Boltpay_InvalidTransitionException $boltPayInvalidTransitionException) {
 
             if ($boltPayInvalidTransitionException->getOldStatus() == Bolt_Boltpay_Model_Payment::TRANSACTION_ON_HOLD) {

--- a/app/code/community/Bolt/Boltpay/controllers/ConfigurationController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ConfigurationController.php
@@ -161,6 +161,9 @@ class Bolt_Boltpay_ConfigurationController extends Mage_Core_Controller_Front_Ac
         if (!$connection->tableColumnExists($quoteTable, 'parent_quote_id')) {
             return false;
         }
+        if (!$connection->tableColumnExists($quoteTable, 'bolt_reference')) {
+            return false;
+        }
 
         $boltUserIdAttr = $setup->getAttribute('customer', 'bolt_user_id');
         if (!$boltUserIdAttr) {

--- a/app/code/community/Bolt/Boltpay/sql/bolt_boltpay_setup/upgrade-1.3.3-1.3.4.php
+++ b/app/code/community/Bolt/Boltpay/sql/bolt_boltpay_setup/upgrade-1.3.3-1.3.4.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Bolt magento plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+/**
+ * This installer unencrypt publishable key
+ *
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = Mage::getResourceModel('sales/setup', 'sales_setup');
+$installer->startSetup();
+
+Mage::log('Installing Bolt 1.3.4 updates', null, 'bolt_install.log');
+
+$installer->addAttribute("quote", "bolt_reference",  array(
+    "type"       => "varchar",
+    "label"      => "Bolt Reference",
+    "input"      => "hidden",
+    "visible"    => false,
+    "required"   => false,
+    "unique"     => false,
+    "note"       => "Bolt Reference for the quote"
+));
+
+Mage::log('Bolt 1.3.4 updates installation completed', null, 'bolt_install.log');
+
+$installer->endSetup();


### PR DESCRIPTION
The bolt-magento 1 plugin updates a lot of things since the last commit of PR https://github.com/BoltApp/bolt-magento1/pull/144, then I create a new PR for the asana task https://app.asana.com/0/436430054069245/760406935557852/f

Tested with magento 1.9.3.8