### PR TITLE
Allow method initBoltButtons to be available even when the cart is empty

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
@@ -54,8 +54,7 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
         $canQuoteUseBolt = $this->isBoltPayActive()
             && (!$checkCountry || ($checkCountry && $this->canUseForCountry($quote->getBillingAddress()->getCountry())))
             && (Mage::app()->getStore()->getCurrentCurrencyCode() == 'USD')
-            && (Mage::app()->getStore()->getBaseCurrencyCode() == 'USD')
-            && count($quote->getAllVisibleItems()) > 0;
+            && (Mage::app()->getStore()->getBaseCurrencyCode() == 'USD');
 
         Mage::app()->setCurrentStore($applicationContextStore);
         return $canQuoteUseBolt;

--- a/app/design/frontend/base/default/template/boltpay/replace.phtml
+++ b/app/design/frontend/base/default/template/boltpay/replace.phtml
@@ -195,13 +195,15 @@ $additionalClasses = $this->boltHelper()->getAdditionalButtonClasses();
         }
     };
 
-    if (document.addEventListener) {
-        document.addEventListener("DOMContentLoaded", initBoltButtons);
-    } else if (window.attachEvent) {
-        window.attachEvent("onload", initBoltButtons);
-    } else {
-        window.onload = initBoltButtons;
-    }
+    <?php if(count($this->getQuote()->getAllVisibleItems()) > 0):?>
+        if (document.addEventListener) {
+            document.addEventListener("DOMContentLoaded", initBoltButtons);
+        } else if (window.attachEvent) {
+            window.attachEvent("onload", initBoltButtons);
+        } else {
+            window.onload = initBoltButtons;
+        }
+    <?php endif; ?>
 
     <?=$this->getAdditionalJs();?>
 </script>

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
@@ -136,6 +136,16 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->dataHelper->canUseBolt($quote));
     }
 
+    public function testCanUseBoltReturnsTrueIfCartIsEmpty()
+    {
+        $this->app->getStore()->setConfig('payment/boltpay/active', 1);
+        $this->app->getStore()->setConfig('payment/boltpay/allowspecific', 0);
+        $this->testHelper->createCheckout('guest');
+        $quote = Mage::getModel('sales/quote');
+
+        $this->assertTrue($this->dataHelper->canUseBolt($quote));
+    }
+
     /**
      * @inheritdoc
      */


### PR DESCRIPTION
# Description
Currently, if a merchant customizes their default add to cart process to use an Ajax request, after adding the first product to the cart, the initBoltButtons method isn’t available to initialize the Bolt button in the mini cart. This PR allows that method to be available even when the cart is empty but only executes it when the cart isn’t empty.

Fixes: https://app.asana.com/0/564264490825835/1149765095655042


#changelog Allow method initBoltButtons to be available even when the cart is empty

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.