### PR TITLE
Does not send void request to Bolt on hooks that cancel the order

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -428,11 +428,17 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
     }
 
     /**
-     * Cancel is the same as void
+     * Voids an item at the Bolt server side
+     *
+     * @param Varien_Object $payment      The payment for the transaction to be voided
+     *
+     * @return Bolt_Boltpay_Model_Payment|Mage_Payment_Model_Abstract   The payment for the transaction to be voided
+     *
+     * @throws Exception    if there is a problem voiding an order at Bolt
      */
     public function cancel(Varien_Object $payment)
     {
-        return $this->void($payment);
+        return $this->canVoid($payment) ? $this->void($payment) : $this;
     }
 
     public function handleOrderUpdate(Varien_Object $order)


### PR DESCRIPTION
# Description
Fixes errors that were being thrown as a result of webhooks trying to void an already voided orders

Fixes: https://app.asana.com/0/inbox/544708310157128/1132767436522534/1142647842364511

https://app.bugsnag.com/bolt/magento/errors/5d95565a6419b9001b5d71a3?filters[event.since][0][type]=eq&filters[event.since][0][value]=30d&filters[search][0][type]=eq&filters[search][0][value]=already&filters[search][1][type]=eq&filters[search][1][value]=voided

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
