### PR TITLE
Create order optimization with Benchmark Profiler

### DIFF
--- a/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
+++ b/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
@@ -46,6 +46,8 @@ trait Bolt_Boltpay_Controller_Traits_WebHookTrait {
      */
     public function preDispatch()
     {
+        benchmark( "Bolt controller predispatch started" );
+
         ob_start();
 
         $this->getResponse()->clearAllHeaders()->clearBody();
@@ -58,6 +60,8 @@ trait Bolt_Boltpay_Controller_Traits_WebHookTrait {
             $this->payload = file_get_contents('php://input');
             $this->verifyBoltSignature($this->payload, @$_SERVER['HTTP_X_BOLT_HMAC_SHA256']);
         }
+
+        benchmark( "Finished Bolt controller predispatch" );
 
         return parent::preDispatch();
     }

--- a/app/code/community/Bolt/Boltpay/Helper/LoggerTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/LoggerTrait.php
@@ -38,6 +38,9 @@ trait Bolt_Boltpay_Helper_LoggerTrait
     use Bolt_Boltpay_Helper_BugsnagTrait;
 
     public static $isLoggerEnabled = true;
+
+    /** @var array A two dimensional array of all benchmark labels and times  */
+    public static $benchmarks = [];
     
     /**
      * Runtime errors that do not require immediate action but should typically
@@ -103,6 +106,125 @@ trait Bolt_Boltpay_Helper_LoggerTrait
                 )
             );
             $this->notifyException( new Exception((string)$message) );
+        }
+    }
+
+    /**
+     * Logs the time taken to reach the point in the codebase
+     *
+     * @param string $label                  Label to add to the benchmark
+     * @param bool   $shouldLogIndividually  If true, the benchmark will be logged separately in addition to with the full log
+     * @param bool   $shouldIncludeInFullLog If false, this benchmark will not be included in the full log
+     * @param bool   $shouldFlushFullLog     If true, will log the full log up to this benchmark call.
+     */
+    public function logBenchmark( $label, $shouldLogIndividually = false, $shouldIncludeInFullLog = true, $shouldFlushFullLog = false ) {
+        if (!$this->getExtraConfig('enableBenchmarkProfiling')) { return; }
+
+        $startTime = Mage::registry('bolt/request_start_time') ?: microtime(true);
+        $previousTime = Mage::registry('bolt/last_process_timestamp') ?: $startTime;
+        $currentTime = microtime(true);
+
+        $sectionDivider = '*****************************************************';
+        $summaryHeader = '-- Benchmark ';
+        $summarySinceLastTime = 'Time since previous benchmark: *';
+        $summarySinceStartTime = 'Time since benchmark profiling was started: ';
+
+        if ($shouldLogIndividually) {
+            $summary = "\n".$summaryHeader." --\n";
+            if ($label) {$summary .= "*$label*\n";}
+
+            $summary .=
+                $summarySinceLastTime.round(($currentTime - $previousTime), 3)."s*\n"
+                .$summarySinceStartTime.round(($currentTime - $startTime), 3).'s';
+
+            $this->info($summary);
+        }
+
+        try {
+            Mage::register('bolt/request_start_time', $startTime, true);
+            Mage::unregister('bolt/last_process_timestamp');
+            Mage::register('bolt/last_process_timestamp', $currentTime);
+        } catch ( Mage_Core_Exception $mce ) {
+            // convenience clobber to suppress IDE warnings.  Logic does not permit the exception
+        }
+
+        if ($shouldIncludeInFullLog) {
+            static::$benchmarks[] = [ 'label' => $label, 'time' => $currentTime ];
+        }
+
+        if ( $shouldFlushFullLog ) {
+
+            if (static::$benchmarks) {
+                $fullSummary = "";
+                $finalBenchmarkTime = static::$benchmarks[count(static::$benchmarks) - 1]['time'];
+                $totalTime = $finalBenchmarkTime - $startTime;
+
+                $i = 0;
+                $previousTime = $startTime;
+                $percentSummaryArray = [];
+                foreach (static::$benchmarks as $benchmark) {
+                    $i++;
+                    $summary = $summaryHeader . " $i --\n";
+                    $label = $benchmark['label'];
+                    if ($label) {
+                        $summary .= "*$label*\n";
+                    }
+
+                    $benchmarkTime = $benchmark['time'];
+                    $processingTime = $benchmarkTime - $previousTime;
+                    $processingPercentage = number_format(round(($processingTime / $totalTime) * 100, 2), 2);
+
+                    $summary .=
+                        $summarySinceLastTime . round(($processingTime), 3) . "s*\n"
+                        . $summarySinceStartTime . round(($benchmarkTime - $startTime), 3) . "s\n"
+                        . "Percent of total benchmarked processing time: *$processingPercentage%*";
+
+                    $previousTime = $benchmarkTime;
+
+                    if ($fullSummary) {
+                        $fullSummary .= "\n\n";
+                    }
+                    $fullSummary .= $summary;
+
+                    $percentSummaryArray[] = [
+                        'index' => $i,
+                        'label' => $label ?: '<No Label>',
+                        'percent' => $processingPercentage,
+                        'time' => number_format(round(($processingTime), 3), 3)
+                    ];
+                }
+                usort(
+                    $percentSummaryArray,
+                    function ($a, $b) {
+                        if ($a['percent'] == $b['percent']) {
+                            return 0;
+                        }
+                        return ($a['percent'] < $b['percent']) ? 1 : -1;
+                    }
+                );
+
+                $percentSummary = $percentSummaryArray
+                    ? "\n\n$sectionDivider\n\n-- Aggregate Benchmark Processing Time Summary --\n\n"
+                    : '';
+
+                $i = 0;
+                foreach ($percentSummaryArray as $benchmark) {
+                    if ($i++) {
+                        $percentSummary .= "\n";
+                    }
+                    $percentSummary .= str_pad($benchmark['percent'], 5, ' ', STR_PAD_LEFT)
+                        . '% - Benchmark '. str_pad( $benchmark['index'], 3)
+                        . ' - ' . $benchmark['label'] . ' - *' . $benchmark['time'] . 's*';
+                }
+
+                $totalTime = "\n\nTotal Processing Time: *" . round($totalTime, 3) . "s*\n\n$sectionDivider\n";
+                $this->info("\n$sectionDivider\n\n".$fullSummary.$percentSummary.$totalTime);
+            }
+
+            # fully reset the benchmarks
+            Mage::unregister('bolt/request_start_time');
+            Mage::unregister('bolt/last_process_timestamp');
+            static::$benchmarks = [];
         }
     }
 }

