### PR TITLE
Adds a defensive pre-auth order cron cleanup in case other mechanisms fail

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Cron.php
+++ b/app/code/community/Bolt/Boltpay/Model/Cron.php
@@ -24,6 +24,12 @@ class Bolt_Boltpay_Model_Cron
 {
     use Bolt_Boltpay_BoltGlobalTrait;
 
+    /*
+     * We will have a conservative tolerance of 6 hours for non-confirmed pre-auth orders before we allow the system
+     * to remove them
+     */
+    const PRE_AUTH_STATE_TIME_LIMIT_MINUTES = 600;
+
     /**
      * After an immutable quote / unused generated session quote on PDP has existed for 2 weeks or more, we remove it from the system.
      * At this point, only the order object is relevant for converted orders and any immutable
@@ -33,15 +39,71 @@ class Bolt_Boltpay_Model_Cron
      * immutable quotes.  We delegate cleanup responsibility of these to the merchants.
      */
     public function cleanupQuotes() {
-        $sales_flat_quote_table = Mage::getSingleton('core/resource')->getTableName('sales/quote');
-        $sales_flat_order_table = Mage::getSingleton('core/resource')->getTableName('sales/order');
+        try {
+            $sales_flat_quote_table = Mage::getSingleton('core/resource')->getTableName('sales/quote');
+            $sales_flat_order_table = Mage::getSingleton('core/resource')->getTableName('sales/order');
 
-        $expiration_time = Mage::getModel('core/date')->date('Y-m-d H:i:s', time()-(60*60*24*7*2));
+            $expiration_time = Mage::getModel('core/date')->date('Y-m-d H:i:s', time()-(60*60*24*7*2));
 
-        $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
+            $connection = Mage::getSingleton('core/resource')->getConnection('core_write');
 
-        $sql = "DELETE sfq FROM $sales_flat_quote_table sfq LEFT JOIN $sales_flat_order_table sfo ON sfq.entity_id = sfo.quote_id WHERE (((sfq.parent_quote_id IS NOT NULL) AND (sfq.parent_quote_id < sfq.entity_id)) OR ((sfq.parent_quote_id IS NULL) AND (sfq.is_bolt_pdp = true))) AND (sfq.updated_at <= '$expiration_time') AND (sfo.entity_id IS NULL)";
+            $sql = "DELETE sfq FROM $sales_flat_quote_table sfq LEFT JOIN $sales_flat_order_table sfo ON sfq.entity_id = sfo.quote_id WHERE (((sfq.parent_quote_id IS NOT NULL) AND (sfq.parent_quote_id < sfq.entity_id)) OR ((sfq.parent_quote_id IS NULL) AND (sfq.is_bolt_pdp = true))) AND (sfq.updated_at <= '$expiration_time') AND (sfo.entity_id IS NULL)";
 
-        $connection->query($sql);
+            $connection->query($sql);
+        } catch ( Exception $e ) {
+            $this->boltHelper()->notifyException($e, array(), 'warning');
+            $this->boltHelper()->logWarning($e->getMessage());
+        }
+    }
+
+    /**
+     * After a pre-auth pending order has existed for 15 minutes or more, we remove it from the system.
+     * At this point, Bolt should have called the "failed_payment" webhook to do this. We are catching
+     * the anomaly cases where the "failed_payment" mechanism is not implemented
+     *
+     * ( e.g. when the Bolt server-side is configured to ignore the pre-auth flow on timeouts or "abnormal responses"
+     * and authorization fails. )
+     */
+    public function cleanupOrders() {
+        try {
+            $expiration_time = Mage::getSingleton('core/date')
+                ->gmtDate('Y-m-d H:i:s', time()-(60*PRE_AUTH_STATE_TIME_LIMIT_MINUTES));  // Magento uses GMT to save in DB
+
+            /* @var Mage_Sales_Model_Resource_Order_Collection $orderCollection */
+            $orderCollection = Mage::getModel('sales/order')->getCollection();
+
+            /** @var Mage_Sales_Model_Order $deletePendingPaymentOrdersBeforeThis */
+            $deletePendingPaymentOrdersBeforeThis = $orderCollection
+                ->addFieldToFilter('created_at', array( 'gte' => $expiration_time))
+                ->setOrder('created_at', 'ASC')
+                ->getFirstItem();
+
+            /* @var Mage_Sales_Model_Resource_Order_Collection $expiredPendindOrderCollection */
+            $expiredPendingPaymentOrderCollection = Mage::getModel('sales/order')->getCollection();
+            $expiredPendingPaymentOrderCollection
+                ->addFieldToFilter('entity_id', array( 'lt' => $deletePendingPaymentOrdersBeforeThis->getId()))
+                ->addFieldToFilter('status', Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING)
+            ;
+
+            $ordersToRemove = $expiredPendingPaymentOrderCollection->getItems();
+
+            /** @var Bolt_Boltpay_Model_Order $orderModel */
+            $orderModel = Mage::getModel('boltpay/order');
+
+            /** @var Mage_Sales_Model_Order $order */
+            foreach($ordersToRemove as $order) {
+                try {
+                    $orderModel->removePreAuthOrder($order);
+                } catch (Exception $e) {
+                    // catch, report and clobber so that we can continue with the queue of orders
+                    $this->boltHelper()->notifyException($e, array(), 'warning');
+                    $this->boltHelper()->logWarning($e->getMessage());
+                }
+            }
+        } catch ( Exception $e ) {
+            // Catch-all for unexpected exceptions
+            $this->boltHelper()->notifyException($e, array(), 'warning');
+            $this->boltHelper()->logWarning($e->getMessage());
+        }
     }
 }

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -966,6 +966,8 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             if ($this->boltHelper()->getExtraConfig('keepPreAuthOrders')) {return;}
             $previousStoreId = Mage::app()->getStore()->getId();
             Mage::app()->setCurrentStore(Mage_Core_Model_App::ADMIN_STORE_ID);
