### PR TITLE
add clearHeaders before setHeader

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -163,7 +163,7 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
         $quote = Mage::getSingleton('checkout/session')->getQuote();
 
         if(!$quote->getId() || !$quote->getItemsCount()){
-            $this->getResponse()->setHeader('Content-type', 'application/json');
+            $this->getResponse()->clearHeaders()->setHeader('Content-type', 'application/json');
             $this->getResponse()->setBody("{}");
             return;
         }
@@ -209,7 +209,7 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
         }
 
         $response = Mage::helper('core')->jsonEncode(array('address_data' => $addressData));
-        $this->getResponse()->setHeader('Content-type', 'application/json');
+        $this->getResponse()->clearHeaders()->setHeader('Content-type', 'application/json');
         $this->getResponse()->setBody($response);
     }
 


### PR DESCRIPTION
Explicitly clear the headers before we send the headers to ensure any native or third-party modules have not already set the header.