### PR TITLE
changed order and binding of firecheckout events to be cleaner, more …

### DIFF
--- a/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace_firecheckout.phtml
@@ -87,6 +87,8 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
         };
 
 
+        var selected_radio = null;
+
         /**
          * Attaches click event to all radio buttons
          *
@@ -103,27 +105,16 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
                 payment_radio.onclick = toggleBoltButton;
 
                 <?php if ($this->isBoltOnlyPayment()): ?>
-                if (payment_radio.id == "p_method_boltpay") {
-                    payment_radio.click();
-                } else {
+                if (payment_radio.id != "p_method_boltpay") {
                     payment_radio.parentNode.style.display = "none";
+                    payment_radio.checked = false;
                 }
                 <?php endif; ?>
 
-                if (payment_radio.checked) payment_radio.click();
+                if (payment_radio.checked) { selected_radio = payment_radio; }
             }
 
         };
-
-        attachClickEvents();
-
-        //////////////////////////////////////////////////////////////////////
-        // Watch for changes in the payment methods to re-attach click events
-        //////////////////////////////////////////////////////////////////////
-        var paymentMethodsContainer = document.getElementById('checkout-payment-method-load');
-        var paymentMethodObserver = new MutationObserver(attachClickEvents);
-        paymentMethodObserver.observe(paymentMethodsContainer, { childList: true });
-        //////////////////////////////////////////////////////////////////////
 
         var autoSelectShipping = function () {
 
@@ -141,13 +132,24 @@ if(!Mage::helper('boltpay')->canUseBolt($this->getQuote(), false) || Mage::getSt
             if (!shipping_selected)  document.querySelectorAll('input[name=shipping_method]')[0].click();
         };
 
-        if (window.addEventListener) {
-            window.addEventListener("load", autoSelectShipping, false);
-        } else if (window.attachEvent) {
-            window.attachEvent("onload", autoSelectShipping);
-        } else {
-            window.onload = autoSelectShipping;
+        autoSelectShipping();
+        attachClickEvents();
+
+        var bolt_radio = document.querySelector('#p_method_boltpay');
+        if (selected_radio) {
+            selected_radio.click();
+        } else if (bolt_radio) {
+            bolt_radio.click();
         }
+
+        //////////////////////////////////////////////////////////////////////
+        // Watch for changes in the payment methods to re-attach click events
+        //////////////////////////////////////////////////////////////////////
+        var paymentMethodsContainer = document.getElementById('checkout-payment-method-load');
+        var paymentMethodObserver = new MutationObserver(attachClickEvents);
+        paymentMethodObserver.observe(paymentMethodsContainer, { childList: true });
+        //////////////////////////////////////////////////////////////////////
+
     };
 
     if (window.addEventListener) {


### PR DESCRIPTION
…logical, and better assuring the correct conditions for Bolt.

In some cases, the Bolt radio was not reliably being clicked to trigger the hiding of the place order button and the display of the Bolt Button.  This caused the Bolt order to be processed under the standard firecheckout context while have the payment type of Bolt.  The result was a call to the API helper `transmit` method from the `Bolt_Boltpay_Model_Observer::setInitialOrderStatusAndDetails` method without a Bolt reference and therefore a null value for command.  The end result is a call to the `merchant` endpoint.

This addresses not reaching the state of the place order button being presented instead of the Bolt button.