### PR TITLE
mPR.11 - Pre-auth order canceling

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Observer.php
+++ b/app/code/community/Bolt/Boltpay/Model/Observer.php
@@ -121,6 +121,24 @@ class Bolt_Boltpay_Model_Observer
         $cartHelper->getCart()->truncate()->save();
     }
 
+    /**
+     * If the session quote has been flagged by having a parent quote Id equal to its own
+     * id, this will clear the cart cache, which, in turn, forces the creation of a new Bolt order
+     *
+     * event: controller_front_init_before
+     *
+     * @param Varien_Event_Observer $observer event contains front (Mage_Core_Controller_Varien_Front)
+     */
+    public function clearCartCacheOnOrderCanceled($observer) {
+        /** @var Mage_Sales_Model_Quote $quote */
+        $quote = Mage::getSingleton('checkout/session')->getQuote();
+        if ($quote && is_int($quote->getId()) && $quote->getId() === $quote->getParentQuoteId()) {
+            Mage::getSingleton('core/session')->unsCachedCartData();
+            // clear the parent quote ID to re-enable cart cache
+            $quote->setParentQuoteId(null);
+        }
+    }
+
     public function sendCompleteAuthorizeRequest($request)
     {
         return $this->boltHelper()->transmit('complete_authorize', $request);

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -384,6 +384,36 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
         return $rateDebuggingData;
     }
 
+    /**
+     * Removes a bolt order from the system.  The order is expected to be a Bolt order
+     *
+     * @param Mage_Sales_Model_Order $order
+     *
+     * @throws Mage_Core_Exception if the order cannot be canceled
+     */
+    public function removePreAuthOrder($order) {
+        if ($this->isBoltOrder($order)) {
+            if ($order->getStatus() !== 'canceled_bolt') {
+                $order->cancel()->setQuoteId(null)->setStatus('canceled_bolt')->save();
+            }
+            $previousStoreId = Mage::app()->getStore()->getId();
+            Mage::app()->setCurrentStore(Mage_Core_Model_App::ADMIN_STORE_ID);
+            $order->delete();
+            Mage::app()->setCurrentStore($previousStoreId);
+        }
+    }
+
+    /**
+     * Determines whether a given order is owned by Bolt
+     *
+     * @param Mage_Sales_Model_Order    $order  the magento order to be inspected
+     *
+     * @return bool true if the payment method for this order is currently set to Bolt, otherwise false
+     */
+    public function isBoltOrder($order) {
+        return (strtolower($order->getPayment()->getMethod()) === Bolt_Boltpay_Model_Payment::METHOD_CODE);
+    }
+
     protected function validateSubmittedOrder($order, $quote) {
         if(empty($order)) {
             $this->boltHelper()->addBreadcrumb(

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -222,6 +222,17 @@
         </boltpay>
       </updates>
     </layout>
+    <events>
+        <controller_front_init_before>
+            <observers>
+                <bolt_boltpay_check_if_order_canceled>
+                    <type>singleton</type>
+                    <class>Bolt_Boltpay_Model_Observer</class>
+                    <method>clearCartCacheOnOrderCanceled</method>
+                </bolt_boltpay_check_if_order_canceled>
+            </observers>
+        </controller_front_init_before>
+    </events>
   </frontend>
 
   <default>


### PR DESCRIPTION
When Bolt cancels a pre-auth pending order, we must 
1.) Release all resources like inventory.  This is done via cancel
2.) Remove the order.  This is done via delete
3.) expire the cache to trigger new Bolt order creation, otherwise the expired token will continue to be used by the Magento plugin.  This handles the expiration.

https://app.asana.com/0/1118494470563243/1123688922955296