### PR TITLE
Fixes error generated when Apple Pay prefill values are not defined

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -348,7 +348,7 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
         }
 
         // Skip pre-fill for Apple Pay related data.
-        if (!($prefill['email'] == 'fake@email.com' || $prefill['phone'] == '1111111111')) {
+        if (!(@$prefill['email'] == 'fake@email.com' || @$prefill['phone'] == '1111111111')) {
             $hints['prefill'] = $prefill;
         }
 


### PR DESCRIPTION
Current code will generate errors in strict environments.   We suppress notices for undefined array indexes to address the problem.