### PR TITLE
Enables the preauth order timestamp switch option that was mistakenly forgetten

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -273,7 +273,9 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
         ///////////////////////////////////////////////////////
 
         // We set the created_at and updated_at date to null to hide the order from ERP until authorized
-        $this->removeOrderTimeStamps($order);
+        if (!$this->boltHelper()->getExtraConfig('keepPreAuthOrderTimeStamps')) {
+            $this->removeOrderTimeStamps($order);
+        }
 
         if ($immutableQuote->getData('is_bolt_pdp') && Mage::getSingleton('customer/session')->isLoggedIn()) {
             $this->associateOrderToCustomerWhenPlacingOnPDP($order->getData('increment_id'));


### PR DESCRIPTION
This places the logic that was intended to be put in place for this config.

https://github.com/BoltApp/bolt-magento1/blob/develop/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php#L290-L300

It enables logic to retain timestamps on preauth orders so that orders will appear in the normal flow of the Magento admin for merchants who wish to see these orders.