### PR TITLE
mPR.04 - On collect totals with clear totals true, cached shipping items must be removed to fully clear price

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
@@ -70,6 +70,9 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
 
         if($clearTotalsCollectedFlag) {
             $quote->setTotalsCollectedFlag(false);
+            $quote->getShippingAddress()->unsetData('cached_items_all');
+            $quote->getShippingAddress()->unsetData('cached_items_nominal');
+            $quote->getShippingAddress()->unsetData('cached_items_nonnominal');
         }
 
         $quote->collectTotals();


### PR DESCRIPTION
This is a subtle bugfix for fully clearing totals when required.
Details: 
https://stackoverflow.com/questions/5671787/unset-shipping-and-recalculate-totals-in-magento