### PR TITLE
Remove authcapture parameter

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -130,18 +130,14 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
      * Generate cart data
      *
      * @param      $orderCreationResponse
-     * @param null $checkoutType
      * @return array
      */
-    public function buildCartData($orderCreationResponse, $checkoutType = null)
+    public function buildCartData($orderCreationResponse)
     {
-        $authCapture = $checkoutType === 'admin' ? true : Mage::getStoreConfigFlag('payment/boltpay/auto_capture');
-
         //////////////////////////////////////////////////////////////////////////
         // Generate JSON cart and hints objects for the javascript returned below.
         //////////////////////////////////////////////////////////////////////////
         $cartData = array(
-            'authcapture' => $authCapture,
             'orderToken' => ($orderCreationResponse) ? $orderCreationResponse->token: '',
         );
 

--- a/app/code/community/Bolt/Boltpay/Controller/Traits/OrderControllerTrait.php
+++ b/app/code/community/Bolt/Boltpay/Controller/Traits/OrderControllerTrait.php
@@ -79,7 +79,7 @@ trait Bolt_Boltpay_Controller_Traits_OrderControllerTrait {
 
         if (!$cart_data) {
             $immutableQuote = $this->cloneQuote($sessionQuote, $checkoutType);
-            $cart_data = $boltpayCheckout->buildCartData($boltOrder->getBoltOrderToken($immutableQuote, $checkoutType),$checkoutType);
+            $cart_data = $boltpayCheckout->buildCartData($boltOrder->getBoltOrderToken($immutableQuote, $checkoutType));
         }
 
         $boltOrder->cacheCartData($cart_data, $sessionQuote, $checkoutType);

--- a/app/code/community/Bolt/Boltpay/etc/system.xml
+++ b/app/code/community/Bolt/Boltpay/etc/system.xml
@@ -46,16 +46,6 @@
               <show_in_website>1</show_in_website>
               <show_in_store>1</show_in_store>
             </test>
-            <auto_capture translate="label">
-              <label>Automatic Capture Mode</label>
-              <comment>If enabled, payment is automatically captured when Bolt approves orders. Otherwise, payment is captured when you create an invoice.</comment>
-              <frontend_type>select</frontend_type>
-              <source_model>adminhtml/system_config_source_yesno</source_model>
-              <sort_order>3</sort_order>
-              <show_in_default>1</show_in_default>
-              <show_in_website>1</show_in_website>
-              <show_in_store>1</show_in_store>
-            </auto_capture>
 
             <api_key translate="label">
               <label>API Key</label>

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -43,7 +43,6 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         $result = $this->currentMock->buildCartData($testBoltResponse);
 
         $cartData = array(
-            'authcapture' => $autoCapture,
             'orderToken' => md5('bolt'),
         );
 
@@ -64,7 +63,6 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         $result = $this->currentMock->buildCartData($testBoltResponse);
 
         $cartData = array(
-            'authcapture'   => $autoCapture,
             'orderToken'    => '',
         );
 
@@ -86,7 +84,6 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         $result = $this->currentMock->buildCartData($testBoltResponse);
 
         $cartData = array(
-            'authcapture' => $autoCapture,
             'orderToken' => md5('bolt'),
         );
 
@@ -111,7 +108,6 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         $result = $this->currentMock->buildCartData($testBoltResponse);
 
         $cartData = array(
-            'authcapture' => $autoCapture,
             'orderToken' => md5('bolt'),
             'error' => $apiErrorMessage
         );
@@ -189,7 +185,6 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
 
         $cartData = json_encode (
             array(
-                'authcapture' => $autoCapture,
                 'orderToken' => md5('bolt')
             )
         );


### PR DESCRIPTION
# Description
Currently configuration for auth capture can be set on magento backend, and this will override the Bolt Merchant admin configuration. Removing this will allow us to use the configuration on the merchant admin.

Fixes: https://app.asana.com/0/564264490825835/1132958531677445

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
