### PR TITLE
Add filter if discount applies to shipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you would like to pull the latest Bolt code from the Git repo and update Mage
 
 | Name | Area | Description | Parameters | Filtered Value | 
 | --- | --- | --- | --- | --- |
+| bolt_boltpay_filter_discount_amount | global | Allows changing of individual discount amount that is displayed in Bolt | **quote**<br>_Mage_Sales_Model_Quote_<br>the Magento cart copy of the Bolt order<br><br>**discount**<br>string<br>the Magento totals array index/label for the discount |
 | bolt_boltpay_filter_shipping_label | global | Allows changing of individual shipping labels that are displayed in Bolt | **rate**<br>_Mage_Sales_Model_Quote_Address_Rate_<br>The information for this calculated rate, including method, carrier, and price | **string**<br>The label to be displayed in the Bolt order |
 | bolt_boltpay_filter_success_url | global | Provides means for custom success order urls | **order**<br>_Mage_Sales_Model_Order_<br>The order to be authorized<br><br>**quoteId**<br>_int_<br>The quote id of the order which maps to the Bolt order reference | **string**<br>The url that the BoltCheckout modal will forward the customer to on successful order authorization |
-| bolt_boltpay_filter_discount_amount | global | Allows changing of individual discount amount that is displayed in Bolt | **quote**<br>_Mage_Sales_Model_Quote_<br>the quote<br><br>**discount**<br>string<br>the index of the discount<br><br>|
 

--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ If you would like to pull the latest Bolt code from the Git repo and update Mage
 | --- | --- | --- | --- | --- |
 | bolt_boltpay_filter_shipping_label | global | Allows changing of individual shipping labels that are displayed in Bolt | **rate**<br>_Mage_Sales_Model_Quote_Address_Rate_<br>The information for this calculated rate, including method, carrier, and price | **string**<br>The label to be displayed in the Bolt order |
 | bolt_boltpay_filter_success_url | global | Provides means for custom success order urls | **order**<br>_Mage_Sales_Model_Order_<br>The order to be authorized<br><br>**quoteId**<br>_int_<br>The quote id of the order which maps to the Bolt order reference | **string**<br>The url that the BoltCheckout modal will forward the customer to on successful order authorization |
+| bolt_boltpay_filter_discount_amount | global | Allows changing of individual discount amount that is displayed in Bolt | **quote**<br>_Mage_Sales_Model_Quote_<br>the quote<br><br>**discount**<br>string<br>the index of the discount<br><br>|
 

--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -324,6 +324,8 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
 
         foreach ($this->discountTypes as $discount) {
             if (@$totals[$discount] && $amount = $totals[$discount]->getValue()) {
+                $amount = $this->boltHelper()->doFilterEvent( 'bolt_boltpay_filter_discount_amount', $amount, array('quote' => $quote, 'discount'=>$discount));
+                
                 // Some extensions keep discount totals as positive values,
                 // others as negative, which is the Magento default.
                 // Using the absolute value.


### PR DESCRIPTION
I added a filter to allow custom discount modifications without the need to override the entire addDiscounts function. This is needed in cases where the default handling of discounts needs to be modified.

For example, let's say that a customer has a $100 subtotal in their cart and they have a $1,000 gift card. At the time of page load the calculated discount would be $100 since there is no shipping applied to the cart total yet. But if the discount is allowed to be applied to shipping as well, then when the shipping is applied during the shipping and tax estimation step, the $100 discount won't be enough to cover the shipping even though the customer has enough on the gift card. In this case we actually need to customize the discount amount at page load to be the full amount (e.g. $1,000) instead of the default amount (e.g. $100) so that if the shipping amount is affected by the discount, the discount will have enough to affect it. In the example above let's say that the shipping was $25. A discount of $1,000 can be applied to a $125 grand total whereas the default discount functionality would only apply to $100 leaving $25 still required by the customer to pay.  Historically we would override the addDiscounts function in the local code pool and apply the full amount of the discount there. However, with the new Filter functionality, we can simply apply a filter to customize the discount. This code simply allows us to do that now without needing to override the entire function.

Fixes: https://app.asana.com/0/932047656377869/1108045192467066