### PR TITLE
Override Magento core by trait to allow for extension by referencing in custom code

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Traits/ValidatorTrait.php
+++ b/app/code/community/Bolt/Boltpay/Model/Traits/ValidatorTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Bolt magento plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2018 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Trait Bolt_Boltpay_Model_ValidatorTrait
+ *
+ * Extends the native Magento Validator functionality in a way that allows for clean, multiple inheritance
+ *
+ */
+trait Bolt_Boltpay_Model_Traits_ValidatorTrait {
+    use Bolt_Boltpay_BoltGlobalTrait;
+
+    /**
+     * Method for resetting rounding delta. Rounding deltas cause percentage discounts applied to an order to often get
+     * off by $0.01 rounding errors because the validator used is a singleton. So every time collectTotals is called
+     * it reuses the previous rounding deltas and causes rounding problems. Since Mage_SalesRule_Model_Validator doesn't
+     * provide a method for resetting these before calling collectTotals, we created one.
+     */
+    public function resetRoundingDeltas()
+    {
+        $this->_roundingDeltas = array();
+    }
+}

--- a/app/code/community/Bolt/Boltpay/Model/Validator.php
+++ b/app/code/community/Bolt/Boltpay/Model/Validator.php
@@ -17,17 +17,5 @@
 
 class Bolt_Boltpay_Model_Validator extends Mage_SalesRule_Model_Validator
 {
-    use Bolt_Boltpay_BoltGlobalTrait;
-    
-    /**
-     * Method for resetting rounding delta. Rounding deltas cause percentage discounts applied to an order to often get
-     * off by $0.01 rounding errors because the validator used is a singleton. So every time collectTotals is called
-     * it reuses the previous rounding deltas and causes rounding problems. Since Mage_SalesRule_Model_Validator doesn't
-     * provide a method for resetting these before calling collectTotals, we created one.
-     */
-    public function resetRoundingDeltas()
-    {
-       $this->_roundingDeltas = array();
-    }
-
+    use Bolt_Boltpay_Model_Traits_ValidatorTrait;
 }


### PR DESCRIPTION
If extending of the Magento core is required, it is best to do it via trait to allow for multiple inheritance in the case where a 3rd-party module overrides the same class.  This prevents the need to redefine the entire methods of the Bolt class making it possible for simple upgrades.

https://app.asana.com/0/544708310157130/1131312115509169

Must fix autoloader for unit test to work