### PR TITLE
Allow orders to be created from orphaned transaction when parent_quote_id is set on parent quote

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -340,13 +340,14 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
     /**
      * Checks several indicators to see if the Magento session or cart has expired
      *
-     * @param Mage_Sales_Model_Quote $immutableQuote    Copy of the Magento session quote used by Bolt
-     * @param Mage_Sales_Model_Quote $parentQuote       The Magento session quote holding cart data
-     * @param object                 $transaction       The Bolt transaction object sent from the Bolt server
+     * @param Mage_Sales_Model_Quote $immutableQuote Copy of the Magento session quote used by Bolt
+     * @param Mage_Sales_Model_Quote $parentQuote    The Magento session quote holding cart data
+     * @param object                 $transaction    The Bolt transaction object sent from the Bolt server
+     * @param bool                   $isPreAuthCreation
      *
-     * @throws Bolt_Boltpay_OrderCreationException  on failure of session validation
+     * @throws Bolt_Boltpay_OrderCreationException on failure of session validation
      */
-    protected function validateCartSessionData($immutableQuote, $parentQuote, $transaction) {
+    protected function validateCartSessionData($immutableQuote, $parentQuote, $transaction, $isPreAuthCreation = false) {
 
         if ($immutableQuote->isEmpty()) {
             throw new Bolt_Boltpay_OrderCreationException(
@@ -363,7 +364,13 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             );
         }
 
-        if ($parentQuote->isEmpty() || ($parentQuote->getParentQuoteId() === $immutableQuote->getId())) {
+        if (
+            $parentQuote->isEmpty() ||
+            (
+                $isPreAuthCreation &&
+                $parentQuote->getParentQuoteId() === $immutableQuote->getId()
+            )
+        ) {
             throw new Bolt_Boltpay_OrderCreationException(
                 OCE::E_BOLT_CART_HAS_EXPIRED,
                 OCE::E_BOLT_CART_HAS_EXPIRED_TMPL_EXPIRED


### PR DESCRIPTION
# Description
Allow orders to be created from orphaned transaction when parent_quote_id is set on parent quote

Fixes: https://app.asana.com/0/1125081140214268/1136652844010093/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
