### PR TITLE
Get correct singleton object

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -98,7 +98,7 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function collectTotals($quote, $clearTotalsCollectedFlag = false)
     {
-        Mage::getSingleton('boltpay/validator')->resetRoundingDeltas();
+        Mage::getSingleton('salesrule/validator')->resetRoundingDeltas();
 
         if($clearTotalsCollectedFlag) {
             $quote->setTotalsCollectedFlag(false);


### PR DESCRIPTION
We need to specify the key of validator class in salesrule/validator, because core magento uses a property of this class to calculate the rounding.

Basically every time, we collect the total, we need to reset it to empty or else a rounding error occurs.