### PR TITLE
Remove testdox from CI phpunit

### DIFF
--- a/tests/scripts/run_phpunit_tests.sh
+++ b/tests/scripts/run_phpunit_tests.sh
@@ -3,5 +3,4 @@
 export TEST_ENV=local
 export PHPUNIT_ENVIRONMENT=true
 
-php ${PHPUNIT_PHAR} --testdox --verbose --report-useless-tests -c tests/unit/phpunit.xml
-
+php ${PHPUNIT_PHAR} --verbose --report-useless-tests -c tests/unit/phpunit.xml


### PR DESCRIPTION
With the version of phpunit we use, testdox cannot show error details when test fails