--- a/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
@@ -298,6 +298,18 @@ JS;
     }
 
     /**
+     * Ensures boolean value for whether bench mark profiling is enabled
+     *
+     * @param mixed $rawConfigValue    The config value pre-filter
+     * @param array  $additionalParams  unused for this filter
+     *
+     * @return bool  the value from the extra config admin forced to boolean
+     */
+    public function filterEnableBenchmarkProfiling($rawConfigValue, $additionalParams = array() ) {
+        return $this->normalizeBoolean($rawConfigValue);
+    }
+
+    /**
      * Normalizes JSON by stripping new lines from the given string and returning null
      * in the case of only white space.
      *

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -53,13 +53,16 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                 throw new Exception($msg);
             }
 
+            benchmark( "Potentially starting to fetch bolt transaction" );
             $transaction = $transaction ?: $this->boltHelper()->fetchTransaction($reference);
+            benchmark( "Finished fetching bolt transaction. Looking up quotes." );
 
             $immutableQuoteId = $this->boltHelper()->getImmutableQuoteIdFromTransaction($transaction);
             $immutableQuote = $this->getQuoteById($immutableQuoteId);
             $immutableQuote->setParentId($transaction->order->cart->order_reference);
             Mage::app()->setCurrentStore($immutableQuote->getStore());
             $parentQuote = $this->getQuoteById($transaction->order->cart->order_reference);
+            benchmark( "Looked up quotes." );
 
             if (!$parentQuote->getIsActive()) {
                 throw new Exception(
@@ -75,6 +78,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                 $this->boltHelper()->setCustomerSessionByQuoteId($sessionQuoteId);
             }
 
+            benchmark( "Dispatching event bolt_boltpay_order_creation_before" );
             Mage::dispatchEvent(
                 'bolt_boltpay_order_creation_before',
                 array(
@@ -83,14 +87,15 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                     'transaction' => $transaction
                 )
             );
+            benchmark( "Dispatched event bolt_boltpay_order_creation_before" );
 
             $this->validateCartSessionData($immutableQuote, $parentQuote, $transaction);
+            benchmark( "Validated session data" );
 
             // adding guest user email to order
             if (!$immutableQuote->getCustomerEmail()) {
                 $email = $transaction->order->cart->billing_address->email_address;
                 $immutableQuote->setCustomerEmail($email);
-                $immutableQuote->save();
             }
 
             // explicitly set quote belong to guest if customer id does not exist
@@ -103,14 +108,15 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                     ->setCustomerFirstname($transaction->order->cart->billing_address->first_name)
                     ->setCustomerLastname($transaction->order->cart->billing_address->last_name);
             }
-            $immutableQuote->save();
+            benchmark( "Saved customer information" );
 
-            $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true)->save();
+            $immutableQuote->getShippingAddress()->setShouldIgnoreValidation(true);
             $immutableQuote->getBillingAddress()
                 ->setFirstname($transaction->order->cart->billing_address->first_name)
                 ->setLastname($transaction->order->cart->billing_address->last_name)
                 ->setShouldIgnoreValidation(true)
                 ->save();
+            benchmark( "Saved address info" );
 
             //////////////////////////////////////////////////////////////////////////////////
             ///  Apply shipping address and shipping method data to quote directly from
@@ -119,22 +125,26 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             $packagesToShip = $transaction->order->cart->shipments;
 
             if ($packagesToShip) {
-
+                benchmark( "Applying shipping" );
                 $shippingAddress = $immutableQuote->getShippingAddress();
                 $shippingMethodCode = null;
 
                 /** @var Bolt_Boltpay_Model_ShippingAndTax $shippingAndTaxModel */
                 $shippingAndTaxModel = Mage::getModel("boltpay/shippingAndTax");
