### PR TITLE
Identify prefetch action by searching for prefetch in URL

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -42,7 +42,7 @@ class Bolt_Boltpay_ShippingController
     {
         $this->_cache = Mage::app()->getCache();
         $this->_shippingAndTaxModel = Mage::getModel("boltpay/shippingAndTax");
-        if ($this->getRequest()->getPathInfo() === '/boltpay/shipping/prefetchEstimate/' ) {
+        if (strpos($this->getRequest()->getPathInfo(), 'prefetchEstimate')) {
             $this->requestMustBeSigned = false;
         }
     }


### PR DESCRIPTION
# Description
Since the URL format is proving to be unpredictable, (e.g. with a trailing "/" or without), we will simplify by calling just checking for `prefetchEstimate` in the request.  Because this is isolated to the shipping controller, this is sufficient for identification.

Fixes: https://app.asana.com/0/941895179897714/1135898978484449

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
