### PR TITLE
mPR.01 - Distinct Bolt Exceptions with new OrderCreationException class implemented

### DIFF
--- a/app/code/community/Bolt/Boltpay/BoltException.php
+++ b/app/code/community/Bolt/Boltpay/BoltException.php
@@ -15,7 +15,7 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-class Bolt_Boltpay_BadInputException extends Bolt_Boltpay_BoltException
+class Bolt_Boltpay_BoltException extends Exception
 {
-
+    use Bolt_Boltpay_BoltGlobalTrait;
 }

--- a/app/code/community/Bolt/Boltpay/Controller/Interface.php
+++ b/app/code/community/Bolt/Boltpay/Controller/Interface.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Bolt magento plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Interface Bolt_Boltpay_Controller_Interface
+ *
+ * Defines the interface and constants used commonly across all Bolt defined controllers
+ */
+interface Bolt_Boltpay_Controller_Interface {
+
+    /**
+     * HTTP status codes
+     */
+    const HTTP_CONTINUE = 100;
+    const HTTP_SWITCHING_PROTOCOLS = 101;
+    const HTTP_PROCESSING = 102;
+    const HTTP_EARLY_HINTS = 103;
+    const HTTP_OK = 200;
+    const HTTP_CREATED = 201;
+    const HTTP_ACCEPTED = 202;
+    const HTTP_NON_AUTHORITATIVE_INFORMATION = 203;
+    const HTTP_NO_CONTENT = 204;
+    const HTTP_RESET_CONTENT = 205;
+    const HTTP_PARTIAL_CONTENT = 206;
+    const HTTP_MULTI_STATUS = 207;
+    const HTTP_ALREADY_REPORTED = 208;
+    const HTTP_IM_USED = 226;
+    const HTTP_MULTIPLE_CHOICES = 300;
+    const HTTP_MOVED_PERMANENTLY = 301;
+    const HTTP_FOUND = 302;
+    const HTTP_SEE_OTHER = 303;
+    const HTTP_NOT_MODIFIED = 304;
+    const HTTP_USE_PROXY = 305;
+    const HTTP_RESERVED = 306;
+    const HTTP_TEMPORARY_REDIRECT = 307;
+    const HTTP_PERMANENTLY_REDIRECT = 308;
+    const HTTP_BAD_REQUEST = 400;
+    const HTTP_UNAUTHORIZED = 401;
+    const HTTP_PAYMENT_REQUIRED = 402;
+    const HTTP_FORBIDDEN = 403;
+    const HTTP_NOT_FOUND = 404;
+    const HTTP_METHOD_NOT_ALLOWED = 405;
+    const HTTP_NOT_ACCEPTABLE = 406;
+    const HTTP_PROXY_AUTHENTICATION_REQUIRED = 407;
+    const HTTP_REQUEST_TIMEOUT = 408;
+    const HTTP_CONFLICT = 409;
+    const HTTP_GONE = 410;
+    const HTTP_LENGTH_REQUIRED = 411;
+    const HTTP_PRECONDITION_FAILED = 412;
+    const HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
+    const HTTP_REQUEST_URI_TOO_LONG = 414;
+    const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
+    const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+    const HTTP_EXPECTATION_FAILED = 417;
+    const HTTP_I_AM_A_TEAPOT = 418;
+    const HTTP_MISDIRECTED_REQUEST = 421;
+    const HTTP_UNPROCESSABLE_ENTITY = 422;
+    const HTTP_LOCKED = 423;
+    const HTTP_FAILED_DEPENDENCY = 424;
+    const HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL = 425;
+    const HTTP_TOO_EARLY = 425;
+    const HTTP_UPGRADE_REQUIRED = 426;
+    const HTTP_PRECONDITION_REQUIRED = 428;
+    const HTTP_TOO_MANY_REQUESTS = 429;
+    const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+    const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS = 451;
+    const HTTP_INTERNAL_SERVER_ERROR = 500;
+    const HTTP_NOT_IMPLEMENTED = 501;
+    const HTTP_BAD_GATEWAY = 502;
+    const HTTP_SERVICE_UNAVAILABLE = 503;
+    const HTTP_GATEWAY_TIMEOUT = 504;
+    const HTTP_VERSION_NOT_SUPPORTED = 505;
+    const HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL = 506;
+    const HTTP_INSUFFICIENT_STORAGE = 507;
+    const HTTP_LOOP_DETECTED = 508;
+    const HTTP_NOT_EXTENDED = 510;
+    const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;
+}

