### PR TITLE
Disable sending void requests to Bolt if the request came from Bolt

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -367,6 +367,22 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
         }
     }
 
+    /**
+     * Check void availability
+     *
+     * @param   Varien_Object $payment
+     * @return  bool
+     */
+    public function canVoid(Varien_Object $payment)
+    {
+        // Disable sending void requests to Bolt if the request came from Bolt
+        if (Bolt_Boltpay_Helper_Data::$fromHooks){
+            return false;
+        }
+
+        return parent::canVoid($payment);
+    }
+
     public function void(Varien_Object $payment)
     {
         try {

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
@@ -7,11 +7,6 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
     private $app;
 
     /**
-     * @var int|null
-     */
-    private static $productId = null;
-
-    /**
      * @var Bolt_Boltpay_TestHelper|null
      */
     private $testHelper = null;
@@ -209,6 +204,14 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
         $orderPayment = new Mage_Sales_Model_Order_Payment();
         $orderPayment->setAdditionalInformation('bolt_transaction_status', Bolt_Boltpay_Model_Payment::TRANSACTION_REJECTED_REVERSIBLE);
         $this->assertTrue($this->_currentMock->canReviewPayment($orderPayment));
+    }
+
+    public function testCannotVoidIfTheRequestIsFromBolt()
+    {
+        $orderPayment = new Mage_Sales_Model_Order_Payment();
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
+
+        $this->assertFalse($this->_currentMock->canVoid($orderPayment));
     }
 
     /**


### PR DESCRIPTION
**Issue:**
Whenever we cancel/void a transaction from Bolt, a void hook request is sent to Magento. It attempts to cancel the Magento order which sends back a void Bolt transaction and there is an exception that occurs as the Bolt transaction is already canceled.

**Proposal solution:**
Disable sending a void request to Bolt if the request is from Bolt

Fixes: https://app.asana.com/0/564264490825835/1139242847263129

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] I have created or modified unit tests to sufficiently cover my changes.
