### PR TITLE
Prevents duplicate JSON output + implement immediate response flushing

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ProductpageController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ProductpageController.php
@@ -46,6 +46,9 @@ class Bolt_Boltpay_ProductpageController
             $this->sendResponse($productCartModel->getResponseHttpCode(), $productCartModel->getResponseBody());
         } catch (Exception $e) {
             // unexpected error
+            $this->boltHelper()->notifyException($e);
+            $this->boltHelper()->logException($e);
+
             $this->sendResponse(422, array(
                 'status' => 'failure',
                 'error'  =>
@@ -54,9 +57,6 @@ class Bolt_Boltpay_ProductpageController
                         'message' => $e->getMessage()
                     )
             ));
-
-            $this->boltHelper()->notifyException($e);
-            $this->boltHelper()->logException($e);
         }
     }
 

--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -117,7 +117,6 @@ class Bolt_Boltpay_ShippingController
                     422,
                     array('status' => 'failure','error' => $addressErrorDetails)
                 );
-                return;
             }
             ////////////////////////////////////////////////////////////////////////////////
 
@@ -184,7 +183,6 @@ class Bolt_Boltpay_ShippingController
             $this->sendResponse(
                 200
             );
-            return;
         }
 
         $requiredAddressFields = array('city'=>'','region'=>'','region_id'=>'','postcode'=>'','country_id'=>'');


### PR DESCRIPTION
# Description
Prevents duplicate API response output in all case.  It also implements the response in such a way that it can be flushed to Bolt while processing of other jobs can occur like third party post order creation code

Fixes: https://app.asana.com/0/941895179897714/1136224221711409/f

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
