### PR TITLE
Added data-was-replaced attribute for replaced button

### DIFF
--- a/app/design/frontend/base/default/template/boltpay/replace.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace.phtml
@@ -83,13 +83,13 @@ $additionalClasses = $this->boltHelper()->getAdditionalButtonClasses();
                                 /**
                                  * Escape double replace buttons
                                 **/
-                                var bolt = element.getAttribute("bolt");
-                                if (bolt != "replaced") {
+                                var wasReplaced = element.getAttribute("data-was-replaced");
+                                if (wasReplaced !== "true") {
                                     element.style.display = "none";
                                     /**
                                      * Mark button as replaced
                                      **/
-                                    element.setAttribute("bolt", "replaced");
+                                    element.setAttribute("data-was-replaced", "true");
                                     var bolt_button =  document.createElement("div");
                                     bolt_button.setAttribute("class",selectors[selector]);
     

--- a/app/design/frontend/base/default/template/boltpay/replace.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace.phtml
@@ -80,21 +80,29 @@ $additionalClasses = $this->boltHelper()->getAdditionalButtonClasses();
 
                                 var element = elements[i];
                                 found_elements = true;
-
-                                element.style.display = "none";
-
-                                var bolt_button =  document.createElement("div");
-                                bolt_button.setAttribute("class",selectors[selector]);
-
-                                <?php $buttonColor = $this->boltHelper()->getBoltPrimaryColor();?>
-                                <?php if($buttonColor):?>
-                                    bolt_button.setAttribute("style", "--bolt-primary-action-color:<?php echo $buttonColor?>");
-                                <?php endif; ?>
-
-                                element.parentNode.insertBefore(bolt_button, element);
-
-                                if (element.parentNode.style.display === "") {
-                                    element.parentNode.style.display = "block";
+                                /**
+                                 * Escape double replace buttons
+                                **/
+                                var bolt = element.getAttribute("bolt");
+                                if (bolt != "replaced") {
+                                    element.style.display = "none";
+                                    /**
+                                     * Mark button as replaced
+                                     **/
+                                    element.setAttribute("bolt", "replaced");
+                                    var bolt_button =  document.createElement("div");
+                                    bolt_button.setAttribute("class",selectors[selector]);
+    
+                                    <?php $buttonColor = $this->boltHelper()->getBoltPrimaryColor();?>
+                                    <?php if($buttonColor):?>
+                                        bolt_button.setAttribute("style", "--bolt-primary-action-color:<?php echo $buttonColor?>");
+                                    <?php endif; ?>
+    
+                                    element.parentNode.insertBefore(bolt_button, element);
+    
+                                    if (element.parentNode.style.display === "") {
+                                        element.parentNode.style.display = "block";
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Asana task: https://app.asana.com/0/899238157173033/1116476869617025/f
This changes prevent double change buttons to Bolt button.
I added attribute, because we could not use style.display attribute of the element because of responsive design