### PR TITLE
[WIP] Improve robustness of authorization/payment identification

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -331,7 +331,12 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
             // Otherwise, ignore the failed payment hook because it arriving out of sync as
             // a payment has already been recorded
             //////////////////////////////////////////////////////////////////////////////////////
-            if ($order->getStatus() !== Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING) {
+            $payment = $order->getPayment();
+            if (
+                $payment->getAdditionalInformation('bolt_reference')
+                || $payment->getAuthorizationTransaction()
+                || $payment->getLastTransId()
+            ) {
                 $message = $this->boltHelper()->__(
                     'Payment was already recorded. The failed payment hook for order %s seems out of sync.',
                     $order->getIncrementId()


### PR DESCRIPTION
# Description
Many merchants have 3rd-party code that changes the status of the Bolt order to something other than pending_bolt.  For failed payments, we want to check that no transaction (e.g. verification of authorization) has occurred before cancelling and deleting the order.  Rather than relying on the status, it is more robust to view if any transactions have been recorded

Fixes: https://app.asana.com/0/544708310157130/1132600015873114

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.

**WIP** pending testing in staging and merchant staging