+
+                benchmark( "Applying shipping - Applying shipping address data" );
                 $shippingAndTaxModel->applyBoltAddressData($immutableQuote, $packagesToShip[0]->shipping_address, false);
+                benchmark( "Finished applying shipping - Applying shipping address data" );
+
                 $shippingMethodCode = $packagesToShip[0]->reference;
 
                 if (!$shippingMethodCode) {
+                    benchmark( "Applying shipping - Collecting shipping rates, legacy" );
                     // Legacy transaction does not have shipments reference - fallback to $service field
                     $shippingMethod = $packagesToShip[0]->service;
 
-                    $this->boltHelper()->collectTotals($immutableQuote);
+                    $this->boltHelper()->collectTotals($immutableQuote, false);
 
-                    $shippingAddress->setCollectShippingRates(true)->collectShippingRates();
                     $rates = $shippingAddress->getAllShippingRates();
 
                     foreach ($rates as $rate) {
@@ -144,11 +154,11 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                             break;
                         }
                     }
+                    benchmark( "Finished applying shipping - Collecting shipping rates, legacy" );
                 }
 
                 if ($shippingMethodCode) {
                     $shippingAndTaxModel->applyShippingRate($immutableQuote, $shippingMethodCode, false);
-                    $shippingAddress->save();
                 } else {
                     $errorMessage = $this->boltHelper()->__('Shipping method not found');
                     $metaData = array(
@@ -161,6 +171,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                     $this->boltHelper()->logWarning($errorMessage);
                     $this->boltHelper()->notifyException(new Exception($errorMessage), $metaData);
                 }
+                benchmark( "Finished applying shipping" );
             }
             //////////////////////////////////////////////////////////////////////////////////
 
