### PR TITLE
optimization for pending hooks to succeed on first call

### DIFF
--- a/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
+++ b/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
@@ -100,9 +100,16 @@ trait Bolt_Boltpay_Controller_Traits_WebHookTrait {
     protected function sendResponse($httpCode, $data = array())
     {
         ob_end_clean();
+        $content = is_string($data) ? $data : json_encode($data);
+        $length = strlen($content);
+
         $this->getResponse()
             ->setHttpResponseCode($httpCode)
-            ->setBody(is_string($data) ? $data : json_encode($data));
+            ->setHeader('Content-Length', $length, true)
+            ->setBody($content)
+            ->sendResponse();
+
+        while (ob_get_level()) { ob_end_clean(); }
     }
 
     /**

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -617,15 +617,15 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
     /**
      * Called after pre-auth order is confirmed as authorized on Bolt.
      *
-     * @param string $orderIncrementId  customer facing order id
-     * @param object $payload           payload sent from Bolt
+     * @param Mage_Sales_Model_Order|string $order      the order or the customer facing order id
+     * @param object|string                 $payload    payload sent from Bolt
      *
      * @throws Mage_Core_Exception if there is a problem retrieving the bolt transaction reference from the payload
      */
-    public function receiveOrder( $orderIncrementId, $payload ) {
+    public function receiveOrder( $order, $payload ) {
         /** @var Mage_Sales_Model_Order $order */
-        $order = Mage::getModel('sales/order')->loadByIncrementId($orderIncrementId);
-        $payloadObject = json_decode($payload);
+        $order = is_object($order) ? $order : Mage::getModel('sales/order')->loadByIncrementId($order);
+        $payloadObject = is_object($payload) ? $payload : json_decode($payload);
         $immutableQuote = $this->getQuoteFromOrder($order);
 
         Mage::dispatchEvent('bolt_boltpay_order_received_before', array('order'=>$order, 'payload' => $payloadObject));

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -41,12 +41,13 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
             $reference = $requestData->reference;
             $transactionId = @$requestData->transaction_id ?: $requestData->id;
             $hookType = @$requestData->notification_type ?: $requestData->type;
-            $parentQuoteId = @$requestData->quote_id;
+            $incrementId = @$requestData->display_id;
 
             /** @var Bolt_Boltpay_Model_Order $orderModel */
             $orderModel = Mage::getModel('boltpay/order');
 
             if ($hookType === 'failed_payment') {
+                $parentQuoteId = $requestData->quote_id;
                 $this->handleFailedPaymentHook($parentQuoteId);
                 return;
             } else if ($hookType === 'discounts.code.apply') {
@@ -54,14 +55,13 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
                 return;
             }
 
-            $transaction = $this->boltHelper()->fetchTransaction($reference);
-            $quoteId = $this->boltHelper()->getImmutableQuoteIdFromTransaction($transaction);
-
             /* If display_id has been confirmed and updated on Bolt, then we should look up the order by display_id */
-            $order = Mage::getModel('sales/order')->loadByIncrementId($transaction->order->cart->display_id);
+            $order = Mage::getModel('sales/order')->loadByIncrementId($incrementId);
 
             /* If it hasn't been confirmed, or could not be found, we use the quoteId as fallback */
             if ($order->isObjectNew()) {
+                $transaction = $this->boltHelper()->fetchTransaction($reference);
+                $quoteId = $this->boltHelper()->getImmutableQuoteIdFromTransaction($transaction);
                 $order =  $orderModel->getOrderByQuoteId($quoteId);
             }
 
@@ -70,6 +70,10 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
                 // Order was found.  We will update it
                 ///////////////////////////////////////
 
+                if (empty($transaction) && $hookType !== 'pending') {
+                    $transaction = $this->boltHelper()->fetchTransaction($reference);
+                }
+
                 $orderPayment = $order->getPayment();
                 if (!$orderPayment->getAdditionalInformation('bolt_reference')) {
                     /////////////////////////////////////////////////////////////////////////////
@@ -77,7 +81,7 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
                     /// session.  We'll complete the post authorization steps prior to processing
                     /// the webhook.
                     /////////////////////////////////////////////////////////////////////////////
-                    $orderModel->receiveOrder($order->getIncrementId(), $this->payload);
+                    $orderModel->receiveOrder($order, $this->payload);
                     /////////////////////////////////////////////////////////////////////////////
                 }
 


### PR DESCRIPTION
https://app.asana.com/0/544708310157130/1119041817660804

Fetching the bolt transaction for pending hooks is not necessary and was causing the initial pending hook after a pre-auth order to always timeout.

This optimizes the pending hook by using the available display_id provided in the hook to look up the order, eliminating the need to do a fetch.  In this way, the hook now completes on time.