### PR TITLE
Add pre-commit hook for checking PHP Lint and MEQP1 style checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,14 @@
     "ext-PDO": "*"
   },
   "require-dev": {
+    "squizlabs/php_codesniffer": "3.*",
+    "magento/marketplace-eqp": "2.*",
     "phpunit/phpunit": "^4.8"
+  },
+  "scripts": {
+    "post-install-cmd": [
+      "bash tools/setup.sh"
+    ]
   },
   "repositories": [
     {

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Adapted from https://robjmills.co.uk/2018/01/14/automatic-psr2-coding-standard.html
+
+PROJECT=`php -r "echo dirname(dirname(dirname(realpath('$0'))));"`
+STAGED_FILES_CMD=`git diff --cached --name-only --diff-filter=ACMR HEAD | grep \\\\.php`
+CODING_STANDARD=vendor/magento/marketplace-eqp/MEQP1
+
+# Determine if a file list is passed
+if [ "$#" -eq 1 ]; then
+    oIFS=$IFS
+    IFS='
+    '
+    SFILES="$1"
+    IFS=${oIFS}
+fi
+SFILES=${SFILES:-$STAGED_FILES_CMD}
+
+echo "Checking PHP Lint..."
+for FILE in ${SFILES}
+do
+    php -l -d display_errors=0 ${PROJECT}/${FILE}
+    if [ $? != 0 ]; then
+        echo "PHP Lint failed. Please fix all syntax errors and try again."
+        exit 1
+    fi
+    FILES="${FILES} $PROJECT/$FILE"
+done
+
+# Run the code style fixes if phpcs exists and environment variable is set
+if [[ -f "vendor/bin/phpcs" ]]; then
+    if [ "${FILES}" != "" ]; then
+        echo "Running phpcs (with warnings), standard:MEQP1"
+        ./vendor/bin/phpcs --standard=${CODING_STANDARD} --encoding=utf-8 -p ${FILES}
+        if [ $? != 0 ]; then
+            exec < /dev/tty
+            echo "PSR-2 issues found. Fix automatically (where possible)? [y/N]"
+            read proceed
+            if [[ ! ("$proceed" == 'y' || "$proceed" == 'Y' || "$proceed" == '') ]]; then
+                echo "Skipping autofixing.."
+            else
+                echo "Automagically fixing files: (⋆._.)⊃―━━☆⌒*."
+                ./vendor/bin/phpcbf --standard=${CODING_STANDARD} ${FILES}
+	            echo "Re-staging updated files"
+                git add ${FILES}
+            fi
+            echo "Committing if no errors remaining..."
+            ./vendor/bin/phpcs --standard=${CODING_STANDARD} --encoding=utf-8 -n -p ${FILES}
+            exit $?
+        fi
+    fi
+fi

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cp tools/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
Here is my first pass at githooks to check linting and style. After pulling this branch, all you need to do is a `composer install` and you're set up. You may need to enter magento credentials the first time you `composer install` (to fetch the `MEQP1` standard).

When you commit, the following happen in order:

1. A basic lint is performed using `php -l`. If this fails, your commit is aborted.
2. A style check against `MEQP1` is performed using `phpcs`. This checks for both errors and warnings.
3. You are given an (optional) prompt to automatically fix warnings and errors.
4. `phpcs` is run again, only checking errors. If no errors are present, your commit goes through - if errors still exist, your commit is aborted.

Please find some screenshots attached with examples:

**PHP Lint fails, abort immediately**
<img width="1218" alt="screen shot 2018-12-21 at 9 19 53 am" src="https://user-images.githubusercontent.com/45575491/50347189-b9fdc400-0502-11e9-8514-76a269c99cdb.png">

**PHPCS finds and fixes warnings, then commits**
<img width="819" alt="screen shot 2018-12-21 at 9 18 16 am" src="https://user-images.githubusercontent.com/45575491/50347218-d568cf00-0502-11e9-9510-c3dca54db37b.png">

**PHPCS finds and fixes warnings, but cannot fix an error, so aborts**
<img width="817" alt="screen shot 2018-12-21 at 9 17 20 am" src="https://user-images.githubusercontent.com/45575491/50347248-e1ed2780-0502-11e9-8489-0eea090c99ac.png">

Let me know if you have any questions or concerns!
