### PR TITLE
Provides support for discount price changes at the time of shipping and tax estimations

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -338,15 +338,24 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
                     /// We want to get the apply the coupon code as a reference.
                     /// Potentially, we will have several 'discount' entries
                     /// but only one coupon code, so we must find the right entry
-                    /// to map to.  Magento stores the coupon rule description in
-                    /// the totals object wrapped in the string "Discount()" and
-                    /// keeps no reference to the rule or coupon code. Here, we use
-                    /// the coupon code to look up the rule description and compare
-                    /// it to the total object's title.
+                    /// to map to.  Magento stores the records rule description or
+                    /// the coupon code when the rule description is empty in
+                    /// the totals object wrapped in the string "Discount()", and
+                    /// keeps no separate reference to the rule or coupon code.
+                    /// Here, we use the coupon code to look up the rule description
+                    /// and compare it and the coupon code to the total object's title.
                     /////////////////////////////////////////////////////////////
                     $coupon = Mage::getModel('salesrule/coupon')->load($quote->getCouponCode(), 'code');
                     $rule = Mage::getModel('salesrule/rule')->load($coupon->getRuleId());
-                    if ($totals[$discount]->getTitle() === Mage::helper('sales')->__('Discount (%s)', (string)$rule->getName()) ) {
+                    if (
+                        in_array(
+                            $totals[$discount]->getTitle(),
+                            [
+                                Mage::helper('sales')->__('Discount (%s)', (string)$rule->getName()),
+                                Mage::helper('sales')->__('Discount (%s)', (string)$quote->getCouponCode())
+                            ]
+                        )
+                    ) {
                         $data['reference'] = $quote->getCouponCode();
                     }
                 }

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -134,7 +134,7 @@ class Bolt_Boltpay_ShippingController
             } else {
                 //Mage::log('Generating address from quote', null, 'shipping_and_tax.log');
                 //Mage::log('Live address: '.var_export($address_data, true), null, 'shipping_and_tax.log');
-                $estimate = $this->_shippingAndTaxModel->getShippingAndTaxEstimate($quote);
+                $estimate = $this->_shippingAndTaxModel->getShippingAndTaxEstimate($quote, $requestData);
                 $this->cacheShippingAndTaxEstimate($estimate, $cachedIdentifier);
                 $cacheBoltHeader = 'MISS';
             }

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/ShippingAndTaxTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/ShippingAndTaxTest.php
@@ -267,13 +267,14 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
         $cart = $this->testHelper->addProduct(self::$productId, 2);
         $quote = $cart->getQuote();
 
-        $originalDiscountedSubtotal = 100;
+        $originalDiscountTotal = 0;
 
         $quote->getShippingAddress()->setShippingAmount(50);
+        $quote->setSubtotal(100);
         $quote->setSubtotalWithDiscount(100);
 
         $expected = 50;
-        $result = $this->currentMock->getAdjustedShippingAmount($originalDiscountedSubtotal, $quote);
+        $result = $this->currentMock->getAdjustedShippingAmount($originalDiscountTotal, $quote);
 
         $this->assertEquals($expected, $result);
     }
@@ -289,13 +290,14 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
         $cart = $this->testHelper->addProduct(self::$productId, 2);
         $quote = $cart->getQuote();
 
-        $originalDiscountedSubtotal = 100;
+        $originalDiscountTotal = 0;
 
         $quote->getShippingAddress()->setShippingAmount(50);
+        $quote->setSubtotal(100);
         $quote->setSubtotalWithDiscount(75); // Discount on shipping: subtotal - shipping_amount * 50% = $75
 
         $expected = 25;
-        $result = $this->currentMock->getAdjustedShippingAmount($originalDiscountedSubtotal, $quote);
+        $result = $this->currentMock->getAdjustedShippingAmount($originalDiscountTotal, $quote);
 
         $this->assertEquals($expected, $result);
     }
@@ -311,13 +313,14 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
         $cart = $this->testHelper->addProduct(self::$productId, 2);
         $quote = $cart->getQuote();
 
-        $originalDiscountedSubtotal = 50;
+        $originalDiscountTotal = 50;
 
         $quote->getShippingAddress()->setShippingAmount(50);
+        $quote->setSubtotal(100);
         $quote->setSubtotalWithDiscount(50); // Discount on quote: subtotal * 50% = $50
 
         $expected = 50;
-        $result = $this->currentMock->getAdjustedShippingAmount($originalDiscountedSubtotal, $quote);
+        $result = $this->currentMock->getAdjustedShippingAmount($originalDiscountTotal, $quote);
 
         $this->assertEquals($expected, $result);
     }
@@ -333,13 +336,14 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
         $cart = $this->testHelper->addProduct(self::$productId, 2);
         $quote = $cart->getQuote();
 
-        $originalDiscountedSubtotal = 50; // Discount on cart: 50%
+        $originalDiscountTotal = 0; // Discount on cart: 50%
 
         $quote->getShippingAddress()->setShippingAmount(50);
-        $quote->setSubtotalWithDiscount(25); // Discount on shipping: subtotal * 50% - shipping_amount * 50% = $25
+        $quote->setSubtotal(100);
+        $quote->setSubtotalWithDiscount(75); // Discount on shipping: subtotal * 50% - shipping_amount * 50% = $25
 
         $expected = 25;
-        $result = $this->currentMock->getAdjustedShippingAmount($originalDiscountedSubtotal, $quote);
+        $result = $this->currentMock->getAdjustedShippingAmount($originalDiscountTotal, $quote);
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
Problem:
If the discount is changed after shipping and tax, for instance, if the Magento Admin is set to include tax as part of a percentage based discount, then pre-auth validation fails and the recorded Bolt totals will be incorrect.  Currently, this will block an order from being able to be processed.

Proposed Solution:
We have always utilized shipping tax in order to get the correct amount for total tax for similar reasons.  Now, we utilize the shipping cost estimate to include the price discount difference and disable subtotal validation in pre-auth.  We have bottom-line price validation that will catch any errors while we are able to preserve recording the proper tax amount.

This is an unblocker for M1 and core team decides on if and how to expand the shipping and tax endpoint to shipping, tax, and discount.

https://app.asana.com/0/941895179897704/1128289474493189