### PR TITLE
Cancels orders via Magento to rollback inventory holds

### DIFF
--- a/tests/unit/testsuite/Bolt/Boltpay/ProductProvider.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/ProductProvider.php
@@ -102,12 +102,35 @@ class Bolt_Boltpay_ProductProvider
         /** @var Magento_Db_Adapter_Pdo_Mysql $writeConnection */
         $writeConnection = $resource->getConnection('core_write');
         $table = $resource->getTableName('catalog/product');
-        
+
         $query = "DELETE FROM ".$table." WHERE entity_id = :productId";
         $bind = array(
             'productId' => (int) $productId
         );
 
         $writeConnection->query($query, $bind);
+    }
+
+    /**
+     * Get store product with it's stock quantity
+     *
+     * @param int $productId Store product ID (catalog_product_entity::entity_id)
+     *
+     * @return Mage_Catalog_Model_Resource_Product
+     */
+    public static function getStoreProductWithQty($productId)
+    {
+        $storeProducts = Mage::getModel('catalog/product')
+            ->getCollection()
+            ->addAttributeToFilter('entity_id', $productId)
+            ->joinField(
+                'qty',
+                'cataloginventory/stock_item',
+                'qty',
+                'product_id=entity_id',
+                '{{table}}.stock_id=1',
+                'left'
+            );
+        return $storeProducts->getFirstItem();
     }
 }


### PR DESCRIPTION
# Description
Orders rejected by Bolt with the inventory having never returned to the system. This addresses the issue

Fixes: https://app.asana.com/0/1125081140214268/1130067876286030

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
