### PR TITLE
Allows for custom success URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ If you would like to pull the latest Bolt code from the Git repo and update Mage
 | Name | Area | Description | Parameters | Filtered Value | 
 | --- | --- | --- | --- | --- |
 | bolt_boltpay_filter_shipping_label | global | Allows changing of individual shipping labels that are displayed in Bolt | **rate**<br>_Mage_Sales_Model_Quote_Address_Rate_<br>The information for this calculated rate, including method, carrier, and price | **string**<br>The label to be displayed in the Bolt order |
+| bolt_boltpay_filter_success_url | global | Provides means for custom success order urls | **order**<br>_Mage_Sales_Model_Order_<br>The order to be authorized<br><br>**quoteId**<br>_int_<br>The quote id of the order which maps to the Bolt order reference | **string**<br>The url that the BoltCheckout modal will forward the customer to on successful order authorization |

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -219,7 +219,18 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
                 }
             }
 
-            $orderSuccessUrl = $this->createSuccessUrl($order, $immutableQuoteId);
+            /////////////////////////////////
+            // create success order URL
+            /////////////////////////////////
+            $orderSuccessUrl = $this->boltHelper()->doFilterEvent(
+                'bolt_boltpay_filter_success_url',
+                $this->createSuccessUrl($order, $immutableQuoteId),
+                [
+                    'order' => $order,
+                    'quote_id' => $immutableQuoteId
+                ]
+            );
+            /////////////////////////////////
 
             $this->sendResponse(
                 200,


### PR DESCRIPTION
There will be cases where merchants override all _/checkout/onepage_ url paths which include the _/checkout/onepage/success_ url used for preauth.

In order to provide a means of not overriding the entire Onepage controller method for this point or any reason, we provide a means to write a custom url via filter.  As an example, in the case described above, we will want to replace _/**checkout**/onepage/success_ with _/**boltpay**/onepage/success_

https://app.asana.com/0/544708310157130/1127609963001801