### PR TITLE
mPR.10 - Restricts changing preauth status to only Bolt webhooks

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Observer.php
+++ b/app/code/community/Bolt/Boltpay/Model/Observer.php
@@ -272,4 +272,18 @@ class Bolt_Boltpay_Model_Observer
             ->setTransactionId($transaction->id)
             ->save();
     }
+
+    /**
+     * Prevents Magento from changing the Bolt preauth statuses
+     *
+     * event: sales_order_save_before
+     *
+     * @param Varien_Event_Observer $observer Observer event contains an order object
+     */
+    public function safeguardPreAuthStatus($observer) {
+        $order = $observer->getEvent()->getOrder();
+        if (!Bolt_Boltpay_Helper_Data::$fromHooks && in_array($order->getOrigData('status'), array('pending_bolt','canceled_bolt')) ) {
+            $order->setStatus($order->getOrigData('status'));
+        }
+    }
 }

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -126,6 +126,15 @@
           </set_initial_order_status_and_details>
         </observers>
       </sales_order_place_after>
+      <sales_order_save_before>
+        <observers>
+          <bolt_boltpay_safeguard_preauth_status>
+            <type>singleton</type>
+            <class>Bolt_Boltpay_Model_Observer</class>
+            <method>safeguardPreAuthStatus</method>
+          </bolt_boltpay_safeguard_preauth_status>
+        </observers>
+      </sales_order_save_before>
     </events>
 
     <sales>


### PR DESCRIPTION
Many plugins change the status of orders.  We do not want to allow this for Bolt pre-auth orders statuses so we restrict changes from that state to only Bolt webhooks.

https://app.asana.com/0/1118494470563243/1123688922955292