### PR TITLE
Datadog - Fix the OrderCreationException to resolve Datadog severity conflict

### DIFF
--- a/lib/Boltpay/DataDog/Client.php
+++ b/lib/Boltpay/DataDog/Client.php
@@ -52,7 +52,7 @@ class DataDog_Client
             $data = DataDog_Request::getRequestMetaData();
         }
 
-        $data['message'] = $message;
+        $data['message'] = addcslashes($message, '{}"');
         $data['status'] = $type;
         $data['service'] = $this->getData('service');
         $data['merchant_platform'] = $this->getData('platform-version');


### PR DESCRIPTION
Issue:
When the Bolt_Boltpay_OrderCreationException exception is thrown, the generated message has a status key in it. Datadog detects that it is an emergency and disregards the error severity passed in.

Proposed solution:
Generate a message instead of getting the JSON response as the error message for class Bolt_Boltpay_OrderCreationException

Code reference:
Bolt_Boltpay_OrderCreationException: https://github.com/BoltApp/bolt-magento1/blob/develop/app/code/community/Bolt/Boltpay/OrderCreationException.php#L163DataDog_Client: https://github.com/BoltApp/bolt-magento1/blob/develop/lib/Boltpay/DataDog/Client.php#L56

Asana task: https://app.asana.com/0/564264490825835/1128573212731792