### PR TITLE
Reactivate used promotion after deleting failed order due to auth failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If you would like to pull the latest Bolt code from the Git repo and update Mage
 | bolt_boltpay_validate_totals_before | global | Entry for altering the behavior of subtotal validation prior to standard subtotal validation.  Each subtotal validation may be canceled by setting to false the respective values for _transaction->shouldDoTaxTotalValidation_, _$transaction->shouldDoDiscountTotalValidation_, and _$transaction->shouldDoShippingTotalValidation_ | **quote**<br>_Mage_Sales_Model_Quote_<br>the Magento cart copy of the Bolt order<br><br>**transaction**<br>_object_<br>Bolt payload |
 | bolt_boltpay_validate_totals_after | global | Entry for adding additional subtotal validation behavior performed after standard subtotal validation | **quote**<br>_Mage_Sales_Model_Quote_<br>the Magento cart copy of the Bolt order<br><br>**transaction**<br>_object_<br>Bolt payload |
 | bolt_boltpay_admin_normalize_order_data_after | global | Entry for additional normalization of admin order data performed after standard order data normalization | **request**<br>_Zend_Controller_Request_Abstract_<br>request object containing the post data to the order creation controller call<br><br>**orderCreateModel**<br>_Mage_Adminhtml_Model_Sales_Order_Create_<br>order create model |
+| bolt_boltpay_failed_order_removed_after | global | Execute after deleting the failed order | **order**<br>_Mage_Sales_Model_Order_<br>removed order object |
 
 ## Custom Bolt Filter Event Reference
 

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -837,7 +837,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 
         $session->unsBoltUserId();
     }
-    
+
     /**
      * Sends an email if an order email has not already been sent.
      *
@@ -941,6 +941,8 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             $previousStoreId = Mage::app()->getStore()->getId();
             Mage::app()->setCurrentStore(Mage_Core_Model_App::ADMIN_STORE_ID);
             $order->delete();
+            Mage::dispatchEvent('bolt_boltpay_failed_order_removed_after', array('order' => $order));
+            $this->reactivateUsedPromotion($order);
             Mage::app()->setCurrentStore($previousStoreId);
             ###########################################################
 
@@ -949,6 +951,37 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             ##########################################################
             $parentQuote->setIsActive(true)->save();
             ###########################################################
+        }
+    }
+
+    /**
+     * Reactivates the promotion if it was used in failed orders
+     *
+     * @param Mage_Sales_Model_Order $order
+     */
+    public function reactivateUsedPromotion(Mage_Sales_Model_Order $order)
+    {
+        try {
+            /** @var Bolt_Boltpay_Model_Coupon $couponModel */
+            $couponModel = Mage::getModel('boltpay/coupon');
+            $customerId = $order->getCustomerId();
+
+            if ($code = $order->getCouponCode()){
+                $coupon = $couponModel->decreaseCouponTimesUsed($code);
+                if ($customerId){
+                    $couponModel->decreaseCustomerCouponTimesUsed($customerId, $coupon);
+                }
+            }
+
+            $ruleIds = explode(',', $order->getAppliedRuleIds());
+            if ($ruleIds && $customerId){
+                foreach ($ruleIds as $ruleId) {
+                    $couponModel->decreaseCustomerRuleTimesUsed($customerId, $ruleId);
+                }
+            }
+        } catch (\Exception $e) {
+            $this->boltHelper()->logException($e);
+            $this->boltHelper()->notifyException($e);
         }
     }
 


### PR DESCRIPTION
If a customer is using a limited use coupon (e.g. one-time use coupon), and their initial auth fails (payment denied, etc), the failed hook deletes the order but doesn’t restore their coupon usage to not having been used. This fix restores the coupon usage to the pre-order creation state.

Fixes: https://app.asana.com/0/564264490825835/1139660501761065

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
