### PR TITLE
Address Pre-auth timeouted out orders, and v1.x orders

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -203,19 +203,17 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
                     initBoltButtons();
                     ";
                 $closeCustom = '';
+                // fall-through
             default:
+                // Backup success page forwarding for Firecheckout, Onepage Checkout, Multi-Checkout/Mini-Cart
+                // Generally all checkouts should fall-through to this
                 $appendChar = (strpos($successUrl, '?') === false) ? '?' : '&';
 
                 $javascript .=
                     "
                     $closeCustom
                     if (window.bolt_transaction_reference) {
-                         setTimeout(
-                              function() {
-                                   window.location = '$successUrl'+'$appendChar'+'bolt_transaction_reference='+window.bolt_transaction_reference;
-                              },
-                              500
-                         );
+                         window.location = '$successUrl'+'$appendChar'+'bolt_transaction_reference='+window.bolt_transaction_reference;
                     }
                     ";
         }

--- a/app/code/community/Bolt/Boltpay/Model/Observer.php
+++ b/app/code/community/Bolt/Boltpay/Model/Observer.php
@@ -122,7 +122,7 @@ class Bolt_Boltpay_Model_Observer
 
             /** @var Mage_Sales_Model_Order $order */
             $order = Mage::getModel('sales/order')->loadByIncrementId($incrementId);
-            $orderEntityId = (!$order->isObjectNew()) ? $order->getId() : 4294967295;  # use required max sentinel id if order not yet created
+            $orderEntityId = (!$order->isObjectNew()) ? $order->getId() : Bolt_Boltpay_Model_Order::MAX_ORDER_ID;  # use required max sentinel id if order not yet created
 
             $requestParams['lastQuoteId'] = $requestParams['lastSuccessQuoteId'] = $immutableQuoteId;
             $requestParams['lastOrderId'] = $orderEntityId;

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -26,6 +26,7 @@ use Bolt_Boltpay_OrderCreationException as OCE;
 class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 {
     const MERCHANT_BACK_OFFICE = 'merchant_back_office';
+    const MAX_ORDER_ID = 4294967295; # represents the max unsigned int by MySQL and MariaDB
 
     /**
      * Processes Magento order creation. Called from both frontend and API.

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -221,6 +221,10 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 
                 $service->submitAll();
                 $order = $service->getOrder();
+                if (!$isPreAuthCreation) {
+                    $order->addStatusHistoryComment($this->boltHelper()->__("BOLT notification: Order created via Bolt Webhook API for transaction $reference "));
+                    $order->save();
+                }
 
                 // Add the user_note to the order comments and make it visible for customer.
                 if (isset($transaction->order->user_note)) {
@@ -911,6 +915,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             ->addStatusHistoryComment($userNote)
             ->setIsVisibleOnFront(true)
             ->setIsCustomerNotified(false);
+        $order->save();
 
         return $order;
     }

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -131,9 +131,11 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
             }
 
             /////////////////////////////////////////////////////
-            /// Order was not found.  Throw Exception
+            /// Order was not found
+            /// Create order from orphaned transaction
             /////////////////////////////////////////////////////
-            throw new Exception("Could not find order ".$transaction->order->cart->display_id);
+            $orderModel->createOrder($reference, null, false, $transaction);
+            throw new Exception("Could not find order ".$transaction->order->cart->display_id. " Created it instead.");
 
         } catch (Bolt_Boltpay_InvalidTransitionException $boltPayInvalidTransitionException) {
             $this->boltHelper()->logException($boltPayInvalidTransitionException);

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
@@ -193,15 +193,10 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
         $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE;
         $saveOrderUrl = Mage::helper('boltpay')->getMagentoUrl("boltpay/order/save/checkoutType/$checkoutType");
 
-        $onSuccessCallback =
-            "function(transaction, callback) {
-                $successCustom
-                callback();
-            }";
-
         $result = $this->currentMock->buildOnSuccessCallback($successCustom, $checkoutType);
 
-        $this->assertEquals($onSuccessCallback, $result);
+        $this->assertStringStartsWith('function', $result);
+        $this->assertContains($successCustom, $result);
     }
 
     /**
@@ -242,13 +237,12 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
     {
         $successUrl = Mage::helper('boltpay')->getMagentoUrl('checkout/onepage/success');
         $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ONE_PAGE;
-        $closeCustom = '';
-
-        $expected = '';
+        $closeCustom = 'console.log("test");';
 
         $result = $this->currentMock->buildOnCloseCallback($closeCustom, $checkoutType);
 
-        $this->assertEquals(preg_replace('/\s/', '', $expected), preg_replace('/\s/', '', $result));
+        $this->assertContains($closeCustom, $result);
+        $this->assertNotEquals($closeCustom, $result);
     }
 
     /**


### PR DESCRIPTION
# Description
Adds the concept of orphaned transactions to 2.0.  This does two things:
  1.)  Allows for orders to be created via webhook if the create_order endpoint times out 
  2.)  Allows for non-pre-auth (legacy) orders to be processed by webhook

Additionally, this adds the user experience code of forwarding the user to the success_url when the Bolt create_order mechanism does not provide the forwarding URL

Fixes: https://app.asana.com/0/436430054069245/1132981769648030

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
