### PR TITLE
Simple product sku is saved incorrectly on Bolt

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -124,7 +124,7 @@ class Bolt_Boltpay_Model_BoltOrder extends Mage_Core_Model_Abstract
                         'reference'    => $quote->getId(),
                         'image_url'    => $imageUrl,
                         'name'         => $item->getName(),
-                        'sku'          => $product->getData('sku'),
+                        'sku'          => $item->getSku(),
                         'description'  => substr($product->getDescription(), 0, 8182) ?: '',
                         'total_amount' => round($item->getCalculationPrice() * 100) * $item->getQty(),
                         'unit_price'   => round($item->getCalculationPrice() * 100),

--- a/app/code/community/Bolt/Boltpay/Model/Order/Detail.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order/Detail.php
@@ -248,7 +248,7 @@ class Bolt_Boltpay_Model_Order_Detail extends Mage_Core_Model_Abstract
                     'reference'    => $this->order->getQuoteId(),
                     'image_url'    => $imageUrl,
                     'name'         => $item->getName(),
-                    'sku'          => $product->getData('sku'),
+                    'sku'          => $item->getSku(),
                     'description'  => substr($product->getDescription(), 0, 8182) ?: '',
                     'total_amount' => $totalAmount,
                     'unit_price'   => $unitPrice,

--- a/app/code/community/Bolt/Boltpay/Model/Productpage/Cart.php
+++ b/app/code/community/Bolt/Boltpay/Model/Productpage/Cart.php
@@ -267,7 +267,7 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Mage_Core_Model_Abstract
                     'reference'    => $this->getSessionQuote()->getId(),
                     'image_url'    => $imageUrl,
                     'name'         => $item->getName(),
-                    'sku'          => $product->getData('sku'),
+                    'sku'          => $item->getSku(),
                     'description'  => substr($product->getDescription(), 0, 8182) ?: '',
                     'total_amount' => $totalAmount,
                     'unit_price'   => $unitPrice,


### PR DESCRIPTION
Fixed the issue with simple product sku not being sent to Bolt when associated with a configurable parent sku.