### PR TITLE
Ignore apple pay prefill

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -347,7 +347,11 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
             $hints['virtual_terminal_mode'] = true;
         }
 
-        $hints['prefill'] = $prefill;
+        // Skip pre-fill for Apple Pay related data.
+        if (!($prefill['email'] == 'fake@email.com' || $prefill['phone'] == '1111111111')) {
+            $hints['prefill'] = $prefill;
+        }
+
         return $hints;
     }
 


### PR DESCRIPTION
https://app.asana.com/0/941895179897714/1121581354248363/f

Quick fix to ignore dummy data the Apple Pay prefills. This occurs when someone clicks on Apple Pay, then cancels out of the apple pay order and uses Bolt Checkout. Many users just keep the dummy data there. Example attached below.

![Screen Shot 2019-05-28 at 11 33 31 AM](https://user-images.githubusercontent.com/45575491/58491139-7441c900-813c-11e9-9d11-56f4d1a50a3d.png)
