### PR TITLE
Email Support for older Magento versions

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -852,7 +852,9 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
     {
         try {
             if (!$order->getEmailSent()) {
-                $order->queueNewOrderEmail();
+                $emailWasSent = method_exists($order, 'queueNewOrderEmail')
+                    ? $order->queueNewOrderEmail()
+                    : $order->sendNewOrderEmail();
                 $history = $order->addStatusHistoryComment( $this->boltHelper()->__('Email sent for order %s', $order->getIncrementId()) );
                 $history->setIsCustomerNotified(true);
             }


### PR DESCRIPTION
# Description
Older version of Magento like 1.9.0.1 and before do not support queuing emails.  We must add backwards support direct sending of emails for these versions

Fixes: https://app.asana.com/0/search/1143688623668737/1143055455198289

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have created or modified unit tests to sufficiently cover my changes.
