### PR TITLE
Automatically create an invoice after creating the shipment if createInvoiceAfterCreatingShipment setting is set to yes

### DIFF
--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -130,6 +130,15 @@
           </bolt_boltpay_safeguard_preauth_status>
         </observers>
       </sales_order_save_before>
+      <sales_order_shipment_save_after>
+        <observers>
+          <bolt_custom_model_observer>
+            <type>singleton</type>
+            <class>Bolt_Boltpay_Model_Observer</class>
+            <method>createInvoiceAfterCreatingShipment</method>
+          </bolt_custom_model_observer>
+        </observers>
+      </sales_order_shipment_save_after>
     </events>
 
     <sales>


### PR DESCRIPTION
Automatically create an invoice after creating the shipment if createInvoiceAfterCreatingShipment setting is set to yes

# Description
Automatically create an invoice after creating the shipment if createInvoiceAfterCreatingShipment setting is set to yes in the admin

Fixes: https://app.asana.com/0/564264490825835/1143014593457481

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
