### PR TITLE
Handles the piped display ID case in failed_payment hooks

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -41,14 +41,15 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
             $reference = $requestData->reference;
             $transactionId = @$requestData->transaction_id ?: $requestData->id;
             $hookType = @$requestData->notification_type ?: $requestData->type;
-            $incrementId = @$requestData->display_id;
+            $incrementId = (strpos(@$requestData->display_id, '|') !== false)
+                ? explode("|", $requestData->display_id)[0]
+                : @$requestData->display_id;
 
             /** @var Bolt_Boltpay_Model_Order $orderModel */
             $orderModel = Mage::getModel('boltpay/order');
 
             if ($hookType === 'failed_payment') {
-                $displayId = $requestData->display_id;
-                $this->handleFailedPaymentHook($displayId);
+                $this->handleFailedPaymentHook($incrementId);
                 return;
             } else if ($hookType === 'discounts.code.apply') {
                 $this->handleDiscountHook();

--- a/tests/unit/testsuite/Bolt/Boltpay/controllers/ApiControllerTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/controllers/ApiControllerTest.php
@@ -142,4 +142,73 @@ class Bolt_Boltpay_ApiControllerTest extends PHPUnit_Framework_TestCase
         );
         $this->assertTrue(self::$_mockOrder->isCanceled());
     }
+
+    /**
+     *  Test makes sure that the non-piped format of display_id is supported for failed_payment hooks
+     */
+    public function testHookAction_thatStandardDisplayIdIsSupportedForFailedPayment() {
+
+        /** @var Bolt_Boltpay_ApiController|PHPUnit_Framework_MockObject_MockObject $apiControllerMock */
+        $apiControllerMock = $this->_apiControllerBuilder
+            ->setMethods(['getRequestData', 'handleFailedPaymentHook'])
+            ->getMock();
+
+        ///////////////////////////////////////////////////////////////////////
+        /// Create a pseudo transaction data and map to request and responses
+        ///////////////////////////////////////////////////////////////////////
+        $stubbedRequestData = new stdClass();
+        $stubbedRequestData->reference = 'TEST-BOLT-TRNX';
+        $stubbedRequestData->id = 'TRboltx0test1';
+        $stubbedRequestData->type = 'failed_payment';
+        $stubbedRequestData->display_id = '9876543210';
+
+        /** @var Bolt_Boltpay_ApiController|PHPUnit_Framework_MockObject_MockObject $apiControllerMock */
+        $apiControllerMock = $this->_apiControllerBuilder
+            ->setMethods(['getRequestData', 'handleFailedPaymentHook'])
+            ->getMock();
+
+        $apiControllerMock->method('getRequestData')->willReturn($stubbedRequestData);
+        $apiControllerMock
+            ->expects($this->once())
+            ->method('handleFailedPaymentHook')
+            ->with($this->equalTo('9876543210'));
+
+        ######################################
+        # Calling the subject method
+        ######################################
+        $apiControllerMock->hookAction();
+        ######################################
+    }
+
+    /**
+     *  Test makes sure that the piped format of display_id is supported for failed_payment hooks
+     */
+    public function testHookAction_thatPipedDisplayIdIsSupportedForFailedPayment() {
+
+        /** @var Bolt_Boltpay_ApiController|PHPUnit_Framework_MockObject_MockObject $apiControllerMock */
+        $apiControllerMock = $this->_apiControllerBuilder
+            ->setMethods(['getRequestData', 'handleFailedPaymentHook'])
+            ->getMock();
+
+        ///////////////////////////////////////////////////////////////////////
+        /// Create a pseudo transaction data and map to request and responses
+        ///////////////////////////////////////////////////////////////////////
+        $stubbedRequestData = new stdClass();
+        $stubbedRequestData->reference = 'TEST-BOLT-TRNX';
+        $stubbedRequestData->id = 'TRboltx0test1';
+        $stubbedRequestData->type = 'failed_payment';
+        $stubbedRequestData->display_id = '1234567890|44444';
+
+        $apiControllerMock->method('getRequestData')->willReturn($stubbedRequestData);
+        $apiControllerMock
+            ->expects($this->once())
+            ->method('handleFailedPaymentHook')
+            ->with($this->equalTo('1234567890'));
+
+        ######################################
+        # Calling the subject method
+        ######################################
+        $apiControllerMock->hookAction();
+        ######################################
+    }
 }


### PR DESCRIPTION
# Description
Failed_Payment hooks can send the piped format of display_id.  This situation was not handled and causes an order to be reported as canceled and handled when in fact it was not.  This adds support for the piped display_id

Fixes: https://app.asana.com/0/inbox/544708310157128/1146968193990481/1146969926976082

#changelog Handles the piped display ID case in failed_payment hooks

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.