@@ -172,16 +183,24 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             $payment->setMethod(Bolt_Boltpay_Model_Payment::METHOD_CODE)->save();
             //////////////////////////////////////////////////////////////////////////////////
 
+
+            benchmark( "Collecting totals to validate" );
             $this->boltHelper()->collectTotals($immutableQuote, true)->save();
+            benchmark( "Finished collecting totals to validate" );
 
             $this->validateCoupons($immutableQuote, $transaction);
+            benchmark( "Validated coupons" );
+
             $this->validateTotals($immutableQuote, $transaction);
+            benchmark( "Validated subTotals" );
+
 
             ////////////////////////////////////////////////////////////////////////////
             // reset increment id if needed
             ////////////////////////////////////////////////////////////////////////////
             /* @var Mage_Sales_Model_Order $preExistingOrder */
             $preExistingOrder = Mage::getModel('sales/order')->loadByIncrementId($parentQuote->getReservedOrderId());
+            benchmark( "Searched for existing order" );
 
             if (!$preExistingOrder->isObjectNew()) {
                 ############################
@@ -205,7 +224,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                     ->reserveOrderId()
                     ->save();
 
-                $immutableQuote->setReservedOrderId($parentQuote->getReservedOrderId());
+                $immutableQuote->setReservedOrderId($parentQuote->getReservedOrderId())->save();
             }
             ////////////////////////////////////////////////////////////////////////////
 
