### PR TITLE
Adds filter event for Bolt order data

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you would like to pull the latest Bolt code from the Git repo and update Mage
 
 | Name | Area | Description | Parameters | Filtered Value | 
 | --- | --- | --- | --- | --- |
+| bolt_boltpay_filter_bolt_order | global | Filters Bolt order data before sending it to the Bolt server | **quote**<br>_Mage_Sales_Model_Quote_<br>the Magento cart copy of the Bolt order<br><br>**isMultiPage**<br>_boolean_<br>true if the order is from the standard multistore context, otherwise false | **array**<br>The PHP formatted order data that is to be sent to Bolt |
 | bolt_boltpay_filter_shipping_label | global | Allows changing of individual shipping labels that are displayed in Bolt | **rate**<br>_Mage_Sales_Model_Quote_Address_Rate_<br>The information for this calculated rate, including method, carrier, and price | **string**<br>The label to be displayed in the Bolt order |
 | bolt_boltpay_filter_success_url | global | Provides means for custom success order urls | **order**<br>_Mage_Sales_Model_Order_<br>The order to be authorized<br><br>**quoteId**<br>_int_<br>The quote id of the order which maps to the Bolt order reference | **string**<br>The url that the BoltCheckout modal will forward the customer to on successful order authorization |
 

--- a/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
@@ -162,13 +162,27 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
     /**
      * Dispatches event to filter a value
      *
-     * @param string                    $eventName              The name of the event to be dispatched
-     * @param mixed                     $valueToFilter          The value to filter
-     * @param mixed                     $additionalParameters   any extra parameters used in filtering
+     * @param string   $eventName              The name of the event to be dispatched
+     * @param mixed    $valueToFilter          The value to filter
+     * @param mixed    $additionalParameters   any extra parameter or array of parameters used in filtering
      *
      * @return mixed   the value after it has been filtered
      */
     public function doFilterEvent($eventName, $valueToFilter, $additionalParameters = array()) {
+        return $this->dispatchFilterEvent($eventName, $valueToFilter, $additionalParameters);
+    }
+
+    /**
+     * Memory conservative version of {@see Bolt_Boltpay_Helper_GeneralTrait::doFilterEvent()}
+     * Use this instead if cases of passing large arrays or large string values
+     *
+     * @param string   $eventName              The name of the event to be dispatched
+     * @param mixed    $valueToFilter          The value to filter
+     * @param mixed    $additionalParameters   any extra parameter or array of parameters used in filtering
+     *
+     * @return mixed   the value after it has been filtered
+     */
+    public function dispatchFilterEvent($eventName, &$valueToFilter, $additionalParameters = array()) {
         $valueWrapper = new Varien_Object();
         $valueWrapper->setValue($valueToFilter);
         Mage::dispatchEvent(
@@ -181,5 +195,4 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
 
         return $valueWrapper->getValue();
     }
-
 }

--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -61,15 +61,20 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
      * Generates order data for sending to Bolt.
      *
      * @param Mage_Sales_Model_Quote        $quote      Magento quote instance
-     * @param bool                          $multipage  Is checkout type Multi-Page Checkout, the default is true, set to false for One Page Checkout
+     * @param bool                          $isMultiPage  Is checkout type Multi-Page Checkout, the default is true, set to false for One Page Checkout
      *
      * @return array            The order payload to be sent as to bolt in API call as a PHP array
+     *
+     * @throws Mage_Core_Model_Store_Exception if the store cannot be determined
      */
-    public function buildOrder($quote, $multipage)
+    public function buildOrder($quote, $isMultiPage)
     {
-        $cart = $this->buildCart($quote, $multipage);
-        return array(
-            'cart' => $cart
+        $cart = $this->buildCart($quote, $isMultiPage);
+        $boltOrder = ['cart' => $cart];
+        return $this->boltHelper()->dispatchFilterEvent(
+            "bolt_boltpay_filter_bolt_order",
+            $boltOrder,
+            ['quote' => $quote, 'isMultiPage' => $isMultiPage]
         );
     }
 


### PR DESCRIPTION
Adds a filter event for Bolt Order data prior to it being completed and sent to the Bolt server.  This allows for additions of attributes and info derived from third party extensions which are currently ignored by our plugin.  One concrete example is third party user notes added prior to Bolt order creation time.

https://app.asana.com/0/941895179897714/1131668256595077