### PR TITLE
Fixed passing argument in "notifyException" function.

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
@@ -56,7 +56,7 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
             $_product = Mage::registry('current_product');
             if (!$_product) {
                 $msg = 'Bolt: Cannot find product info';
-                $this->boltHelper()->notifyException($msg);
+                $this->boltHelper()->notifyException(new Exception($msg));
                 return '""';
             }
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
@@ -7,11 +7,6 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
     private $app;
 
     /**
-     * @var int|null
-     */
-    private static $productId = null;
-
-    /**
      * @var Bolt_Boltpay_TestHelper|null
      */
     private $testHelper = null;


### PR DESCRIPTION
# Description
After investigating an error, i found that one argument is incorrect.:
```
unable to fetch shipping&Tax info for merchant:[411], division:[472]: APIError(47) Error while unmarshalling shipping and tax response: [200][Fatal error:  Call to a member function getMessage() on string in /usr/share/nginx/tadashishoji.com/app/code/community/Bolt/Boltpay/Helper/BugsnagTrait.php on line 107
```

Fixes: no link.

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
