### PR TITLE
Set initial back-office order state to new

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -126,13 +126,16 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
     public function initialize($paymentAction, $stateObject)
     {
         $stateObject
-            ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
             ->setIsNotified(false);
 
         if ($this->isAdminArea()){
-            $stateObject->setStatus('pending');
+            $stateObject
+                ->setState(Mage_Sales_Model_Order::STATE_NEW)
+                ->setStatus('pending');
         } else {
-            $stateObject->setStatus('pending_bolt');
+            $stateObject
+                ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
+                ->setStatus('pending_bolt');
         }
 
         return parent::initialize($paymentAction, $stateObject);


### PR DESCRIPTION
After creating a back-office order, the state is set to pending_payment. This introduces the possibility of recreating the bug stated in PR https://github.com/BoltApp/bolt-magento1/pull/511 as the dropdown status contains all of the statuses that belong to pending_payment including the pending_bolt status, see here https://screencast.com/t/CIyJK6POGY. Setting the state to “new” resolves this.

Fixes: https://app.asana.com/0/941895179897714/1141138267580345

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
