### PR TITLE
Only run integration test on relevant branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,10 +67,16 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  tests:
     jobs:
+      - integration-sandbox:
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+                - circleci
       - unit-php55-mage18
       - unit-php55-mage19
       - unit-php56-mage18
       - unit-php56-mage19
-      - integration-sandbox


### PR DESCRIPTION
Integration test runs based on the latest content of develop branch. This PR restrict integration test run on develop/master/circleci. (circleci branch is used to test tweaking config change)