### PR TITLE
Prevent accidentally changing a processing order status to a pending bolt authorization status

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -127,8 +127,13 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
     {
         $stateObject
             ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
-            ->setStatus('pending_bolt')
             ->setIsNotified(false);
+
+        if ($this->isAdminArea()){
+            $stateObject->setStatus('pending');
+        } else {
+            $stateObject->setStatus('pending_bolt');
+        }
 
         return parent::initialize($paymentAction, $stateObject);
     }
@@ -138,7 +143,7 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
      */
     public function isAdminArea()
     {
-        return (Mage::app()->getStore()->isAdmin() && Mage::getDesign()->getArea() === 'adminhtml');
+        return (Mage::app()->getStore()->isAdmin() || Mage::getDesign()->getArea() === 'adminhtml');
     }
 
     public function getConfigData($field, $storeId = null)


### PR DESCRIPTION
This prevents the following case:

The administrator creates an order which shows the current order status as Pending Bolt Authorization. They then comment on the order after Bolt has changed the status to something other than Pending Bolt Authorization and it changes the status back to Pending Bolt Authorization when the comment is submitted. This then causes the order to no longer show up in the admin order grid.

Fixes: https://app.asana.com/0/564264490825835/1139660501761068

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
