### PR TITLE
Add call to singular method for setting shipping method.

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -111,57 +111,51 @@ class Bolt_Boltpay_Model_Order extends Mage_Core_Model_Abstract
             }
             $immutableQuote->save();
 
+            $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true)->save();
+            $immutableQuote->getBillingAddress()->setShouldIgnoreValidation(true)->save();
+
             //////////////////////////////////////////////////////////////////////////////////
             ///  Apply shipping address and shipping method data to quote directly from
             ///  the Bolt transaction.
             //////////////////////////////////////////////////////////////////////////////////
-            $shippingMethodCode = null;
-            $shippingAndTaxModel = Mage::getModel("boltpay/shippingAndTax");
-            if ($transaction->order->cart->shipments) {
+            $packagesToShip = $transaction->order->cart->shipments;
 
-                $shippingAndTaxModel->applyShippingAddressToQuote($immutableQuote, $transaction->order->cart->shipments[0]->shipping_address);
-                $shippingMethodCode = $transaction->order->cart->shipments[0]->reference;
-            }
-
-            $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true)->save();
-            $immutableQuote->getBillingAddress()->setShouldIgnoreValidation(true)->save();
-
-            if ($shippingMethodCode) {
-                $immutableQuote->getShippingAddress()->setShippingMethod($shippingMethodCode)->save();
-                Mage::dispatchEvent(
-                    'bolt_boltpay_shipping_method_applied',
-                    array(
-                        'quote'=>$immutableQuote,
-                        'shippingMethodCode' => $shippingMethodCode
-                    )
-                );
-            } else {
-                // Legacy transaction does not have shipments reference - fallback to $service field
-                $service = $transaction->order->cart->shipments[0]->service;
-
-                Mage::helper('boltpay')->collectTotals($immutableQuote);
+            if ($packagesToShip) {
 
                 $shippingAddress = $immutableQuote->getShippingAddress();
-                $shippingAddress->setCollectShippingRates(true)->collectShippingRates();
-                $rates = $shippingAddress->getAllShippingRates();
+                $shippingMethodCode = null;
+                /** @var Bolt_Boltpay_Model_ShippingAndTax $shippingAndTaxModel */
+                $shippingAndTaxModel = Mage::getModel("boltpay/shippingAndTax");
 
-                $isShippingSet = false;
-                foreach ($rates as $rate) {
-                    if ($rate->getCarrierTitle() . ' - ' . $rate->getMethodTitle() == $service
-                        || (!$rate->getMethodTitle() && $rate->getCarrierTitle() == $service)) {
-                        $shippingMethod = $rate->getCarrier() . '_' . $rate->getMethod();
-                        $immutableQuote->getShippingAddress()->setShippingMethod($shippingMethod)->save();
-                        $isShippingSet = true;
-                        break;
+                $shippingAndTaxModel->applyShippingAddressToQuote($immutableQuote, $packagesToShip[0]->shipping_address);
+                $shippingMethodCode = $packagesToShip[0]->reference;
+
+                if (!$shippingMethodCode) {
+                    // Legacy transaction does not have shipments reference - fallback to $service field
+                    $service = $packagesToShip[0]->service;
+
+                    Mage::helper('boltpay')->collectTotals($immutableQuote);
+
+                    $shippingAddress->setCollectShippingRates(true)->collectShippingRates();
+                    $rates = $shippingAddress->getAllShippingRates();
+
+                    foreach ($rates as $rate) {
+                        if ($rate->getCarrierTitle() . ' - ' . $rate->getMethodTitle() == $service
+                            || (!$rate->getMethodTitle() && $rate->getCarrierTitle() == $service)) {
+                            $shippingMethodCode = $rate->getCarrier() . '_' . $rate->getMethod();
+                            break;
+                        }
                     }
                 }
 
-                if ($isShippingSet) {
+                if ($shippingMethodCode) {
+                    $shippingAndTaxModel->applyShippingRate($immutableQuote, $shippingMethodCode);
+                    $shippingAddress->save();
                     Mage::dispatchEvent(
-                        'bolt_boltpay_shipping_method_applied',
+                        'bolt_boltpay_order_creation_shipping_method_applied',
                         array(
                             'quote'=> $immutableQuote,
-                            'shippingMethodCode' => $shippingMethod
+                            'shippingMethodCode' => $shippingMethodCode
                         )
                     );
                 } else {

--- a/app/code/community/Bolt/Boltpay/Model/ShippingAndTax.php
+++ b/app/code/community/Bolt/Boltpay/Model/ShippingAndTax.php
@@ -193,7 +193,7 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Mage_Core_Model_Abstract
      * Applies shipping rate to quote. Clears previously calculated discounts by clearing address id.
      *
      * @param Mage_Sales_Model_Quote $quote    Quote which has been updated to use new shipping rate
-     * @param string $shippingRateCode    Shipping rate code
+     * @param string $shippingRateCode         Shipping rate code composed of {carrier}_{method}
      */
     public function applyShippingRate($quote, $shippingRateCode) {
         $shippingAddress = $quote->getShippingAddress();
@@ -203,7 +203,9 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Mage_Core_Model_Abstract
             $shippingAddress->isObjectNew(true);
             $shippingAddressId = $shippingAddress->getData('address_id');
 
-            $shippingAddress->setShippingMethod($shippingRateCode);
+            $shippingAddress
+                ->setShippingMethod($shippingRateCode)
+                ->setCollectShippingRates(true);
 
             // When multiple shipping methods apply a discount to the sub-total, collect totals doesn't clear the
             // previously set discount, so the previous discount gets added to each subsequent shipping method that
@@ -219,6 +221,14 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Mage_Core_Model_Abstract
             if(!empty($shippingAddressId) && $shippingAddressId != $shippingAddress->getData('address_id')) {
                 $shippingAddress->setData('address_id', $shippingAddressId);
             }
+
+            Mage::dispatchEvent(
+                'bolt_boltpay_shipping_method_applied',
+                array(
+                    'quote'=> $quote,
+                    'shippingMethodCode' => $shippingRateCode
+                )
+            );
         }
     }
 


### PR DESCRIPTION
https://app.asana.com/0/544708310157130/1108910545116701

This refactors so that adding a shipping method to the quote always goes down the same path to assure discounts and rules are always recalculated.  This DRYs out the codebase

This also adds distinction between the event for adding a shipping rate to the quote for general purposes like shipping and tax estimates and add the shipping rate in the process of order creation.