### PR TITLE
Expose an endpoint for LoadTesting

### DIFF
--- a/tests/load/setup_files/CartDataLoadTest.php
+++ b/tests/load/setup_files/CartDataLoadTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Bolt magento plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Class Bolt_Boltpay_Model_CartDataLoadTest
+ *
+ * The Magento Model class that creates a cart and saves it to the session for LoadTesting
+ *
+ */
+class Bolt_Boltpay_Model_CartDataLoadTest extends Bolt_Boltpay_Model_Abstract
+{
+    /**
+     * Adds the given items to a cart and saves it to the checkout session
+     *
+     * @return  void
+     *
+     */
+    public function saveCart($cart_items) {
+        // add items to a cart
+        $quote = Mage::getSingleton('checkout/session')->getQuote();
+        foreach ($cart_items as $item) {
+            $product = Mage::getModel('catalog/product')->load($item->id);
+            $quote->addProduct($product, 1);
+        }
+        // save the cart to the session
+        $quote->collectTotals()->save();
+    }
+}

--- a/tests/load/setup_files/CartDataLoadTest.php
+++ b/tests/load/setup_files/CartDataLoadTest.php
@@ -29,10 +29,10 @@ class Bolt_Boltpay_Model_CartDataLoadTest extends Bolt_Boltpay_Model_Abstract
      * @return  void
      *
      */
