### PR TITLE
Correct incomplete and improper saving of addresses during shipping and tax

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -124,7 +124,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 
                 /** @var Bolt_Boltpay_Model_ShippingAndTax $shippingAndTaxModel */
                 $shippingAndTaxModel = Mage::getModel("boltpay/shippingAndTax");
-                $shippingAndTaxModel->applyShippingAddressToQuote($immutableQuote, $packagesToShip[0]->shipping_address);
+                $shippingAndTaxModel->applyBoltAddressData($immutableQuote, $packagesToShip[0]->shipping_address);
                 $shippingMethodCode = $packagesToShip[0]->reference;
 
                 if (!$shippingMethodCode) {

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -100,7 +100,7 @@ class Bolt_Boltpay_ShippingController
                 $addressErrorDetails = array('code' => 6101, 'message' => $msg);
                 $this->boltHelper()->logWarning($msg);
             } else {
-                $addressData = $this->_shippingAndTaxModel->applyShippingAddressToQuote($quote, $shippingAddress);
+                $addressData = $this->_shippingAndTaxModel->applyBoltAddressData($quote, $shippingAddress);
 
                 if ($this->shouldDoAddressValidation()) {
                     $magentoAddressErrors = $quote->getShippingAddress()->validate();

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/ShippingAndTaxTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/ShippingAndTaxTest.php
@@ -75,7 +75,7 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
             'company' => 'Bolt',
             'region' => 'California'
         );
-        $result = $this->currentMock->applyShippingAddressToQuote($quote, $shippingAddress);
+        $result = $this->currentMock->applyBoltAddressData($quote, $shippingAddress);
 
         $expected = array(
             'email' => 'test@bolt.com',
@@ -115,7 +115,7 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
             'company' => 'Bolt',
             'region' => 'California'
         );
-        $result = $this->currentMock->applyShippingAddressToQuote($quote, $shippingAddress);
+        $result = $this->currentMock->applyBoltAddressData($quote, $shippingAddress);
 
         $expected = array(
             'email' => 'test@bolt.com',
@@ -145,7 +145,7 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
             'country_code' => 'US',
             'region' => 'California'
         );
-        $result = $this->currentMock->applyShippingAddressToQuote($quote, $shippingAddress);
+        $result = $this->currentMock->applyBoltAddressData($quote, $shippingAddress);
 
         $expected = array(
             'email' => 'test@bolt.com',
@@ -183,7 +183,7 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
             'company' => 'Bolt',
             'region' => 'California'
         );
-        $result = $this->currentMock->applyShippingAddressToQuote($quote, $shippingAddress);
+        $result = $this->currentMock->applyBoltAddressData($quote, $shippingAddress);
 
         $expected = array(
             'email' => 'test@bolt.com',
@@ -222,7 +222,7 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
             'company' => 'Bolt',
             'region' => 'CA'
         );
-        $result = $this->currentMock->applyShippingAddressToQuote($quote, $shippingAddress);
+        $result = $this->currentMock->applyBoltAddressData($quote, $shippingAddress);
 
         $expected = array(
             'email' => 'test@bolt.com',
@@ -247,7 +247,7 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
             'email' => 'test@bolt.com'
         );
         try {
-            $this->currentMock->applyShippingAddressToQuote($quote, $shippingAddress);
+            $this->currentMock->applyBoltAddressData($quote, $shippingAddress);
         } catch (Exception $e) {
             $this->assertEquals('Address must contain postal_code and country_code.', $e->getMessage());
             return;


### PR DESCRIPTION
Context:
Plugins potentially may expect or validate against the address data once it is saved.  Such an expectation was causing a problem at a merchant site for new customers that did not have default values already saved for shipping and billing addresses.

Fix:
This adds the full address info to a customer address prior to trying to saving it, which also cuts down on unnecessary double saves to the database.  Additionally, this sets a default billing address if none already exist. 

https://app.asana.com/0/941895179897714/1129037493381871