### PR TITLE
Always dispatch shipping applied to bolt order event at the end of routine

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -218,10 +218,8 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
             ///////////////////////////////////////////
 
             ////////////////////////////////////////////////////////////////////////////////////
-            // For one page checkout type include tax and shipment / address data in submission.
+            // For one page checkout/admin type include tax and shipment / address data in submission.
             ////////////////////////////////////////////////////////////////////////////////////
-
-
             if (Mage::app()->getStore()->isAdmin()) {
                 /* @var Mage_Adminhtml_Block_Sales_Order_Create_Totals $totalsBlock */
                 $totalsBlock =  Mage::app()->getLayout()->createBlock("adminhtml/sales_order_create_totals_shipping");
@@ -298,9 +296,12 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
                         }
                     }
                 }
-                $this->dispatchCartDataEvent('bolt_boltpay_shipping_applied_to_bolt_order', $quote, $cartSubmissionData);
+
                 $calculatedTotal += isset($cartSubmissionData['shipments']) ? array_sum(array_column($cartSubmissionData['shipments'], 'cost')) : 0;
             }
+
+            # It is possible that no shipments were added which could be used as indicative of an In-Store Pickup/No Shipping Required
+            $this->dispatchCartDataEvent('bolt_boltpay_shipping_applied_to_bolt_order', $quote, $cartSubmissionData);
             ////////////////////////////////////////////////////////////////////////////////////
         }
 


### PR DESCRIPTION
# Description
The `bolt_boltpay_shipping_applied_to_bolt_order` event most naturally fits after the business logic has been processed for the task regardless of whether an actual method is added to the Bolt order.  If no shipping method was added after the application of this logic, it is still useful information for merchants, for instance, this could indicate that an in-store pickup is to be applied.

Fixes: https://app.asana.com/0/544708310157130/1132674635377298

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.


