### PR TITLE
Uses native Magento method for determining if order email has been sent

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -694,10 +694,8 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
     public function sendOrderEmail($order)
     {
         try {
-            $mustSendEmail = !$order->getPayment()->getAdditionalInformation("orderEmailWasSent");
-            if ($mustSendEmail) {
+            if (!$order->getEmailSent()) {
                 $order->queueNewOrderEmail();
-                $order->getPayment()->setAdditionalInformation("orderEmailWasSent", "true")->save();
                 $history = $order->addStatusHistoryComment( $this->boltHelper()->__('Email sent for order %s', $order->getIncrementId()) );
                 $history->setIsCustomerNotified(true);
             }

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
@@ -55,7 +55,6 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
             ->willReturn($history);
 
         $this->assertNull($history->getIsCustomerNotified());
-        $this->assertNull($orderPayment->getAdditionalInformation("orderEmailWasSent"));
 
         try {
             $orderModel->sendOrderEmail($order);
@@ -64,7 +63,6 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertTrue($history->getIsCustomerNotified());
-        $this->assertEquals('true', $orderPayment->getAdditionalInformation("orderEmailWasSent"));
     }
 
     /**


### PR DESCRIPTION
Using the native email sent methodology is preferred as it will be detected if a third party plugin sets this, whereas our existing method will not.

https://app.asana.com/0/544708310157130/1128043171296216