### PR TITLE
Rolls back the use of set state to ensure proper state after irreversible rejection

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -495,9 +495,9 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
                 } elseif ($newTransactionStatus == self::TRANSACTION_REJECTED_IRREVERSIBLE) {
                     /** @var Mage_Sales_Model_Order $order */
                     $order = $payment->getOrder();
-                    $order->cancel();
+                    $order->cancel();  # returns inventory
                     $message = $this->boltHelper()->__('BOLT notification: Transaction reference "%s" has been permanently rejected by Bolt', $reference);
-                    $order->addStatusHistoryComment($message)->setIsVisibleOnFront(false)->setIsCustomerNotified(false);
+                    $order->setState(Mage_Sales_Model_Order::STATE_CANCELED, true, $message); # adds message and ensures state changed
                     $order->save();
                 } elseif ($newTransactionStatus == self::TRANSACTION_REJECTED_REVERSIBLE) {
                     $order = $payment->getOrder();


### PR DESCRIPTION
# Description
HOTFIX for 2.0.1 release
Originates from #443 

It turns out that it is not assured that state of the order is changed to cancel by calling the order cancel method.  To ensure this, we explicitly set the state.

Fixes: https://app.asana.com/0/1125081140214268/1130067876286030

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