+            $adminEntry = Mage::getModel('sales/order_grid')->load($order->getId());
+            $adminEntry->delete();
             $order->delete();
             Mage::dispatchEvent('bolt_boltpay_failed_order_removed_after', array('order' => $order));
             $this->reactivateUsedPromotion($order);

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -295,6 +295,14 @@
           <model>boltpay/cron::cleanupQuotes</model>
         </run>
       </immutable_quote_cleanup>
+      <preauth_order_cleanup>
+        <schedule>
+          <cron_expr>*/20 * * * *</cron_expr>
+        </schedule>
+        <run>
+          <model>boltpay/cron::cleanupOrders</model>
+        </run>
+      </preauth_order_cleanup>
     </jobs>
   </crontab>
 </config>

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/CronTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/CronTest.php
@@ -1,0 +1,139 @@
+<?php
+
+require_once('OrderHelper.php');
+
+class Bolt_Boltpay_Model_CronTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Bolt_Boltpay_Model_Cron The subject object which is actually a true unstubbed instance of the class
+     */
+    private $_currentMock;
+
+    /**
+     * @var int|null Dummy product ID used in all orders
+     */
+    private static $productId = null;
+
+    /**
+     * Initialization before each test.  We currently create a fresh Bolt_Boltpay_Model_Cron model for each test
+     */
+    public function setUp()
+    {
+        $this->_currentMock = Mage::getModel('boltpay/cron');
+    }
+
+    /**
+     * Generates a dummy product used for creating test orders once and only once before any test in this class are run
+     */
+    public static function setUpBeforeClass()
+    {
+        self::$productId = Bolt_Boltpay_ProductProvider::createDummyProduct('PHPUNIT_TEST_1', array(), 20);
+    }
+
+    /**
+     * Delete dummy products after all test of this class have run
+     */
+    public static function tearDownAfterClass()
+    {
+        Bolt_Boltpay_ProductProvider::deleteDummyProduct(self::$productId);
+    }
+
+    /**
+     * Test to see if the cron will delete pending_payment Bolt orders that are older than 15 minutes while leaving all
+     * other orders
+     *
+     * @throws Mage_Core_Exception       on failure to create or delete a dummy order
+     */
+    public function testCleanupOrders()
+    {
+        $cron = $this->_currentMock;
+
+        $pendingPaymentOrders = [];
+        $paidOrders = [];
+        $ordersPastExpiration = [];
+        $activeOrders = [];
+
+        // Create dummy orders
+        for ($i = 0; $i < 5; $i++) {
+            for ($j = rand(1,3); $j > 0; $j--) {
+                $order = Bolt_Boltpay_OrderHelper::createDummyOrder(self::$productId, 1, 'boltpay');
+                if ($i%2) {
+                    $order
+                        ->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT)
+                        ->setStatus(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING);
+                    $pendingPaymentOrders[$order->getId()] = $order;
+                } else {
+                    $order
+                        ->setState(Mage_Sales_Model_Order::STATE_PROCESSING)
+                        ->setStatus(Mage_Sales_Model_Order::STATE_PROCESSING);
+                    $paidOrders[$order->getId()] = $order;
+                }
+                $order->save();
+
+                if ($i >= 2) {
+                    $order->setCreatedAt(Mage::getSingleton('core/date')->gmtDate('Y-m-d H:i:s', time()-(60*20)));
+                    $order->save();
+                    $ordersPastExpiration[$order->getId()] = $order;
+                } else {
+                    $activeOrders[$order->getId()] = $order;
+                }
+            }
+        }
+
+        ////////////////////////////////
+        // Call subject method
+        ////////////////////////////////
+        $cron->cleanupOrders();
+        ////////////////////////////////
+
+        $casesCovered = [];
+        // Check for preserved orders
+        foreach ( $activeOrders as $id => $activeOrder ) {
+            /** @var Mage_Sales_Model_Order $foundOrder */
+            $foundOrder = Mage::getModel('sales/order')->load( $id );
+            $this->assertFalse($foundOrder->isObjectNew());
+            if ( array_key_exists($id, $paidOrders) ) {
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $activeOrder->getState());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $activeOrder->getStatus());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $foundOrder->getState());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $foundOrder->getStatus());
+                $casesCovered['active|preserved|processing'] = true;
+            } else {
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, $activeOrder->getState());
+                $this->assertEquals(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, $activeOrder->getStatus());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, $foundOrder->getState());
+                $this->assertEquals(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, $foundOrder->getStatus());
+                $casesCovered['active|preserved|pending_payment'] = true;
+            }
+            Bolt_Boltpay_OrderHelper::deleteDummyOrder($activeOrder);
+        }
+
+        // Check that expired pending_payment orders were deleted while others preserved
+        foreach ( $ordersPastExpiration as $id => $expiredOrder ) {
+            /** @var Mage_Sales_Model_Order $foundOrder */
+            $foundOrder = Mage::getModel('sales/order')->load( $id );
+            if ( array_key_exists($id, $paidOrders) ) {
+                $this->assertFalse($foundOrder->isObjectNew());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $expiredOrder->getState());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $expiredOrder->getStatus());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $foundOrder->getState());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $foundOrder->getStatus());
+                $casesCovered['expired|preserved|processing'] = true;
+            } else {
+                $this->assertArrayHasKey($id, $pendingPaymentOrders);
+                $this->assertTrue($foundOrder->isObjectNew());
+                $this->assertEquals(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, $expiredOrder->getState());
+                $this->assertEquals(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, $expiredOrder->getState());
+                $this->assertEmpty($foundOrder->getState());
+                $this->assertEmpty($foundOrder->getStatus());
+                $casesCovered['expired|deleted|pending_payment'] = true;
+            }
+            Bolt_Boltpay_OrderHelper::deleteDummyOrder($expiredOrder);
+        }
+
+        $this->assertEquals(4, count($casesCovered));
+    }
+
+}
+


### PR DESCRIPTION
# Description
Initially proposed as PR #385

After a pre-auth pending order has existed for 15 minutes or more, we remove it from the system.
At this point, Bolt should have called the "failed_payment" webhook to do this. We are catching
the anomaly cases where this mechanism fails.  This will resolve any outstanding pending_payment Bolt orders on production servers.

Fixes: https://app.asana.com/0/1125081140214268/1146968193990481/f

#changelog  Internal order artifact cleanup routines

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.