### PR TITLE
Automatically create an invoice after creating the shipment 

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
@@ -106,6 +106,13 @@ trait Bolt_Boltpay_Helper_ConfigTrait {
     }
 
     /**
+     * @return mixed
+     */
+    public function getAutoCreateInvoiceAfterCreatingShipment(){
+        return Mage::getStoreConfig('payment/boltpay/auto_create_invoice_after_creating_shipment');
+    }
+
+    /**
      * Get config value from specific bolt config and depending on checkoutType.
      *
      * @param $configPath

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -130,6 +130,15 @@
           </bolt_boltpay_safeguard_preauth_status>
         </observers>
       </sales_order_save_before>
+      <sales_order_shipment_save_after>
+        <observers>
+          <bolt_boltpay_create_invoice_after_creating_shipment>
+            <type>singleton</type>
+            <class>Bolt_Boltpay_Model_Observer</class>
+            <method>createInvoiceAfterCreatingShipment</method>
+          </bolt_boltpay_create_invoice_after_creating_shipment>
+        </observers>
+      </sales_order_shipment_save_after>
     </events>
 
     <sales>
@@ -282,6 +291,7 @@
         <use_javascript_in_admin>0</use_javascript_in_admin>
         <add_button_everywhere>0</add_button_everywhere>
         <sort_order>0</sort_order>
+        <auto_create_invoice_after_creating_shipment>0</auto_create_invoice_after_creating_shipment>
       </boltpay>
     </payment>
   </default>

--- a/app/code/community/Bolt/Boltpay/etc/system.xml
+++ b/app/code/community/Bolt/Boltpay/etc/system.xml
@@ -451,6 +451,15 @@ This function is called when the Bolt checkout modal is closed.
               <show_in_store>1</show_in_store>
               <frontend_class>validate-number</frontend_class>
             </sort_order>
+            <auto_create_invoice_after_creating_shipment>
+              <label>Automatically create an invoice after creating a shipmentt</label>
+              <frontend_type>select</frontend_type>
+              <source_model>adminhtml/system_config_source_yesno</source_model>
+              <sort_order>145</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>1</show_in_store>
+            </auto_create_invoice_after_creating_shipment>
             <extra_options translate="label">
               <label>Extra config</label>
               <frontend_type>textarea</frontend_type>


### PR DESCRIPTION
Automatically create an invoice after creating the shipment 

# Description
Some merchants can’t capture until shipment, but also don’t want to have to manually capture once a shipment is created (e.g. ERP system generates a shipment, etc). This code allows merchants to auto-invoice after creating shipments.

Fixes: https://app.asana.com/0/564264490825835/1143014593457481

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
