### PR TITLE
Allowed custom route for Bolt button.

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -635,7 +635,10 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
 
         $isEnabledProductPageCheckout = $this->boltHelper()->isEnabledProductPageCheckout();
 
-        $isAllowed = ($routeName === 'checkout' && $controllerName === 'cart')
+        $customRoutes = $this->boltHelper()->getAllowedButtonByCustomRoutes();
+        Mage::log(var_export($customRoutes), true, 'bolt.log');
+
+        $isAllowed = (in_array($routeName, $customRoutes) || ($routeName === 'checkout' && $controllerName === 'cart'))
             || ($routeName === 'firecheckout')
             || ($isEnabledProductPageCheckout && $routeName === 'catalog' && $controllerName === 'product')
             || ($routeName === 'adminhtml' && in_array($controllerName, array('sales_order_create', 'sales_order_edit')));

--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -636,7 +636,6 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
         $isEnabledProductPageCheckout = $this->boltHelper()->isEnabledProductPageCheckout();
 
         $customRoutes = $this->boltHelper()->getAllowedButtonByCustomRoutes();
-        Mage::log(var_export($customRoutes), true, 'bolt.log');
 
         $isAllowed = (in_array($routeName, $customRoutes) || ($routeName === 'checkout' && $controllerName === 'cart'))
             || ($routeName === 'firecheckout')

--- a/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
@@ -127,7 +127,8 @@ trait Bolt_Boltpay_Helper_ConfigTrait {
     {
         $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE;
         $config = $this->getPaymentBoltpayConfig('allowed_button_by_custom_routes', $checkoutType);
-        $result = explode(',', $config);
+        // removes all NULL, FALSE and Empty Strings but leaves 0 (zero) values
+        $result = array_filter(explode(',', $config));
 
         return (empty($result)) ? [] : $result;
     }

--- a/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
@@ -128,7 +128,8 @@ trait Bolt_Boltpay_Helper_ConfigTrait {
         $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE;
         $config = $this->getPaymentBoltpayConfig('allowed_button_by_custom_routes', $checkoutType);
         // removes all NULL, FALSE and Empty Strings but leaves 0 (zero) values
-        $result = array_filter(explode(',', $config));
+        $configData = explode(',', $config);
+        $result = array_values(array_filter(array_map('trim', $configData), 'strlen'));
 
         return (empty($result)) ? [] : $result;
     }

--- a/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
@@ -121,6 +121,18 @@ trait Bolt_Boltpay_Helper_ConfigTrait {
     }
 
     /**
+     * @return array
+     */
+    public function getAllowedButtonByCustomRoutes()
+    {
+        $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE;
+        $config = $this->getPaymentBoltpayConfig('allowed_button_by_custom_routes', $checkoutType);
+        $result = explode(',', $config);
+
+        return (empty($result)) ? [] : $result;
+    }
+
+    /**
      * Check if the Bolt payment method can be used for specific country
      *
      * @param string $country   the country to be compared in check for allowing Bolt as a payment method

--- a/app/code/community/Bolt/Boltpay/etc/system.xml
+++ b/app/code/community/Bolt/Boltpay/etc/system.xml
@@ -178,7 +178,7 @@
             </selector_styles>
 
             <allowed_button_by_custom_routes>
-                <label>Allowed Button By Custom Route(s)</label>
+                <label>Show Bolt Button on Pages By Custom Route(s)</label>
                 <frontend_type>text</frontend_type>
                 <comment>Routes are comma delimited. Leave empty if not require additional custom route.</comment>
                 <sort_order>38</sort_order>

--- a/app/code/community/Bolt/Boltpay/etc/system.xml
+++ b/app/code/community/Bolt/Boltpay/etc/system.xml
@@ -177,6 +177,16 @@
               <show_in_store>1</show_in_store>
             </selector_styles>
 
+            <allowed_button_by_custom_routes>
+                <label>Allowed Button By Custom Route(s)</label>
+                <frontend_type>text</frontend_type>
+                <comment>Routes are comma delimited. Leave empty if not require additional custom route.</comment>
+                <sort_order>38</sort_order>
+                <show_in_default>1</show_in_default>
+                <show_in_website>1</show_in_website>
+                <show_in_store>0</show_in_store>
+            </allowed_button_by_custom_routes>
+
             <enable_product_page_checkout>
               <label>[Experimental] Enable Product Page Checkout</label>
               <comment></comment>

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/ConfigTraitTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/ConfigTraitTest.php
@@ -1,0 +1,66 @@
+<?php
+require_once('TestHelper.php');
+
+class Bolt_Boltpay_Helper_ConfigTraitTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Bolt_Boltpay_Helper_ConfigTrait
+     */
+    private $currentMock;
+
+    private $app;
+
+    public function setUp()
+    {
+        $this->app = Mage::app('default');
+        /** @var Mage_Core_Model_Store $appStore */
+        $appStore = $this->app->getStore();
+        $appStore->resetConfig();
+
+        $this->currentMock = $this->getMockForTrait('Bolt_Boltpay_Helper_ConfigTrait',
+            [],
+            '',
+            false,
+            false,
+            false,
+            ['getPaymentBoltpayConfig'],
+            false
+        );
+
+        $appStore->setConfig('payment/boltpay/active', 1);
+    }
+
+    public function testGetAllowedButtonByCustomRoutes_EmptyConfig()
+    {
+        $this->currentMock->expects($this->once())
+            ->method('getPaymentBoltpayConfig')
+            ->with('allowed_button_by_custom_routes', Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE)
+            ->will($this->returnValue(''));
+
+        $this->assertEmpty($this->currentMock->getAllowedButtonByCustomRoutes());
+    }
+
+    public function testGetAllowedButtonByCustomRoutes_WithValuesCommaSeparated()
+    {
+        $this->currentMock->expects($this->once())
+            ->method('getPaymentBoltpayConfig')
+            ->with('allowed_button_by_custom_routes', Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE)
+            ->will($this->returnValue("testroute, test-route, \r, \n, \r\n, 0, a"));
+
+        $result = ['testroute', 'test-route', '0', 'a'];
+
+        $this->assertEquals($result, $this->currentMock->getAllowedButtonByCustomRoutes());
+    }
+
+    public function testGetAllowedButtonByCustomRoutes_WithValuesWithoutComma()
+    {
+        $this->currentMock->expects($this->once())
+            ->method('getPaymentBoltpayConfig')
+            ->with('allowed_button_by_custom_routes', Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE)
+            ->will($this->returnValue('testroute test-route'));
+
+        $result = ['testroute test-route'];
+
+        $this->assertEquals($result, $this->currentMock->getAllowedButtonByCustomRoutes());
+    }
+}


### PR DESCRIPTION
Allowed custom route for Bolt button.
This change allows showing Bolt button if the checkout/cart (or other default pages which we use with Block/Checkout/Bolt.php) page was rewritten.