### PR TITLE
Fixes error of Cart has expired after failed_payment hook

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
@@ -298,6 +298,18 @@ JS;
     }
 
     /**
+     * Ensures boolean value for whether to keep for pre-auth orders after failed payment hoods
+     *
+     * @param mixed $rawConfigValue    The config value pre-filter
+     * @param array  $additionalParams  unused for this filter
+     *
+     * @return bool  the value from the extra config admin forced to boolean
+     */
+    public function filterKeepPreAuthOrders($rawConfigValue, $additionalParams = array() ) {
+        return $this->normalizeBoolean($rawConfigValue);
+    }
+
+    /**
      * Ensures boolean value for whether bench mark profiling is enabled
      *
      * @param mixed $rawConfigValue    The config value pre-filter

--- a/app/code/community/Bolt/Boltpay/Model/Observer.php
+++ b/app/code/community/Bolt/Boltpay/Model/Observer.php
@@ -98,10 +98,10 @@ class Bolt_Boltpay_Model_Observer
         /** @var Mage_Sales_Model_Quote $quote */
         $quote = Mage::getSingleton('checkout/session')->getQuote();
 
-        if ($quote && is_int($quote->getId()) && $quote->getId() === $quote->getParentQuoteId()) {
+        if ($quote && is_int($quote->getParentQuoteId()) && $quote->getIsActive()) {
             Mage::getSingleton('core/session')->unsCachedCartData();
             // clear the parent quote ID to re-enable cart cache
-            $quote->setParentQuoteId(null);
+            $quote->setParentQuoteId(null)->save();
         }
     }
 

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -60,19 +60,10 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 
             $immutableQuoteId = $this->boltHelper()->getImmutableQuoteIdFromTransaction($transaction);
             $immutableQuote = $this->getQuoteById($immutableQuoteId);
-            $immutableQuote->setParentId($transaction->order->cart->order_reference);
+            $immutableQuote->setParentQuoteId($transaction->order->cart->order_reference);
             Mage::app()->setCurrentStore($immutableQuote->getStore());
             $parentQuote = $this->getQuoteById($transaction->order->cart->order_reference);
             benchmark( "Looked up quotes." );
