### PR TITLE
Populate billing name

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -134,6 +134,12 @@ class Bolt_Boltpay_Model_Order extends Mage_Core_Model_Abstract
             $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true)->save();
             $immutableQuote->getBillingAddress()->setShouldIgnoreValidation(true)->save();
 
+            // Explicitly set the billing name to the correct billing information saved in $transaction
+            $billingFirstName = $transaction->from_credit_card->billing_address->first_name;
+            $billingLastName = $transaction->from_credit_card->billing_address->last_name;
+            $immutableQuote->getBillingAddress()->setFirstname($billingFirstName)->save();
+            $immutableQuote->getBillingAddress()->setLastname($billingLastName)->save();
+
             if ($shippingMethodCode) {
                 $immutableQuote->getShippingAddress()->setShippingMethod($shippingMethodCode)->save();
                 Mage::dispatchEvent(


### PR DESCRIPTION
Set the billing name from the transaction object explicitly to prevent issues like https://app.asana.com/0/941895179897714/1107491074225023/f
Images are in Asana of the problem being fixed.