### PR TITLE
Frontend non-multistore URL pre-processing

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -177,8 +177,8 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function buildOnCloseCallback($closeCustom, $checkoutType)
     {
-        // For frontend URLs, we want to session id process the URL to get the correct URL
-        // in the non-multi-store context
+        // For frontend URLs, we want to "session id process" the URL to get the 
+        // final format URL which may or may not contain the __SID=(S|U) parameter
         $successUrl = Mage::getModel('core/url')->sessionUrlVar(
             $this->getMagentoUrl(Mage::getStoreConfig('payment/boltpay/successpage'))
         );

--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -177,7 +177,11 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function buildOnCloseCallback($closeCustom, $checkoutType)
     {
-        $successUrl = $this->getMagentoUrl(Mage::getStoreConfig('payment/boltpay/successpage'));
+        // For frontend URLs, we want to session id process the URL to get the correct URL
+        // in the non-multi-store context
+        $successUrl = Mage::getModel('core/url')->sessionUrlVar(
+            $this->getMagentoUrl(Mage::getStoreConfig('payment/boltpay/successpage'))
+        );
         $javascript = "";
         switch ($checkoutType) {
             case Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ADMIN:


### PR DESCRIPTION
# Description
In the multi-store context and in the caching context, Magento uses a placeholder "___SID" to store a session id on URLs.  This is post-processed upon rendering of the HTML and in single store context, or when it is not needed, it will be removed.  Because we are checking our required URL outside of the rendered context, we get differences between the final outputed URL and the pre-processed URL.  For our purposes, we want to process the URL prior to comparisons.

Fixes: https://app.asana.com/0/544708310157130/1135096267113402

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
