### PR TITLE
mPR02 - Bolt order creation bugfixes, improved internal docs, naming, and formatting

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -76,11 +76,13 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
      * Generates cart submission data for sending to Bolt order cart field.
      *
      * @param Mage_Sales_Model_Quote        $quote      Magento quote instance
-     * @param bool                          $multipage  Is checkout type Multi-Page Checkout, the default is true, set to false for One Page Checkout
+     * @param bool                          $isMultipage  Is checkout type Multi-Page Checkout, the default is true, set to false for One Page Checkout
      *
      * @return array            The cart data part of the order payload to be sent as to bolt in API call as a PHP array
+     *
+     * @throws Mage_Core_Model_Store_Exception if the store cannot be determined
      */
-    public function buildCart($quote, $multipage)
+    public function buildCart($quote, $isMultipage)
     {
 
         ///////////////////////////////////////////////////////////////////////////////////
@@ -126,13 +128,13 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
             'display_id'      => $quote->getReservedOrderId().'|'.$quote->getId(),
             'items'           => array_map(
                 function ($item) use ($quote, &$calculatedTotal) {
+                    /** @var Mage_Sales_Model_Quote_Item $item */
                     $imageUrl = $this->boltHelper()->getItemImageUrl($item);
                     $product   = Mage::getModel('catalog/product')->load($item->getProductId());
                     $type = $product->getTypeId() == 'virtual' ? self::ITEM_TYPE_DIGITAL : self::ITEM_TYPE_PHYSICAL;
-
                     $calculatedTotal += round($item->getPrice() * 100 * $item->getQty());
                     return array(
-                        'reference'    => $quote->getId(),
+                        'reference'    => $item->getId(),
                         'image_url'    => $imageUrl,
                         'name'         => $item->getName(),
                         'sku'          => $item->getSku(),
@@ -141,7 +143,7 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
                         'unit_price'   => round($item->getCalculationPrice() * 100),
                         'quantity'     => $item->getQty(),
                         'type'         => $type,
-                        'properties' => $this->getItemProperties($item)
+                        'properties'   => $this->getItemProperties($item)
                     );
                 }, $quote->getAllVisibleItems()
             ),
@@ -152,14 +154,14 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
         /////////////////////////////////////////////////////////////////////////
         // Check for discounts and include them in the submission data if found.
         /////////////////////////////////////////////////////////////////////////
-        $this->addDiscounts($totals, $cartSubmissionData);
+        $this->addDiscounts($totals, $cartSubmissionData, $quote);
         $this->dispatchCartDataEvent('bolt_boltpay_discounts_applied_to_bolt_order', $quote, $cartSubmissionData);
         $totalDiscount = isset($cartSubmissionData['discounts']) ? array_sum(array_column($cartSubmissionData['discounts'], 'amount')) : 0;
 
         $calculatedTotal -= $totalDiscount;
         /////////////////////////////////////////////////////////////////////////
 
-        if ($multipage) {
+        if ($isMultipage) {
             /////////////////////////////////////////////////////////////////////////////////////////
             // For multi-page checkout type send only subtotal, do not include shipping and tax info.
             /////////////////////////////////////////////////////////////////////////////////////////
@@ -325,12 +327,20 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
                 // others as negative, which is the Magento default.
                 // Using the absolute value.
                 $discountAmount = (int) abs(round($amount * 100));
-
-                $cartSubmissionData['discounts'][] = array(
+                $data = array(
                     'amount'      => $discountAmount,
                     'description' => $totals[$discount]->getTitle(),
                     'type'        => 'fixed_amount',
                 );
+                if ($discount === 'discount' && $quote->getCouponCode()) {
+                    $coupon = Mage::getModel('salesrule/coupon')->load($quote->getCouponCode(), 'code');
+                    $rule = Mage::getModel('salesrule/rule')->load($coupon->getRuleId());
+
+                    if (strpos($totals[$discount]->getTitle(), $rule->getName()) !== false) {
+                        $data['reference'] = $quote->getCouponCode();
+                    }
+                }
+                $cartSubmissionData['discounts'][] = $data;
                 $totalDiscount += $discountAmount;
             }
         }
@@ -352,7 +362,7 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
 
 
     /**
-     * Adds the calculated shipping tax to the Bolt order
+     * Adds the calculated shipping to the Bolt order
      *
      * @param array                                 $totals             totals array from collectTotals
      * @param array                                 $cartSubmissionData data to be sent to Bolt
@@ -449,7 +459,7 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
         // otherwise, we have no better thing to do than let the Bolt server do the checking
         return $magentoDerivedCartData;
     }
-    
+
 
     /**
      * Checks if billing address of a quote has all the expected fields.
@@ -578,7 +588,7 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
             //////////////////////////////////////////////////
             // In the admin, we first check form session data.
             // For order edits or reorders, the guest customer's email
-            // will be stored in the order 
+            // will be stored in the order
             //////////////////////////////////////////////////
             $shippingAddressData = Mage::getSingleton('admin/session')->getOrderShippingAddress() ?: array( 'email_address' => '', 'email' => '' );
             $customerEmail = $shippingAddressData['email_address'] ?: $shippingAddressData['email'];
@@ -888,6 +898,7 @@ PROMISE;
     {
         $properties = array();
         foreach($this->getProductOptions($item) as $option) {
+            /** @var Mage_Sales_Model_Quote_Item_Option $option */
             $optionValue = $this->getOptionValue($option);
 
             if ($optionValue) {

--- a/app/code/community/Bolt/Boltpay/Model/Coupon.php
+++ b/app/code/community/Bolt/Boltpay/Model/Coupon.php
@@ -149,7 +149,6 @@ class Bolt_Boltpay_Model_Coupon extends Bolt_Boltpay_Model_Abstract
         }
     }
 
-
     /**
      * Verifies the coupon rule exists.
      *
@@ -596,6 +595,7 @@ class Bolt_Boltpay_Model_Coupon extends Bolt_Boltpay_Model_Abstract
             }
 
             $coupon = $this->getCoupon();
+
             // Load the coupon discount rule
             /** @var Mage_SalesRule_Model_Rule $rule */
             $rule = Mage::getModel('salesrule/rule')->load($coupon->getRuleId());

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -124,11 +124,11 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      */
     public function testGetCartURL()
     {
-        $expect = Mage::helper('boltpay')->getMagentoUrl('checkout/cart');
+        $expected = Mage::helper('boltpay')->getMagentoUrl('checkout/cart');
 
         $result = $this->currentMock->getCartUrl();
 
-        $this->assertEquals($expect, $result);
+        $this->assertEquals($expected, $result);
     }
 
     public function testGetSelectorsCSS()
@@ -149,11 +149,11 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
     {
         $url = 'checkout/onepage/success';
         $this->app->getStore()->setConfig('payment/boltpay/successpage', $url);
-        $expect = Mage::helper('boltpay')->getMagentoUrl($url);
+        $expected = Mage::helper('boltpay')->getMagentoUrl($url);
 
         $result = $this->currentMock->getSuccessUrl();
 
-        $this->assertEquals($expect, $result);
+        $this->assertEquals($expected, $result);
     }
 
     /**
@@ -230,10 +230,10 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      */
     public function testGetSaveOrderURL()
     {
-        $expect = Mage::helper('boltpay')->getMagentoUrl('boltpay/order/save');
+        $expected = Mage::helper('boltpay')->getMagentoUrl('boltpay/order/save');
 
         $result = $this->currentMock->getSaveOrderUrl();
 
-        $this->assertEquals($expect, $result);
+        $this->assertEquals($expected, $result);
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/BoltOrderTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/BoltOrderTest.php
@@ -61,14 +61,16 @@ class Bolt_Boltpay_Model_BoltOrderTest extends PHPUnit_Framework_TestCase
 
         $_quote = $cart->getQuote();
         $_quote->reserveOrderId();
-        $_items = $_quote->getAllItems();
-        $_multipage = true;
+        $_items = $_quote->getAllVisibleItems();
+        $_isMultipage = true;
         $item = $_items[0];
         $product = $item->getProduct();
 
         /** @var Bolt_Boltpay_Helper_Data $helper */
         $helper = Mage::helper('boltpay');
         $imageUrl = $helper->getItemImageUrl($item);
+
+        $helper->collectTotals($_quote)->save();
 
         $expected = array (
             'order_reference' => $_quote->getParentQuoteId(),
@@ -77,7 +79,7 @@ class Bolt_Boltpay_Model_BoltOrderTest extends PHPUnit_Framework_TestCase
                 array (
                     0 =>
                         array (
-                            'reference' => $_quote->getId(),
+                            'reference' => $item->getId(),
                             'image_url' => (string) $imageUrl,
                             'name' => $item->getName(),
                             'sku' => $item->getSku(),
@@ -94,7 +96,7 @@ class Bolt_Boltpay_Model_BoltOrderTest extends PHPUnit_Framework_TestCase
             'total_amount' => round($_quote->getSubtotal() * 100),
         );
 
-        $result = $this->currentMock->buildCart($_quote, $_items, $_multipage);
+        $result = $this->currentMock->buildCart($_quote, $_items, $_isMultipage);
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
Bolt order creation is improved by
- bugfix: Uses proper id of cart item which is critical for cart item change inspection
- enhancement: Adding coupon reference to the Bolt order
- adding session/quote context information when adding discounts to the order

Style improved by
- using conventional boolean naming conventions 
- adding better spacing and indentation

Test improved by
- being consistent in using Quote's `getAllVisibleItems` method to generate bolt cart