### PR TITLE
Feature/configurable shipping controller timeout

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
@@ -261,6 +261,18 @@ JS;
     }
 
     /**
+     * Defines the default value for shipping and tax timeout to be 30 seconds
+     *
+     * @param int|string $rawConfigValue    The config value pre-filter. Will be an int for seconds or an empty string
+     * @param array      $additionalParams  unused for this filter
+     *
+     * @return int  the number of seconds defined in the extra config admin.  If not defined, the default of 30
+     */
+    public function filterShippingTimeout($rawConfigValue, $additionalParams = array()) {
+        return is_int($rawConfigValue) ? abs($rawConfigValue) : 30;
+    }
+
+    /**
      * Defines the default value as a 1 cent tolerance for Bolt and Magento grand total
      * difference
      *

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -56,8 +56,8 @@ class Bolt_Boltpay_ShippingController
     public function indexAction()
     {
         try {
-
-            set_time_limit(30);
+            $timeout = $this->boltHelper()->getExtraConfig('shippingTimeout');
+            set_time_limit($timeout);
             ignore_user_abort(true);
 
             $requestData = $this->getRequestData();


### PR DESCRIPTION
# Description
Bolt server-side sets a hard timeout at 15 seconds, however many merchants need more processing time than this to calculate shipping and tax.  We continue processing after Bolt times out to allow for the estimates to be cached and immediately available upon a subsequent call.  This PR allows this value, which defaults to 30 seconds to be configurable on each server

Fixes: https://app.asana.com/0/941895179897714/1139778770614417

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