--- a/app/code/community/Bolt/Boltpay/InvalidTransitionException.php
+++ b/app/code/community/Bolt/Boltpay/InvalidTransitionException.php
@@ -21,7 +21,7 @@
  * This exception is thrown when an attempt is made to change a transactions state through
  * and unsupported workflow.
  */
-class Bolt_Boltpay_InvalidTransitionException extends Exception
+class Bolt_Boltpay_InvalidTransitionException extends Bolt_Boltpay_BoltException
 {
     private $_oldStatus;
     private $_newStatus;

--- a/app/code/community/Bolt/Boltpay/OrderCreationException.php
+++ b/app/code/community/Bolt/Boltpay/OrderCreationException.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Bolt magento plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+use Bolt_Boltpay_Controller_Interface as RESPONSE_CODE;
+
+/**
+ * Class Bolt_Boltpay_OrderCreationException
+ *
+ * This exception is thrown when an error occurs while trying to create a backend order
+ */
+class Bolt_Boltpay_OrderCreationException extends Bolt_Boltpay_BoltException
+{
+
+    /**
+     * Database error or error in incoming request
+     */
+    const E_BOLT_GENERAL_ERROR               = 2001001;
+    const E_BOLT_GENERAL_ERROR_TMPL_HMAC     = '{"reason": "Invalid HMAC header"}';
+    const E_BOLT_GENERAL_ERROR_TMPL_GENERIC  = '{"reason": "%s"}';
+
+    /**
+     * The order already exist in the system
+     */
+    const E_BOLT_ORDER_ALREADY_EXISTS        = 2001002;
+    const E_BOLT_ORDER_ALREADY_EXISTS_TMPL   = '{"display_id": "%s", "order_status": "%s"}';
+
+    /**
+     * General non-item cart changes
+     */
+    const E_BOLT_CART_HAS_EXPIRED                         = 2001003;
+    const E_BOLT_CART_HAS_EXPIRED_TMPL_EMPTY              = '{"reason": "Cart is empty"}';
+    const E_BOLT_CART_HAS_EXPIRED_TMPL_EXPIRED            = '{"reason": "Cart has expired"}';
+    const E_BOLT_CART_HAS_EXPIRED_TMPL_NOT_FOUND          = '{"reason": "Cart does not exist with reference", "reference": "%s"}';
+    const E_BOLT_CART_HAS_EXPIRED_TMPL_NOT_PURCHASABLE    = '{"reason": "The product is not purchasable", "product_id": "%d"}';
+    const E_BOLT_CART_HAS_EXPIRED_TMPL_GRAND_TOTAL        = '{"reason": "Grand total has changed", "old_value": "%d", "new_value": "%d"}';
+    const E_BOLT_CART_HAS_EXPIRED_TMPL_DISCOUNT           = '{"reason": "Discount total has changed", "old_value": "%d", "new_value": "%d"}';
+    const E_BOLT_CART_HAS_EXPIRED_TMPL_TAX                = '{"reason": "Tax amount has changed", "old_value": "%d", "new_value": "%d"}';
+
+    /**
+     * Currently not used -- shipping tax in M1 is used to fix rounding problems and reports the
+     * full cart tax.  Therefore, checking full tax is sufficient
+     */
+    const E_BOLT_CART_HAS_EXPIRED_TMPL_SHIPPING_TAX       = '{"reason": "Shipping tax amount has changed", "old_value": "%d", "new_value": "%d"}';
+
+    /**
+     * Item price changes
+     */
+    const E_BOLT_ITEM_PRICE_HAS_BEEN_UPDATED         = 2001004;
+    const E_BOLT_ITEM_PRICE_HAS_BEEN_UPDATED_TMPL    = '{"product_id": "%d", "old_price": "%d", "new_price": "%d"}';
+
+    /**
+     * Items have become out of stock without back-orders enabled
+     */
+    const E_BOLT_OUT_OF_INVENTORY         = 2001005;
+    const E_BOLT_OUT_OF_INVENTORY_TMPL    = '{"product_id": "%d", "available_quantity": %d, "needed_quantity": %d}';
+
+    /**
+     * Error applying discount to the cart
+     */
+    const E_BOLT_DISCOUNT_CANNOT_APPLY                 = 2001006;
+    const E_BOLT_DISCOUNT_CANNOT_APPLY_TMPL_EXPIRED    = '{"reason": "This coupon has expired", "discount_code": "%s"}';
+    const E_BOLT_DISCOUNT_CANNOT_APPLY_TMPL_GENERIC    = '{"reason": "%s", "discount_code": "%s"}';
+
+    /**
+     * Invalid discount code used
+     */
+    const E_BOLT_DISCOUNT_DOES_NOT_EXIST        = 2001007;
+    const E_BOLT_DISCOUNT_DOES_NOT_EXIST_TMPL   = '{"discount_code": "%s"}';
+
+    /**
+     * Change in shipping price
+     */
+    const E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED           = 2001008;
+    const E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED_TMPL      = '{"reason": "Shipping total has changed", "old_value": "%d", "new_value": "%d"}';
+
+    /**
+     * @var int http response code that is to be returned
+     */
+    protected $httpCode;
+
+    /**
+     * @var string The json to be returned to Bolt associated with this exception
+     */
+    protected $json;
+
+    /**
+     * @var array All possible error codes supported by Bolt
+     */
+    protected static $validCodes = array(
+        self::E_BOLT_GENERAL_ERROR,
+        self::E_BOLT_ORDER_ALREADY_EXISTS,
+        self::E_BOLT_CART_HAS_EXPIRED,
+        self::E_BOLT_ITEM_PRICE_HAS_BEEN_UPDATED,
+        self::E_BOLT_OUT_OF_INVENTORY,
+        self::E_BOLT_DISCOUNT_CANNOT_APPLY,
+        self::E_BOLT_DISCOUNT_DOES_NOT_EXIST,
+        self::E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED
+    );
+
+    /**
+     * Bolt_Boltpay_OrderCreationException constructor.
+     *
+     * @param int    $code          The Bolt defined error code
+     * @param string $dataTemplate  specific Bolt error sub-category
+     * @param array  $dataValues    An array of values to be added to the data template
+     * @param string $message       The exception message to throw.
+     * @param Throwable|null $previous  [optional] The previously throwable used for exception chaining.
+     */
+    public function __construct($code = self::E_BOLT_GENERAL_ERROR, $dataTemplate = self::E_BOLT_GENERAL_ERROR_TMPL_GENERIC, array $dataValues = array(), $message = null, Throwable $previous = null)
+    {
+        // If code is invalid, we will use the generic message
+        if (!in_array($code, self::$validCodes)) {
+            $code = self::E_BOLT_GENERAL_ERROR;
+            $dataTemplate = self::E_BOLT_GENERAL_ERROR_TMPL_GENERIC;
+            $dataValues = array($message);
+        }
+
+        foreach( $dataValues as $index => $value ) {
+            $dataValues[$index] = addcslashes($dataValues[$index], '"\\');
+        }
+
+        $this->httpCode = $this->selectHttpCode($code, $dataTemplate);
+        $this->json = $this->createJson($code, $dataTemplate, $dataValues);
+
+        if (empty($message)) {
+            $message = $this->getJson();
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Finds the httpCode based on the error parameters
+     *
+     * @param int    $code         Bolt error code
+     * @param string $dataTemplate specific Bolt error sub-category
+     *
+     * @return int The HTTP code that was found which matches the provided error info
+     */
+    public function selectHttpCode( $code, $dataTemplate ) {
+        // Select the http code
+        switch ($code) {
+            case self::E_BOLT_GENERAL_ERROR:
+                if ($dataTemplate === self::E_BOLT_GENERAL_ERROR_TMPL_HMAC) {
+                    return RESPONSE_CODE::HTTP_UNAUTHORIZED; // 401
+                }
+            case self::E_BOLT_ORDER_ALREADY_EXISTS:
+                return RESPONSE_CODE::HTTP_CONFLICT; // 409
+            case self::E_BOLT_CART_HAS_EXPIRED:
+                switch ($dataTemplate) {
+                    case self::E_BOLT_CART_HAS_EXPIRED_TMPL_NOT_FOUND:
+                        return RESPONSE_CODE::HTTP_NOT_FOUND; // 404
+                    case self::E_BOLT_CART_HAS_EXPIRED_TMPL_EMPTY:
+                    case self::E_BOLT_CART_HAS_EXPIRED_TMPL_EXPIRED:
+                        return RESPONSE_CODE::HTTP_GONE;  // 410
+                }
+            default:
+                return RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY; // 422
+        }
+    }
+
+    /**
+     * Creates the JSON to be returned to the Bolt server
+     *
+     * @param int    $code         Bolt error code
+     * @param string $dataTemplate specific Bolt error sub-category
+     * @param array  $dataValues   An array of values to be added to the data template
+     *
+     * @return string  The JSON that was created as part of this call
+     */
+    private function createJson( $code, $dataTemplate, array $dataValues = array() )
+    {
+        array_unshift($dataValues, $dataTemplate);
+        $dataJson = call_user_func_array(array($this->boltHelper(), '__'), $dataValues);
+        return <<<JSON
+        {
+            "status": "failure",
+            "error": [{
+                "code": $code,
+                "data": [$dataJson]
+            }]
+        }
+JSON;
+    }
+
+    /**
+     * The request body to be returned for this error
+     *
+     * @return string   well-formatted JSON that conforms to the Bolt error code standard
+     */
+    public function getJson() {
+        return $this->json;
+    }
+
+    /**
+     * Returns the HTTP response code
+     *
+     * @return int HTTP response code defined by error type
+     */
+    public function getHttpCode() {
+        return $this->httpCode;
+    }
+}

--- a/app/code/community/Bolt/Boltpay/OrderCreationException.php
+++ b/app/code/community/Bolt/Boltpay/OrderCreationException.php
@@ -154,10 +154,6 @@ class Bolt_Boltpay_OrderCreationException extends Bolt_Boltpay_BoltException
     public function selectHttpCode( $code, $dataTemplate ) {
         // Select the http code
         switch ($code) {
-            case self::E_BOLT_GENERAL_ERROR:
-                if ($dataTemplate === self::E_BOLT_GENERAL_ERROR_TMPL_HMAC) {
-                    return RESPONSE_CODE::HTTP_UNAUTHORIZED; // 401
-                }
             case self::E_BOLT_ORDER_ALREADY_EXISTS:
                 return RESPONSE_CODE::HTTP_CONFLICT; // 409
             case self::E_BOLT_CART_HAS_EXPIRED:
@@ -167,6 +163,10 @@ class Bolt_Boltpay_OrderCreationException extends Bolt_Boltpay_BoltException
                     case self::E_BOLT_CART_HAS_EXPIRED_TMPL_EMPTY:
                     case self::E_BOLT_CART_HAS_EXPIRED_TMPL_EXPIRED:
                         return RESPONSE_CODE::HTTP_GONE;  // 410
+                }
+            case self::E_BOLT_GENERAL_ERROR:
+                if ($dataTemplate === self::E_BOLT_GENERAL_ERROR_TMPL_HMAC) {
+                    return RESPONSE_CODE::HTTP_UNAUTHORIZED; // 401
                 }
             default:
                 return RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY; // 422

--- a/app/code/community/Bolt/Boltpay/controllers/Adminhtml/Sales/Order/CreateController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/Adminhtml/Sales/Order/CreateController.php
@@ -25,7 +25,8 @@ require_once(Mage::getModuleDir('controllers','Bolt_Boltpay').DS.'OrderControlle
  * @package    Mage_Adminhtml
  * @author      Magento Core Team <core@magentocommerce.com>
  */
-class Bolt_Boltpay_Adminhtml_Sales_Order_CreateController extends Mage_Adminhtml_Sales_Order_CreateController
+class Bolt_Boltpay_Adminhtml_Sales_Order_CreateController
+    extends Mage_Adminhtml_Sales_Order_CreateController implements Bolt_Boltpay_Controller_Interface
 {
     use Bolt_Boltpay_OrderControllerTrait;
 

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -20,7 +20,7 @@
  *
  * Webhook endpoint.
  */
-class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action
+class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action implements Bolt_Boltpay_Controller_Interface
 {
     use Bolt_Boltpay_BoltGlobalTrait;
 

--- a/app/code/community/Bolt/Boltpay/controllers/ConfigurationController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ConfigurationController.php
@@ -20,7 +20,8 @@
  *
  * Check Configuration for Bolt
  */
-class Bolt_Boltpay_ConfigurationController extends Mage_Core_Controller_Front_Action
+class Bolt_Boltpay_ConfigurationController
+    extends Mage_Core_Controller_Front_Action implements Bolt_Boltpay_Controller_Interface
 {
     use Bolt_Boltpay_BoltGlobalTrait;
 

--- a/app/code/community/Bolt/Boltpay/controllers/IndexController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/IndexController.php
@@ -20,7 +20,7 @@
  *
  * @deprecated OAuth will be removed in future versions
  */
-class Bolt_Boltpay_IndexController extends Mage_Adminhtml_Controller_Action
+class Bolt_Boltpay_IndexController extends Mage_Adminhtml_Controller_Action implements Bolt_Boltpay_Controller_Interface
 {
     use Bolt_Boltpay_BoltGlobalTrait;
 

--- a/app/code/community/Bolt/Boltpay/controllers/OnepageController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OnepageController.php
@@ -22,7 +22,8 @@ require_once 'Mage/Checkout/controllers/OnepageController.php';
  *
  * @deprecated This will be removed after the skip payment option is resolved.
  */
-class Bolt_Boltpay_OnepageController extends Mage_Checkout_OnepageController
+class Bolt_Boltpay_OnepageController
+    extends Mage_Checkout_OnepageController implements Bolt_Boltpay_Controller_Interface
 {
     use Bolt_Boltpay_BoltGlobalTrait;
 

--- a/app/code/community/Bolt/Boltpay/controllers/OrderController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/OrderController.php
@@ -22,7 +22,8 @@ require_once(Mage::getModuleDir('controllers','Bolt_Boltpay').DS.'OrderControlle
  *
  * Saves the order in Magento system after successful Bolt transaction processing.
  */
-class Bolt_Boltpay_OrderController extends Mage_Core_Controller_Front_Action
+class Bolt_Boltpay_OrderController
+    extends Mage_Core_Controller_Front_Action implements Bolt_Boltpay_Controller_Interface
 {
     use Bolt_Boltpay_OrderControllerTrait;
 

--- a/app/code/community/Bolt/Boltpay/controllers/ProductpageController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ProductpageController.php
@@ -18,7 +18,8 @@
 /**
  * Class Bolt_Boltpay_ProductpageController
  */
-class Bolt_Boltpay_ProductpageController extends Mage_Core_Controller_Front_Action
+class Bolt_Boltpay_ProductpageController
+    extends Mage_Core_Controller_Front_Action implements Bolt_Boltpay_Controller_Interface
 {
     use Bolt_Boltpay_BoltGlobalTrait;
 

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -20,7 +20,8 @@
  *
  * Shipping And Tax endpoint.
  */
-class Bolt_Boltpay_ShippingController extends Mage_Core_Controller_Front_Action
+class Bolt_Boltpay_ShippingController
+    extends Mage_Core_Controller_Front_Action implements Bolt_Boltpay_Controller_Interface
 {
     use Bolt_Boltpay_BoltGlobalTrait;
 

--- a/tests/unit/testsuite/Bolt/Boltpay/OrderCreationExceptionTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/OrderCreationExceptionTest.php
@@ -7,7 +7,6 @@ use Bolt_Boltpay_Controller_Interface as RESPONSE_CODE;
  */
 class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
 {
-
     /**
      * Test JSON response for general error with default parameters
      */
@@ -30,7 +29,7 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR, $exception->error[0]->code);
         $this->assertEquals($reason, $exception->error[0]->data[0]->reason);
 
-        $this->assertEquals(RESPONSE_CODE::HTTP_CONFLICT, $boltOrderCreationException->getHttpCode());
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
     }
 
     /**
@@ -327,7 +326,48 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($reason, $exception->error[0]->data[0]->reason);
         $this->assertEquals($previousException, $boltOrderCreationException->getPrevious());
         $this->assertEquals('This is previous error', $boltOrderCreationException->getPrevious()->getMessage());
-        $this->assertEquals(RESPONSE_CODE::HTTP_CONFLICT, $boltOrderCreationException->getHttpCode());
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test if special characters are escaped in JSON response
+     */
+    public function testEscapeSpecialCharacters()
+    {
+        $reason = 'test "error" \path\example';
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR_TMPL_GENERIC,
+            [$reason]
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals($reason, $exception->error[0]->data[0]->reason);
+
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * If non-registered code is passed to a constructor it should generate generic exception
+     */
+    public function testNonRegisteredErrorCode()
+    {
+        $reason = 'test non-existing code';
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            12345,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR_TMPL_GENERIC,
+            [$reason],
+            $reason
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals($reason, $exception->error[0]->data[0]->reason);
+
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
     }
 
     /**
@@ -336,7 +376,7 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     public function testGeneralExceptionHttpCode()
     {
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException();
-        $this->assertEquals(RESPONSE_CODE::HTTP_CONFLICT, $boltOrderCreationException->getHttpCode());
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
     }
 
     /**

--- a/tests/unit/testsuite/Bolt/Boltpay/OrderCreationExceptionTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/OrderCreationExceptionTest.php
@@ -1,0 +1,367 @@
+<?php
+
+use Bolt_Boltpay_Controller_Interface as RESPONSE_CODE;
+
+/**
+ * Class Bolt_Boltpay_OrderCreationExceptionTest
+ */
+class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test JSON response for general error with default parameters
+     */
+    public function testGeneralExceptionJson()
+    {
+        $reason = 'test error';
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR_TMPL_GENERIC,
+            [$reason]
+        );
+
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertNotEmpty($exception->status);
+        $this->assertExceptionProperties($exception);
+        $this->assertNotEmpty($exception->error[0]->data[0]->reason);
+
+        $this->assertEquals(Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR, $exception->error[0]->code);
+        $this->assertEquals($reason, $exception->error[0]->data[0]->reason);
+
+        $this->assertEquals(RESPONSE_CODE::HTTP_CONFLICT, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test for correct data for existing order exception
+     */
+    public function testExistingCartExceptionJson()
+    {
+        $dataValues = ['id_123', 'pending'];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_ORDER_ALREADY_EXISTS,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_ORDER_ALREADY_EXISTS_TMPL,
+            $dataValues);
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->display_id);
+        $this->assertEquals($dataValues[1], $exception->error[0]->data[0]->order_status);
+
+        $this->assertEquals(RESPONSE_CODE::HTTP_CONFLICT, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test for correct data for various cart exceptions
+     */
+    public function testCartExceptionJson()
+    {
+        // Empty cart
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_EMPTY
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('Cart is empty', $exception->error[0]->data[0]->reason);
+        $this->assertEquals(RESPONSE_CODE::HTTP_GONE, $boltOrderCreationException->getHttpCode());
+
+        // Expired cart
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_EXPIRED
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('Cart has expired', $exception->error[0]->data[0]->reason);
+        $this->assertEquals(RESPONSE_CODE::HTTP_GONE, $boltOrderCreationException->getHttpCode());
+
+        // Cart does not exist
+        $dataValues = ['cart_reference_001'];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_NOT_FOUND,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('Cart does not exist with reference', $exception->error[0]->data[0]->reason);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->reference);
+        $this->assertEquals(RESPONSE_CODE::HTTP_NOT_FOUND, $boltOrderCreationException->getHttpCode());
+
+        // Cart is not purchasable
+        $dataValues = [905];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_NOT_PURCHASABLE,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('The product is not purchasable', $exception->error[0]->data[0]->reason);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->product_id);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+
+        // Cart grand total has changed
+        $dataValues = [100, 150];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_GRAND_TOTAL,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('Grand total has changed', $exception->error[0]->data[0]->reason);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->old_value);
+        $this->assertEquals($dataValues[1], $exception->error[0]->data[0]->new_value);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+
+        // Cart discount total has changed
+        $dataValues = [100, 150];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_DISCOUNT,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('Discount total has changed', $exception->error[0]->data[0]->reason);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->old_value);
+        $this->assertEquals($dataValues[1], $exception->error[0]->data[0]->new_value);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+
+        // Chart tax has changed
+        $dataValues = [100, 150];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_TAX,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('Tax amount has changed', $exception->error[0]->data[0]->reason);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->old_value);
+        $this->assertEquals($dataValues[1], $exception->error[0]->data[0]->new_value);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test for correct data for cart items exception
+     */
+    public function testItemPriceException()
+    {
+        $dataValues = [905, 100, 150];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_ITEM_PRICE_HAS_BEEN_UPDATED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_ITEM_PRICE_HAS_BEEN_UPDATED_TMPL,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->product_id);
+        $this->assertEquals($dataValues[1], $exception->error[0]->data[0]->old_price);
+        $this->assertEquals($dataValues[2], $exception->error[0]->data[0]->new_price);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test for correct data for cart inventory exception
+     */
+    public function testCartInventoryException()
+    {
+        $dataValues = [905, 100, 150];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_OUT_OF_INVENTORY,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_OUT_OF_INVENTORY_TMPL,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->product_id);
+        $this->assertEquals($dataValues[1], $exception->error[0]->data[0]->available_quantity);
+        $this->assertEquals($dataValues[2], $exception->error[0]->data[0]->needed_quantity);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test for correct exception data when discount can not be applied
+     */
+    public function testDiscountCanNotBeAppliedException()
+    {
+        // Generic exception
+        $dataValues = ['Discount code too cool to be used', 'FREE_BEER_FOR_LIFE'];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_DISCOUNT_CANNOT_APPLY,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_DISCOUNT_CANNOT_APPLY_TMPL_GENERIC,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->reason);
+        $this->assertEquals($dataValues[1], $exception->error[0]->data[0]->discount_code);
+
+        // Discount code expired exception
+        $dataValues = ['FREE_BEER_FOR_1_SEC'];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_DISCOUNT_CANNOT_APPLY,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_DISCOUNT_CANNOT_APPLY_TMPL_EXPIRED,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('This coupon has expired', $exception->error[0]->data[0]->reason);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->discount_code);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test for correct exception data when discount code is invalid
+     */
+    public function testInvalidDiscountCodeException()
+    {
+        $dataValues = ['GIVE_ME_FREE'];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_DISCOUNT_DOES_NOT_EXIST,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_DISCOUNT_DOES_NOT_EXIST_TMPL,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->discount_code);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test for correct exception when shipping price or tax are changed
+     */
+    public function testShippingPriceOrTaxChangedException()
+    {
+        $dataValues = [100, 150];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED_TMPL,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('Shipping total has changed', $exception->error[0]->data[0]->reason);
+        $this->assertEquals($dataValues[0], $exception->error[0]->data[0]->old_value);
+        $this->assertEquals($dataValues[1], $exception->error[0]->data[0]->new_value);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * In case when we pass string data instead of expected numbers, values in the response will be set to zero
+     */
+    public function testIncorrectDataJson()
+    {
+        $dataValues = ['hundred', 'hundred and fifty'];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED_TMPL,
+            $dataValues
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception);
+        $this->assertEquals('Shipping total has changed', $exception->error[0]->data[0]->reason);
+        $this->assertNotEquals($dataValues[0], $exception->error[0]->data[0]->old_value);
+        $this->assertNotEquals($dataValues[1], $exception->error[0]->data[0]->new_value);
+        $this->assertEquals(0, $exception->error[0]->data[0]->old_value);
+        $this->assertEquals(0, $exception->error[0]->data[0]->new_value);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Test if OrderCreationException is keeping a reference to previous error
+     */
+    public function testExceptionWithPreviousException()
+    {
+        $reason = 'test with previous error';
+        $previousException = new Exception('This is previous error');
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR_TMPL_GENERIC,
+            [$reason],
+            $reason,
+            $previousException
+        );
+
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertNotEmpty($exception->status);
+        $this->assertExceptionProperties($exception);
+        $this->assertNotEmpty($exception->error[0]->data[0]->reason);
+
+        $this->assertEquals(Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR, $exception->error[0]->code);
+        $this->assertEquals($reason, $exception->error[0]->data[0]->reason);
+        $this->assertEquals($previousException, $boltOrderCreationException->getPrevious());
+        $this->assertEquals('This is previous error', $boltOrderCreationException->getPrevious()->getMessage());
+        $this->assertEquals(RESPONSE_CODE::HTTP_CONFLICT, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Testing HTTP response code for general exception with default parameters
+     */
+    public function testGeneralExceptionHttpCode()
+    {
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException();
+        $this->assertEquals(RESPONSE_CODE::HTTP_CONFLICT, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Testing HTTP response code for general exception with default parameters
+     */
+    public function testExistingCartExceptionHttpCode()
+    {
+        $dataValues = ['id_123', 'pending'];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_ORDER_ALREADY_EXISTS,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_ORDER_ALREADY_EXISTS_TMPL,
+            $dataValues);
+        $this->assertEquals(RESPONSE_CODE::HTTP_CONFLICT, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * Helper function for asserting that all required params exist in the exception instance
+     *
+     * @param Throwable $exception The exception instance we are testing
+     */
+    private function assertExceptionProperties($exception)
+    {
+        $this->assertNotEmpty($exception->error);
+        $this->assertNotEmpty($exception->error[0]->code);
+        $this->assertNotEmpty($exception->error[0]->data);
+        $this->assertEquals('failure', $exception->status);
+    }
+}


### PR DESCRIPTION
Previous PR closed due to mixing with full code: https://github.com/BoltApp/bolt-magento1/pull/359
https://app.asana.com/0/544708310157130/1121158206133098

In version 2.0, we improve our error design by designating all Bolt generated exceptions as `Bolt_Boltpay_BoltException`'s (_BoltException_) which allows us to distinguish between Bolt expected exceptions and all other types.

A _BoltException_ will have access to all helper methods as provided the global Bolt trait that is now ubiquitous among all Bolt classes.  The global helper greatly improves IDE code hinting for development.

Finally, we introduce the `Bolt_Boltpay_OrderCreationException` (_OrderCreationException_) which closely adheres to the specification defined here:
https://docs.google.com/document/d/1L5DzKak94_QVS-4VR0u4atXk4M4SvXe_krcZDZiC9rg/edit

Deviations are noted in the comments, and the exceptions have been extended for fuller coverage.  Additionally, the new shipping change code has been implemented. 

 Error messages are i18n ready.