### PR TITLE
fixes php7 not json decoding null by using empty array instead

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
@@ -191,6 +191,6 @@ JS;
      * @return string|null    The string stripped of newline characters or null on error
      */
     private function normalizeJSON($string) {
-        return trim(preg_replace( '/(\r\n)|\n|\r/', '', $string )) ?: null;
+        return trim(preg_replace( '/(\r\n)|\n|\r/', '', $string )) ?: array();
     }
 }


### PR DESCRIPTION
https://app.asana.com/0/inbox/544708310157128/1110257233649801/1110933955640367