### PR TITLE
Re-renders button in mini-cart after it is ajax reloaded

### DIFF
--- a/app/design/frontend/base/default/template/boltpay/replace.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace.phtml
@@ -167,6 +167,12 @@ $additionalClasses = $this->boltHelper()->getAdditionalButtonClasses();
 
         replaceCheckout();
 
+        if (typeof Minicart != "undefined") {
+            Minicart.prototype.hideOverlay = function(){
+                onDomReady();
+                $j(this.selectors.overlay).removeClass('loading');
+            };
+        }
     };
 
     if (document.addEventListener) {

--- a/app/design/frontend/base/default/template/boltpay/replace.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace.phtml
@@ -33,7 +33,7 @@ $additionalClasses = $this->boltHelper()->getAdditionalButtonClasses();
 ?>
 <script>
 
-    var onDomReady = function(){
+    var initBoltButtons = function(){
 
         /****************************************************************************************************
          * Finds and replaces specified buttons with Bolt checkout buttons. Runs internal function
@@ -168,19 +168,26 @@ $additionalClasses = $this->boltHelper()->getAdditionalButtonClasses();
         replaceCheckout();
 
         if (typeof Minicart != "undefined") {
+            /*************************************************************
+             * Minicart HTML is regenerated via ajax after document load.
+             * On each ajax call, and overlay is added and then removed
+             * after the rendering of the new HTML is complete.  At this
+             * point we want to re-render the Bolt buttons, which will
+             * have been removed in the regeneration
+             *************************************************************/
             Minicart.prototype.hideOverlay = function(){
-                onDomReady();
+                initBoltButtons();
                 $j(this.selectors.overlay).removeClass('loading');
             };
         }
     };
 
     if (document.addEventListener) {
-        document.addEventListener("DOMContentLoaded", onDomReady);
+        document.addEventListener("DOMContentLoaded", initBoltButtons);
     } else if (window.attachEvent) {
-        window.attachEvent("onload", onDomReady);
+        window.attachEvent("onload", initBoltButtons);
     } else {
-        window.onload = onDomReady;
+        window.onload = initBoltButtons;
     }
 
 </script>


### PR DESCRIPTION
Context:
Bolt button disappears from mini cart when quantity is updated (desktop and mobile)

https://app.asana.com/0/inbox/544708310157128/1122886631659761/1123291135314664