### PR TITLE
Restore our long-standing default behavior of allowing a 1 cent price difference

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
@@ -263,7 +263,7 @@ JS;
     }
 
     /**
-     * Defines the default value as a 0 cent tolerance for Bolt and Magento grand total
+     * Defines the default value as a 1 cent tolerance for Bolt and Magento grand total
      * difference
      *
      * @param int|string $rawConfigValue    The config value pre-filter. Will be an int or an empty string
@@ -272,7 +272,7 @@ JS;
      * @return int  the number defined in the extra config admin.  If not defined, the default of 1
      */
     public function filterPriceFaultTolerance($rawConfigValue, $additionalParams = array() ) {
-        return is_int($rawConfigValue) ? $rawConfigValue : 0;
+        return is_int($rawConfigValue) ? $rawConfigValue : 1;
     }
 
     /**


### PR DESCRIPTION
For many, many releases in 1.x and possibly 0.x we have always allowed for a price-mismatch of 1 cent due to rounding errors in discount and tax because Bolt requires these prices to be separated while Magento collectively rounds and in some cases, has a slightly different algorithm for displaying values like discount in quote estimations than what it produces in quote to order conversion.  

Complete description is at https://app.asana.com/0/544708310157130/1127097389119930