### PR TITLE
Set plugin-magento1 as a service for datadog

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/DataDogTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/DataDogTrait.php
@@ -90,6 +90,7 @@ trait Bolt_Boltpay_Helper_DataDogTrait
         $this->_data['platform-version'] = 'Magento ' . Mage::getVersion();
         $this->_data['bolt-plugin-version'] = static::getPluginVersion();
         $this->_data['store_url'] = Mage::getBaseUrl();
+        $this->_data['service'] = 'plugin-magento1';
         if (isset($_SERVER['PHPUNIT_ENVIRONMENT']) && $_SERVER['PHPUNIT_ENVIRONMENT']) {
             $this->_data['env'] = Boltpay_DataDog_Environment::TEST_ENVIRONMENT;
         } else {


### PR DESCRIPTION
# Description
Currently DataDog doesn’t track the plugin for Magento 1. Added it.

Fixes: (link Asana Task)

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