-
-            if (!$parentQuote->getIsActive()) {
-                throw new Exception(
-                    $this->boltHelper()->__("Bolt expects the parent quote [%s] to be available.  Instead it found that the parent quote [%s] for the immutable quote [%s] is currently being processed, has been processed, or can not be processed for order [#%s]. Check quote [%s] for details.",
-                        $transaction->order->cart->order_reference, $parentQuote->getId(), $immutableQuote->getId(), $parentQuote->getReservedOrderId(), $parentQuote->getParentQuoteId() )
-                );
-            }
-
-            $parentQuote->setIsActive(false)->save();
 
             if (!$sessionQuoteId){
                 $sessionQuoteId = $immutableQuote->getParentQuoteId();
@@ -92,6 +83,8 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 
             $this->validateCartSessionData($immutableQuote, $parentQuote, $transaction);
             benchmark( "Validated session data" );
+
+            $parentQuote->setIsActive(false)->save();  # block synchronous processing of cart
 
             // adding guest user email to order
             if (!$immutableQuote->getCustomerEmail()) {
@@ -132,8 +125,8 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 
                 /** @var Bolt_Boltpay_Model_ShippingAndTax $shippingAndTaxModel */
                 $shippingAndTaxModel = Mage::getModel("boltpay/shippingAndTax");
-
                 $shouldRecalculateShipping = (bool) $this->boltHelper()->getExtraConfig("recalculateShipping"); # false by default
+
                 benchmark( "Applying shipping - Applying shipping address data" );
                 $shippingAndTaxModel->applyBoltAddressData($immutableQuote, $packagesToShip[0]->shipping_address, $shouldRecalculateShipping);
                 benchmark( "Finished applying shipping - Applying shipping address data" );
@@ -160,7 +153,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                 }
 
                 if ($shippingMethodCode) {
-                    $shippingAndTaxModel->applyShippingRate($immutableQuote, $shippingMethodCode, false);
+                    $shippingAndTaxModel->applyShippingRate($immutableQuote, $shippingMethodCode, $shouldRecalculateShipping);
                 } else {
                     $errorMessage = $this->boltHelper()->__('Shipping method not found');
                     $metaData = array(
@@ -363,7 +356,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             );
         }
 
-        if ($parentQuote->isObjectNew() || ($parentQuote->getParentQuoteId() === $immutableQuote->getId())) {
+        if ($parentQuote->isObjectNew() || !$parentQuote->getIsActive()) {
             throw new Bolt_Boltpay_OrderCreationException(
                 OCE::E_BOLT_CART_HAS_EXPIRED,
                 OCE::E_BOLT_CART_HAS_EXPIRED_TMPL_EXPIRED
@@ -646,6 +639,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
         foreach ($transaction->order->cart->items as $boltCartItem) {
 
             $cartItem = $immutableQuote->getItemById($boltCartItem->reference);
+            if ( !($cartItem instanceof Mage_Sales_Model_Quote_Item) ) { continue; }
 
             $cartItem->shouldNotBeValidated = false;
             Mage::dispatchEvent(
@@ -927,13 +921,33 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
      */
     public function removePreAuthOrder($order) {
         if ($this->isBoltOrder($order)) {
+
+            $parentQuote = $this->getParentQuoteFromOrder($order);
+
+            ##############################################################
+            # Cancel order for restocking inventory and triggering events
+            ##############################################################
             if ($order->getStatus() !== 'canceled_bolt') {
-                $order->cancel()->setQuoteId(null)->setStatus('canceled_bolt')->save();
+                $order->setQuoteId(null)->save();
+                $order->cancel()->setStatus('canceled_bolt')->save();
             }
+            ##############################################################
+
+            ###########################################################
+            # Permanently delete order
+            ###########################################################
+            if ($this->boltHelper()->getExtraConfig('keepPreAuthOrders')) {return;}
             $previousStoreId = Mage::app()->getStore()->getId();
             Mage::app()->setCurrentStore(Mage_Core_Model_App::ADMIN_STORE_ID);
             $order->delete();
             Mage::app()->setCurrentStore($previousStoreId);
+            ###########################################################
+
+            ##########################################################
+            # Unblock quote to allow order to be re-processed
+            ##########################################################
+            $parentQuote->setIsActive(true)->save();
+            ###########################################################
         }
     }
 
@@ -991,4 +1005,5 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             $this->boltHelper()->logWarning($e->getMessage());
         }
     }
+
 }

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -208,20 +208,18 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
             $transaction = $this->getRequestData();
             $displayId = $transaction->order->cart->display_id;
 
+            /** @var  Bolt_Boltpay_Model_Order $orderModel */
+            $orderModel = Mage::getModel('boltpay/order');
+            $immutableQuoteId = $this->boltHelper()->getImmutableQuoteIdFromTransaction($transaction);
+
             if (strpos($displayId, '|') !== false) {
                 /* This is when the order has not already been created, nor order success URL sent to Bolt */
-
-                $immutableQuoteId = $this->boltHelper()->getImmutableQuoteIdFromTransaction($transaction);
-
-                /** @var  Bolt_Boltpay_Model_Order $orderModel */
-                $orderModel = Mage::getModel('boltpay/order');
                 $order = $orderModel->getOrderByQuoteId($immutableQuoteId);
-                benchmark( "Finished looking up order by quote id" );
+                benchmark( "Finished looking up order details by quote id" );
             } else {
                 /* @var Mage_Sales_Model_Order $order */
                 $order = Mage::getModel('sales/order')->loadByIncrementId($displayId);
-                benchmark( "Finished looking up order by display id" );
-                $immutableQuoteId = $order->getQuoteId();
+                benchmark( "Finished looking up order details by display id" );
             }
 
             if ($order->isObjectNew()) {
@@ -364,28 +362,6 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
             //////////////////////////////////////////////////////////////////////////////////////
 
             $orderModel->removePreAuthOrder($order);
-        }
-
-        ////////////////////////////////////////////////////////////////////
-        /// We treat Bolt initiated failed payment cancels to be the same as a directive
-        /// to expire the cached immutable quote that is stored in the session,
-        /// otherwise, the Bolt checkout could result in a locked state where the end
-        /// user will repeatedly be told that his cart has expired and to refresh. However,
-        /// since we are operating outside the session we cannot directly clear
-        /// the cache session from data
-        ///
-        /// Instead, we mark the Bolt order token cache to be expired by setting
-        /// the parent quote to be the parent quote of itself.  We take care of this
-        /// via an observer that watches for this condition.  This will preserve
-        /// native abandoned cart behavior while not marking the quote for
-        /// cleanup.
-        ////////////////////////////////////////////////////////////////////
-
-        $parentQuote = $orderModel->getParentQuoteFromOrder($order);
-        if ($parentQuote->getId()) {
-            $parentQuote
-                ->setParentQuoteId($parentQuote->getId())
-                ->save();
         }
 
         $this->sendResponse(


### PR DESCRIPTION
# Description
This replaces PR #495 

Quotes are not being blocked for processing after failed_payment hooks.  After a create preauth order is deleted due to failed_payment, (after 10 minutes or immediately if that option is enabled), the quote would be reported as expired due to the order having been created. The manifestation of this in orphaned transactions is a failed webhook with the same error message.

This unblocks the quotes to allow orders to be re-created after failed_payments. 

Fixes: https://app.asana.com/0/inbox/544708310157128/1136200477398193/1136201003916971

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
