### PR TITLE
Lookup order by increment id after order has been created

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -201,11 +201,21 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
     public function create_orderAction() {
         try {
             $transaction = $this->getRequestData();
-            $immutableQuoteId = $this->boltHelper()->getImmutableQuoteIdFromTransaction($transaction);
+            $displayId = $transaction->order->cart->display_id;
 
-            /** @var  Bolt_Boltpay_Model_Order $orderModel */
-            $orderModel = Mage::getModel('boltpay/order');
-            $order = $orderModel->getOrderByQuoteId($immutableQuoteId);
+            if (strpos($displayId, '|') !== false) {
+                /* This is when the order has not already been created, nor order success URL sent to Bolt */
+
+                $immutableQuoteId = $this->boltHelper()->getImmutableQuoteIdFromTransaction($transaction);
+
+                /** @var  Bolt_Boltpay_Model_Order $orderModel */
+                $orderModel = Mage::getModel('boltpay/order');
+                $order = $orderModel->getOrderByQuoteId($immutableQuoteId);
+            } else {
+                /* @var Mage_Sales_Model_Order $order */
+                $order = Mage::getModel('sales/order')->loadByIncrementId($displayId);
+                $immutableQuoteId = $order->getQuoteId();
+            }
 
             if ($order->isObjectNew()) {
                 /** @var Mage_Sales_Model_Order $order */


### PR DESCRIPTION
In the case of failed payment, (or something similar to what was previously called and orphaned transaction), the order potentially will be created and display_id updated at Bolt.  If this is the case, the order is already at the merchant site and needs to be looked up by increment id, which will now be the display ID.

https://app.asana.com/0/544708310157130/1130793273664830