### PR TITLE
Get path for route condition.

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -42,7 +42,7 @@ class Bolt_Boltpay_ShippingController
     {
         $this->_cache = Mage::app()->getCache();
         $this->_shippingAndTaxModel = Mage::getModel("boltpay/shippingAndTax");
-        if ($this->getRequest()->getRequestUri() === '/boltpay/shipping/prefetchEstimate/' ) {
+        if ($this->getRequest()->getPathInfo() === '/boltpay/shipping/prefetchEstimate/' ) {
             $this->requestMustBeSigned = false;
         }
     }


### PR DESCRIPTION
For case when requestMustBeSigned = false.

The root cause of error is in Magento's store code in url.
Usually it looks like (for ajax) http://example.com/en/boltpay/shipping/prefetchEstimate/

Magento's setting(choose `Default Config` in scope view): `System > Configuration > General > Web > Add Store Code to Urls` set to Yes.

Previously in code we get data from request through `getRequestUri()`, current method get data like `/en/boltpay/shipping/prefetchEstimate/`. Instead of  `getRequestUri` i put method `getPathInfo()` which returns `/boltpay/shipping/prefetchEstimate/`