-    public function saveCart($cart_items) {
+    public function saveCart($cartItems) {
         // add items to a cart
         $quote = Mage::getSingleton('checkout/session')->getQuote();
-        foreach ($cart_items as $item) {
+        foreach ($cartItems as $item) {
             $product = Mage::getModel('catalog/product')->load($item->id);
             $quote->addProduct($product, 1);
         }

--- a/tests/load/setup_files/CartDataLoadTestController.php
+++ b/tests/load/setup_files/CartDataLoadTestController.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Bolt magento plugin
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Bolt
+ * @package    Bolt_Boltpay
+ * @copyright  Copyright (c) 2019 Bolt Financial, Inc (https://www.bolt.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Class Bolt_Boltpay_CartDataLoadTestController
+ *
+ * Cart Data Load Test Endpoint.
+ */
+class Bolt_Boltpay_CartDataLoadTestController
+    extends Mage_Core_Controller_Front_Action implements Bolt_Boltpay_Controller_Interface
+{
+    use Bolt_Boltpay_Controller_Traits_WebHookTrait;
+
+    /**
+     * @var Bolt_Boltpay_Model_CartDataLoadTest  Object that creates the cart and saves it to the session
+     */
+    protected $_cartDataLoadTest;
+
+    /**
+     * Initializes Controller member variables
+     */
+    protected function _construct()
+    {
+        $this->_cartDataLoadTest = Mage::getModel("boltpay/cartDataLoadTest");
+    }
+
+    /**
+     * Receives json formated request from a Load test,
+     * containing cart with an array of cart items in
+     * format: {"cart":[{"id": 1} ... ]}
+     * Responds with order_token and order_reference
+     * of the order that is created in Bolt.
+     */
+    public function indexAction()
+    {
+        try {
+            // creates a cart in session
+            $cart_items = $this->getRequestData()->cart;
+            $this->_cartDataLoadTest->saveCart($cart_items);
+
+            // OrderControllerTrait::createAction():
+            $boltpayCheckout = Mage::app()->getLayout()->createBlock('boltpay/checkout_boltpay');
+            /** @var Mage_Sales_Model_Quote $quote */
+            $quote = $boltpayCheckout->getSessionQuote(Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE);
+
+            // OrderControllerTrait::getCartData():
+            /** @var Bolt_Boltpay_Model_BoltOrder $boltOrder */
+            $boltOrder = Mage::getModel('boltpay/boltOrder');
+
+            $cart_data = $boltOrder->getCachedCartData($quote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE);
+
+            if (!$cart_data) {
+                $immutableQuote = $boltOrder->cloneQuote($quote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE);
+                $cart_data = $boltpayCheckout->buildCartData($boltOrder->getBoltOrderToken($immutableQuote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE));
+            }
+
+            $this->getResponse()->setHeader('Content-type', 'application/json', true);
+            $cart_data["order_reference"] = $immutableQuote->getParentQuoteId();
+            $responseJSON = json_encode($cart_data, JSON_PRETTY_PRINT);
+            $this->sendResponse(
+                200,
+                $responseJSON
+            );
+        } catch (Exception $e) {
+            $metaData = array();
+            if (isset($quote)){
+                $metaData['quote'] = var_export($quote->debug(), true);
+            }
+            $this->sendResponse(
+                422,
+                $e->getMessage()
+            );
+
+            $this->boltHelper()->notifyException($e, $metaData);
+            $this->boltHelper()->logException($e, $metaData);
+        }
+    }
+}

--- a/tests/load/setup_files/CartDataLoadTestController.php
+++ b/tests/load/setup_files/CartDataLoadTestController.php
@@ -49,8 +49,8 @@ class Bolt_Boltpay_CartDataLoadTestController
     {
         try {
             // creates a cart in session
-            $cart_items = $this->getRequestData()->cart;
-            $this->_cartDataLoadTest->saveCart($cart_items);
+            $cartItems = $this->getRequestData()->cart;
+            $this->_cartDataLoadTest->saveCart($cartItems);
 
             // OrderControllerTrait::createAction():
             $boltpayCheckout = Mage::app()->getLayout()->createBlock('boltpay/checkout_boltpay');
@@ -61,16 +61,16 @@ class Bolt_Boltpay_CartDataLoadTestController
             /** @var Bolt_Boltpay_Model_BoltOrder $boltOrder */
             $boltOrder = Mage::getModel('boltpay/boltOrder');
 
-            $cart_data = $boltOrder->getCachedCartData($quote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE);
+            $cartData = $boltOrder->getCachedCartData($quote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE);
 
-            if (!$cart_data) {
+            if (!$cartData) {
                 $immutableQuote = $boltOrder->cloneQuote($quote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE);
-                $cart_data = $boltpayCheckout->buildCartData($boltOrder->getBoltOrderToken($immutableQuote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE));
+                $cartData = $boltpayCheckout->buildCartData($boltOrder->getBoltOrderToken($immutableQuote, Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE));
             }
 
             $this->getResponse()->setHeader('Content-type', 'application/json', true);
-            $cart_data["order_reference"] = $immutableQuote->getParentQuoteId();
-            $responseJSON = json_encode($cart_data, JSON_PRETTY_PRINT);
+            $cartData["order_reference"] = $immutableQuote->getParentQuoteId();
+            $responseJSON = json_encode($cartData, JSON_PRETTY_PRINT);
             $this->sendResponse(
                 200,
                 $responseJSON

--- a/tests/load/setup_files/README.md
+++ b/tests/load/setup_files/README.md
@@ -1,0 +1,6 @@
+# Load Test Setup 
+1. Create an M1 store as described here: [Configure Store on Lightsail](https://www.notion.so/boltteam/Creating-Stores-in-Lightsail-c1457819c4ba454fbb668ca76d50ad87)
+
+2. Configure Bolt on your M1 store as described here: [Configure Bolt](https://docs.bolt.com/docs/magento-1-integration)
+
+3. Then run `source setup.sh`

--- a/tests/load/setup_files/setup.sh
+++ b/tests/load/setup_files/setup.sh
@@ -1,0 +1,4 @@
+cp CartDataLoadTest.php /var/www/html/app/code/community/Bolt/Boltpay/Model/
+cp CartDataLoadTestController.php /var/www/html/app/code/community/Bolt/Boltpay/controllers/
+php -f /var/www/html/shell/compile.php clear
+php -f /var/www/html/shell/compile.php compile

--- a/tests/load/setup_files/setup.sh
+++ b/tests/load/setup_files/setup.sh
@@ -1,4 +1,4 @@
 cp CartDataLoadTest.php /var/www/html/app/code/community/Bolt/Boltpay/Model/
 cp CartDataLoadTestController.php /var/www/html/app/code/community/Bolt/Boltpay/controllers/
-php -f /var/www/html/shell/compile.php clear
-php -f /var/www/html/shell/compile.php compile
+php -f /var/www/html/shell/compiler.php clear
+php -f /var/www/html/shell/compiler.php compile


### PR DESCRIPTION
# Description
This PR allows devs to easily setup a test store and expose an endpoint that triggers the part of the plugin that is responsible for turning a cart on M1 into a bolt order. This allows us to load test a part of the plugin that is not directly exposed by an endpoint. 

Note: The actual load tests will be included in a separate PR (https://github.com/BoltApp/bolt-magento1/pull/545)

Fixes: https://app.asana.com/0/941895179897714/1149771740841853/f

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ x ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ x ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.