### PR TITLE
mPR.06 - Include coupon in shipping and tax estimate 

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/ShippingAndTax.php
+++ b/app/code/community/Bolt/Boltpay/Model/ShippingAndTax.php
@@ -61,7 +61,7 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Bolt_Boltpay_Model_Abstract
             . (@$shippingAddress->street_address3 ?: '') . "\n"
             . (@$shippingAddress->street_address4 ?: '')
         );
-            
+
         $addressData = array(
             'email' => @$shippingAddress->email ?: $shippingAddress->email_address,
             'firstname' => @$shippingAddress->first_name,
@@ -138,10 +138,9 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Bolt_Boltpay_Model_Abstract
         );
 
         try {
-            $this->boltHelper()->collectTotals(Mage::getModel('sales/quote')->load($quote->getId()));
             $originalCouponCode = $quote->getCouponCode();
-
             if ($parentQuote) $quote->setCouponCode($parentQuote->getCouponCode());
+            $this->boltHelper()->collectTotals(Mage::getModel('sales/quote')->load($quote->getId()), true);
 
             //we should first determine if the cart is virtual
             if($quote->isVirtual()){
@@ -179,6 +178,7 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Bolt_Boltpay_Model_Abstract
                     continue;
                 }
 
+                if ($parentQuote) $quote->setCouponCode($parentQuote->getCouponCode());
                 $this->applyShippingRate($quote, $rate->getCode());
 
                 $rateCode = $rate->getCode();
@@ -203,6 +203,7 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Bolt_Boltpay_Model_Abstract
 
                 $response['shipping_options'][] = $option;
             }
+
         } finally {
             $quote->setCouponCode($originalCouponCode);
         }
@@ -217,6 +218,7 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Bolt_Boltpay_Model_Abstract
      * @param string $shippingRateCode         Shipping rate code composed of {carrier}_{method}
      */
     public function applyShippingRate($quote, $shippingRateCode) {
+
         $shippingAddress = $quote->getShippingAddress();
 
         if (!empty($shippingAddress)) {

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -59,7 +59,7 @@ class Bolt_Boltpay_ShippingController
     public function indexAction()
     {
         try {
-          
+
             set_time_limit(30);
             ignore_user_abort(true);
 
@@ -117,7 +117,6 @@ class Bolt_Boltpay_ShippingController
             }
             ////////////////////////////////////////////////////////////////////////////////
 
-
             ////////////////////////////////////////////////////////////////////////////////////////
             // Check session cache for estimate.  If the shipping city or postcode, and the country code match,
             // then use the cached version.  Otherwise, we have to do another calculation
@@ -169,7 +168,6 @@ class Bolt_Boltpay_ShippingController
      */
     public function prefetchEstimateAction()
     {
-
         set_time_limit(30);
         ignore_user_abort(true);
 
@@ -266,7 +264,7 @@ class Bolt_Boltpay_ShippingController
         if(!empty($addressData['country_id'])){
             /** @var Mage_Directory_Model_Country $countryObj */
             $countryObj = Mage::getModel('directory/country')->loadByCode($addressData['country_id']);
-    
+
             if (!$countryObj->getRegionCollection()->getSize()) {
                 // If country does not have region options for dropdown.
                 $addressData['region'] = $addressData['region_name'];
@@ -277,7 +275,7 @@ class Bolt_Boltpay_ShippingController
                     $addressData['region'] = $regionModel->getName();
                     $addressData['region_id'] = $regionModel->getId();
                 }
-            }    
+            }
         }
         return $addressData;
     }
@@ -365,7 +363,7 @@ class Bolt_Boltpay_ShippingController
     private function isApplePayRequest() {
         $requestData = json_decode($this->_requestJSON);
         $shippingAddress = $requestData->shipping_address;
-        
+
         // For a more strict check, we would enable verifying the phone number is null
         return ($shippingAddress->name === 'n/a') /* && is_null($shippingAddress->phone) */;
     }


### PR DESCRIPTION
Correctly add coupon in shipping calculations and events at all key shipping and tax moments to remove the need to override Bolt core methods