@@ -218,9 +237,10 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             $service = Mage::getModel('sales/service_quote', $immutableQuote);
 
             try {
-
+                benchmark( "Submitting order" );
                 $service->submitAll();
                 $order = $service->getOrder();
+                benchmark( "Submitted order and validated it" );
 
                 // Add the user_note to the order comments and make it visible for customer.
                 if (isset($transaction->order->user_note)) {
@@ -281,21 +301,25 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
         if ($immutableQuote->getData('is_bolt_pdp') && Mage::getSingleton('customer/session')->isLoggedIn()) {
             $this->associateOrderToCustomerWhenPlacingOnPDP($order->getData('increment_id'));
         }
+        benchmark( "Finished post order processing" );
 
         ///////////////////////////////////////////////////////
         /// Dispatch order save events
         ///////////////////////////////////////////////////////
         $recurringPaymentProfiles = $service->getRecurringPaymentProfiles();
 
+        benchmark( 'Running independent merchant third-party code via checkout_submit_all_after');
         Mage::dispatchEvent(
             'checkout_submit_all_after',
             array('order' => $order, 'quote' => $immutableQuote, 'recurring_profiles' => $recurringPaymentProfiles)
         );
+        benchmark( "Finished running independent merchant third-party code via checkout_submit_all_after" );
 
         Mage::dispatchEvent(
             'bolt_boltpay_order_creation_after',
             array('order'=>$order, 'quote'=>$immutableQuote, 'transaction' => $transaction)
         );
+        benchmark( "Dispatched bolt_boltpay_order_creation_after" );
         ///////////////////////////////////////////////////////
 
         return $order;

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -132,8 +132,9 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                 /** @var Bolt_Boltpay_Model_ShippingAndTax $shippingAndTaxModel */
                 $shippingAndTaxModel = Mage::getModel("boltpay/shippingAndTax");
 
+                $shouldRecalculateShipping = (bool) $this->boltHelper()->getExtraConfig("recalculateShipping"); # false by default
                 benchmark( "Applying shipping - Applying shipping address data" );
-                $shippingAndTaxModel->applyBoltAddressData($immutableQuote, $packagesToShip[0]->shipping_address, false);
+                $shippingAndTaxModel->applyBoltAddressData($immutableQuote, $packagesToShip[0]->shipping_address, $shouldRecalculateShipping);
                 benchmark( "Finished applying shipping - Applying shipping address data" );
 
                 $shippingMethodCode = $packagesToShip[0]->reference;
@@ -143,7 +144,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                     // Legacy transaction does not have shipments reference - fallback to $service field
                     $shippingMethod = $packagesToShip[0]->service;
 
-                    $this->boltHelper()->collectTotals($immutableQuote, false);
+                    $this->boltHelper()->collectTotals($immutableQuote, $shouldRecalculateShipping);
 
                     $rates = $shippingAddress->getAllShippingRates();
 

--- a/app/code/community/Bolt/Boltpay/Model/ShippingAndTax.php
+++ b/app/code/community/Bolt/Boltpay/Model/ShippingAndTax.php
@@ -265,10 +265,11 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Bolt_Boltpay_Model_Abstract
     /**
      * Applies shipping rate to quote. Clears previously calculated discounts by clearing address id.
      *
-     * @param Mage_Sales_Model_Quote $quote              Quote which has been updated to use new shipping rate
-     * @param string                 $shippingRateCode   Shipping rate code composed of {carrier}_{method}
+     * @param Mage_Sales_Model_Quote $quote                     Quote which has been updated to use new shipping rate
+     * @param string                 $shippingRateCode          Shipping rate code composed of {carrier}_{method}
+     * @param bool                   $shouldRecalculateShipping Determines if shipping should be recalculated
      */
-    public function applyShippingRate($quote, $shippingRateCode) {
+    public function applyShippingRate($quote, $shippingRateCode, $shouldRecalculateShipping = true ) {
 
         $shippingAddress = $quote->getShippingAddress();
 
@@ -280,7 +281,7 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Bolt_Boltpay_Model_Abstract
 
             $shippingAddress
                 ->setShippingMethod($shippingRateCode)
-                ->setCollectShippingRates(true);
+                ->setCollectShippingRates($shouldRecalculateShipping);
 
             // When multiple shipping methods apply a discount to the sub-total, collect totals doesn't clear the
             // previously set discount, so the previous discount gets added to each subsequent shipping method that
@@ -299,7 +300,7 @@ class Bolt_Boltpay_Model_ShippingAndTax extends Bolt_Boltpay_Model_Abstract
                 )
             );
 
-            $this->boltHelper()->collectTotals($quote, true);
+            $this->boltHelper()->collectTotals($quote, $shouldRecalculateShipping);
 
             if(!empty($shippingAddressId) && $shippingAddressId != $shippingAddress->getData('address_id')) {
                 $shippingAddress->setData('address_id', $shippingAddressId);

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -68,6 +68,22 @@
     </resources>
 
     <events>
+      <controller_front_init_before>
+          <observers>
+              <bolt_boltpay_init_benchmarking>
+                  <class>Bolt_Boltpay_Model_Observer</class>
+                  <method>initializeBenchmarkProfiler</method>
+              </bolt_boltpay_init_benchmarking>
+          </observers>
+      </controller_front_init_before>
+      <controller_front_send_response_after>
+          <observers>
+              <bolt_boltpay_flush_benchmark_logs>
+                  <class>Bolt_Boltpay_Model_Observer</class>
+                  <method>logFullBenchmarkProfile</method>
+              </bolt_boltpay_flush_benchmark_logs>
+          </observers>
+      </controller_front_send_response_after>
       <checkout_onepage_controller_success_action> <!-- Call after order has been saved and forwarded to success page -->
         <observers>
           <bolt_boltpay_clear_shopping_cart>


### PR DESCRIPTION
# Description
To reduce processing time for create_order, we eliminate recalculation of shipping, which has been done sufficiently via the shipping and tax end point.  We also add the ability to log execution times via a benchmarking so that we may quantify processing time.

Fixes: https://app.asana.com/0/inbox/544708310157128/1132981769648030/1132983838706810

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
