### PR TITLE
Updated multiple capture

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Observer.php
+++ b/app/code/community/Bolt/Boltpay/Model/Observer.php
@@ -197,7 +197,7 @@ class Bolt_Boltpay_Model_Observer
                     $payment->setAdditionalInformation('bolt_transaction_status', Bolt_Boltpay_Model_Payment::TRANSACTION_COMPLETED);
                     break;
                 case Mage_Sales_Model_Order::STATE_PROCESSING:
-                    if ($order->getTotalPaid() >= .01) {
+                    if (!$order->getTotalDue()) {
                         $payment->setAdditionalInformation('bolt_transaction_status', Bolt_Boltpay_Model_Payment::TRANSACTION_COMPLETED);
                     } else {
                         $payment->setAdditionalInformation('bolt_transaction_status', Bolt_Boltpay_Model_Payment::TRANSACTION_AUTHORIZED);

--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -757,6 +757,9 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
         $boltCaptures = $this->getNewBoltCaptures($payment);
 
         $order = $payment->getOrder();
+        $order->setStatus(Mage_Sales_Model_Order::STATE_PROCESSING);
+        $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING);
+
         // Create invoices for items from $boltCaptures that are not exists on Magento
         $identifier = count($boltCaptures) > 1 ? 0 : null;
         foreach ($boltCaptures as $captureAmount) {
@@ -768,7 +771,7 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
             $identifier++;
         }
 
-        if ($boltCaptures) { $order->save(); }
+        $order->save();
     }
 
     /**

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -91,7 +91,7 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
                 //Mage::log('Order Found. Updating it', null, 'bolt.log');
                 $orderPayment = $order->getPayment();
 
-                $newTransactionStatus = Bolt_Boltpay_Model_Payment::translateHookTypeToTransactionStatus($hookType);
+                $newTransactionStatus = Bolt_Boltpay_Model_Payment::translateHookTypeToTransactionStatus($hookType, $transaction);
                 $prevTransactionStatus = $orderPayment->getAdditionalInformation('bolt_transaction_status');
 
                 // Update the transaction id as it may change, particularly with refunds


### PR DESCRIPTION
When implementing multiple capture for Magento 1 Bolt set the transaction status to complete after partial capture. When implementing multiple capture for Magento 2, I realized the transaction status should be authorized in M1 due to new logic. Created this task to fix the M1 version.