### PR TITLE
Add m1 codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically request reviews from M1 code-owners
+* @matt-thomason @mccottry @johnmccombs1


### PR DESCRIPTION
Adding `CODEOWNERS` file to automatically request reviews.
https://github.blog/2017-07-06-introducing-code-owners/