### PR TITLE
Exposes javascript Bolt Modal object to be available in window context

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -322,7 +322,7 @@ PROMISE;
             var quote_id = '{$quote->getId()}';
             var order_completed = false;
 
-            BoltCheckout.configure(
+            window.BoltModal = BoltCheckout.configure(
                 json_cart,
                 json_hints,
                 $callbacks

--- a/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
@@ -23,7 +23,7 @@ var boltConfigPDP = {
             jsonProductCart.items = [];
         }
 
-        BoltCheckout.configureProductCheckout(
+        window.BoltModal = BoltCheckout.configureProductCheckout(
             jsonProductCart,
             boltJsonProductHints,
             <?php echo $this->getBoltCallbacks(); ?>,

--- a/tests/unit/testsuite/Bolt/Boltpay/TestHelper.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/TestHelper.php
@@ -148,7 +148,7 @@ class Bolt_Boltpay_TestHelper
             var quote_id = '{$immutableQuoteId}';
             var order_completed = false;
 
-            BoltCheckout.configure(
+            window.BoltModal = BoltCheckout.configure(
                 json_cart,
                 json_hints,
                 $configCallbacks


### PR DESCRIPTION
https://app.asana.com/0/544708310157130/1108757786846726

Since BoltCheckout.configure now returns an object with an "open" method and "hasBoltButton" boolean, this object should be made available to the global browser scope

As an example, this will allow for code such as:

```
var customerIsLoggedIn = <?= ($this->customerIsLoggedIn()) ? 'true' : 'false';>;
var wasLoggedInByBolt = <?= ($this->wasBoltInitiatedLogin()) ? 'true' : 'false';>;

if (customerIsLoggedIn && wasLoggedInByBolt && BoltModal.hasBoltButton) {
    BoltModal.open();  // automatically open the Bolt modal
} else if (!customerIsLoggedIn) {
    doBoltInitiatedCustomerLogin();  // will refresh page
}
```