### PR TITLE
Cast to Array if String Value forEach

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -312,10 +312,7 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
         }
 
         // include any discounts or gift card rules because they may affect shipping
-        $rules = $quote->getAppliedRuleIds();
-        if(!is_array($rules)) {
-            $rules = explode(",", $rules);
-        }
+        $rules = explode( ",", $quote->getAppliedRuleIds() );
         foreach($rules as $ruleId) {
             $cacheIdentifier .= '_applied-rule-'.$ruleId;
         }

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -312,7 +312,11 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
         }
 
         // include any discounts or gift card rules because they may affect shipping
-        foreach($quote->getAppliedRuleIds() as $ruleId) {
+        $rules = $quote->getAppliedRuleIds();
+        if(!is_array($rules)) {
+            $rules = array($rules);
+        }
+        foreach($rules as $ruleId) {
             $cacheIdentifier .= '_applied-rule-'.$ruleId;
         }
 

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -312,10 +312,7 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
         }
 
         // include any discounts or gift card rules because they may affect shipping
-        $rules = explode( ",", $quote->getAppliedRuleIds() );
-        foreach($rules as $ruleId) {
-            $cacheIdentifier .= '_applied-rule-'.$ruleId;
-        }
+        $cacheIdentifier .= '_applied-rules-'.json_encode($quote->getAppliedRuleIds());
 
         return md5($cacheIdentifier);
     }

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -314,7 +314,7 @@ class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
         // include any discounts or gift card rules because they may affect shipping
         $rules = $quote->getAppliedRuleIds();
         if(!is_array($rules)) {
-            $rules = array($rules);
+            $rules = explode(",", $rules);
         }
         foreach($rules as $ruleId) {
             $cacheIdentifier .= '_applied-rule-'.$ruleId;


### PR DESCRIPTION
If $quote->getAppliedRuleIds() returns a string value, cast to an array to avoid foreach error on string.