### PR TITLE
Allows merchant to specify quote cloning/Bolt order creation on Bolt button click

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -212,6 +212,7 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
         $onCheckCallback = $boltHelper->buildOnCheckCallback($checkoutType, $quote);
 
         $hintsTransformFunction = $boltHelper->getExtraConfig('hintsTransform');
+        $shouldCloneImmediately = !$boltHelper->getExtraConfig( 'cloneOnClick' );
 
         $boltConfigureCall =
         "
@@ -225,8 +226,10 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
         switch ($checkoutType) {
             case self::CHECKOUT_TYPE_MULTI_PAGE:
                 // if it is a multipage checkout from the shopping cart,
-                // we will call configure immediately
-                if ($this->helper('boltpay')->isShoppingCartPage()) break;
+                // we will call configure immediately unless extra config 'cloneOnClick' overrides this
+                if ($this->helper('boltpay')->isShoppingCartPage() && $shouldCloneImmediately) break;
+            case self::CHECKOUT_TYPE_ONE_PAGE:
+                if ($shouldCloneImmediately) break;
             case self::CHECKOUT_TYPE_ADMIN:
             case self::CHECKOUT_TYPE_FIRECHECKOUT:
                 // We postpone calling configure until Bolt button clicked and form is ready


### PR DESCRIPTION
https://app.asana.com/0/941895179897714/1110284468674223/f

The config is an `Extra config` boolean value called `cloneOnClick`.  

Example usage to enable cloning on Bolt button click:

In the Magento Admin `System -> Configuration -> Payment Methods -> Bolt Pay -> Extra Config`
```
{
"boltPrimaryColor":"#fff000",
"hintsTransform":
"
     function(hints){
          hints.prefill = 
               {\"email\":\"leon@bolt.com\"};
          return hints;
     }
",
"cloneOnClick": true
}
```

