### PR TITLE
Force Payment Update on payment review orders if transaction history is out of sync

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -209,14 +209,18 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
             }
 
             $transactionStatus = strtolower($response->status);
-            $prevTransactionStatus = $payment->getAdditionalInformation('bolt_transaction_status');
+
+            /** @var Mage_Sales_Model_Order $order */
+            $order = $payment->getOrder();
+            $prevTransactionStatus = ($order && ($order->getState() === Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW))
+                ? self::TRANSACTION_PENDING
+                : $payment->getAdditionalInformation('bolt_transaction_status');
 
             if ($transactionStatus === self::TRANSACTION_PENDING) {
                 $message = $this->boltHelper()->__('Bolt is still reviewing this transaction.  The order status will be updated automatically after review.');
                 $this->boltHelper()->logWarning($message);
                 Mage::getSingleton('adminhtml/session')->addNotice($message);
             }
-
             $this->handleTransactionUpdate($payment, $transactionStatus, $prevTransactionStatus);
             //Mage::log(sprintf('Fetch transaction info completed for payment id: %d', $payment->getId()), null, 'bolt.log');
         } catch (Exception $e) {


### PR DESCRIPTION
# Description
Merchant was reporting that several orders were stuck in Payment Review and they could not us the "Get Payment Update" button.  This forces an update on payment review orders, even if the bolt_transaction_status/hook history manages to get out of sync.

Fixes: https://app.asana.com/0/search/1137497898160001/1120933731228864

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
