### PR TITLE
Makes coupon code comparison case-insensitive

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -579,8 +579,10 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
                 $couponExists = (bool) $magentoCoupon->getId();
 
                 if ($couponExists) {
-                    $magentoCouponCodes = $immutableQuote->getCouponCode() ? explode(',', (string) $immutableQuote->getCouponCode()) : array();
-                    if (!in_array($boltCoupon->reference, $magentoCouponCodes)) {
+                    $magentoCouponCodes = $immutableQuote->getCouponCode()
+                        ? explode(',', strtolower((string) $immutableQuote->getCouponCode()))
+                        : array();
+                    if (!in_array(strtolower($boltCoupon->reference), $magentoCouponCodes)) {
                         /** @var Mage_SalesRule_Model_Rule $rule */
                         $rule = (@$cachedRules[$magentoCoupon->getRuleId()]) ?: Mage::getModel('salesrule/rule')->load($magentoCoupon->getRuleId());
                         $toTime = $rule->getToDate() ? ((int) strtotime($rule->getToDate()) + Mage_CatalogRule_Model_Resource_Rule::SECONDS_IN_DAY - 1) : 0;


### PR DESCRIPTION
# Description
Magento looks up coupon codes in a case-insensitive way.  Our coupon code comparison should therefore follow suite.

Fixes: https://app.asana.com/0/941895179897714/1138749880537314

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
