### PR TITLE
Fixes 'hidden' failures in Bolt_Boltpay_Model_CronTest

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Cron.php
+++ b/app/code/community/Bolt/Boltpay/Model/Cron.php
@@ -66,17 +66,17 @@ class Bolt_Boltpay_Model_Cron
      */
     public function cleanupOrders() {
         try {
-            $expiration_time = Mage::getSingleton('core/date')
-                ->gmtDate('Y-m-d H:i:s', time()-(60*PRE_AUTH_STATE_TIME_LIMIT_MINUTES));  // Magento uses GMT to save in DB
+            $expiration_time = gmdate('Y-m-d H:i:s', time()-(60*self::PRE_AUTH_STATE_TIME_LIMIT_MINUTES));  // Magento uses GMT to save in DB
 
             /* @var Mage_Sales_Model_Resource_Order_Collection $orderCollection */
             $orderCollection = Mage::getModel('sales/order')->getCollection();
 
+             $orderCollection
+                ->addFieldToFilter('created_at', array( 'gteq' => $expiration_time))
+                ->setOrder('created_at', 'ASC');
+
             /** @var Mage_Sales_Model_Order $deletePendingPaymentOrdersBeforeThis */
-            $deletePendingPaymentOrdersBeforeThis = $orderCollection
-                ->addFieldToFilter('created_at', array( 'gte' => $expiration_time))
-                ->setOrder('created_at', 'ASC')
-                ->getFirstItem();
+            $deletePendingPaymentOrdersBeforeThis = $orderCollection->getFirstItem();
 
             /* @var Mage_Sales_Model_Resource_Order_Collection $expiredPendindOrderCollection */
             $expiredPendingPaymentOrderCollection = Mage::getModel('sales/order')->getCollection();

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/CronTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/CronTest.php
@@ -4,6 +4,10 @@ require_once('OrderHelper.php');
 
 class Bolt_Boltpay_Model_CronTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * A time in minutes padded to test entry timestamps to make them eligible for cleanup
+     */
+    const MINUTES_PADDING_FOR_TEST_ENTRY_TIMESTAMPS = 3;
 
     /**
      * @var Bolt_Boltpay_Model_Cron The subject object which is actually a true unstubbed instance of the class
@@ -28,7 +32,7 @@ class Bolt_Boltpay_Model_CronTest extends PHPUnit_Framework_TestCase
      */
     public static function setUpBeforeClass()
     {
-        self::$productId = Bolt_Boltpay_ProductProvider::createDummyProduct('PHPUNIT_TEST_1', array(), 20);
+        self::$productId = Bolt_Boltpay_ProductProvider::createDummyProduct(uniqid('PHPUNIT_TEST_'), array(), 20);
     }
 
     /**
@@ -54,9 +58,14 @@ class Bolt_Boltpay_Model_CronTest extends PHPUnit_Framework_TestCase
         $ordersPastExpiration = [];
         $activeOrders = [];
 
+        $cleanupDate = gmdate(
+            'Y-m-d H:i:s',
+            time()-(60*(Bolt_Boltpay_Model_Cron::PRE_AUTH_STATE_TIME_LIMIT_MINUTES+self::MINUTES_PADDING_FOR_TEST_ENTRY_TIMESTAMPS))
+        );
+
         // Create dummy orders
         for ($i = 0; $i < 5; $i++) {
-            for ($j = rand(1,3); $j > 0; $j--) {
+            for ($j = rand(2,3); $j > 0; $j--) {
                 $order = Bolt_Boltpay_OrderHelper::createDummyOrder(self::$productId, 1, 'boltpay');
                 if ($i%2) {
                     $order
@@ -71,8 +80,8 @@ class Bolt_Boltpay_Model_CronTest extends PHPUnit_Framework_TestCase
                 }
                 $order->save();
 
-                if ($i >= 2) {
-                    $order->setCreatedAt(Mage::getSingleton('core/date')->gmtDate('Y-m-d H:i:s', time()-(60*20)));
+                if ($i < 2) {
+                    $order->setCreatedAt($cleanupDate);
                     $order->save();
                     $ordersPastExpiration[$order->getId()] = $order;
                 } else {
@@ -124,7 +133,7 @@ class Bolt_Boltpay_Model_CronTest extends PHPUnit_Framework_TestCase
                 $this->assertArrayHasKey($id, $pendingPaymentOrders);
                 $this->assertTrue($foundOrder->isObjectNew());
                 $this->assertEquals(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, $expiredOrder->getState());
-                $this->assertEquals(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, $expiredOrder->getState());
+                $this->assertEquals(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, $expiredOrder->getStatus());
                 $this->assertEmpty($foundOrder->getState());
                 $this->assertEmpty($foundOrder->getStatus());
                 $casesCovered['expired|deleted|pending_payment'] = true;
@@ -132,8 +141,8 @@ class Bolt_Boltpay_Model_CronTest extends PHPUnit_Framework_TestCase
             Bolt_Boltpay_OrderHelper::deleteDummyOrder($expiredOrder);
         }
 
+        // make sure that we have create found and handled at least one order for each case
         $this->assertEquals(4, count($casesCovered));
     }
 
 }
-


### PR DESCRIPTION
# Description
Due to an oversight with output buffering affecting the reporting of unit test failures, several failed test have been going unnoticed under the radar.  These changes fix the test and/or tested object to restore M1 Unit test is good standing.

Fixes: https://app.asana.com/0/544708310157130/1151537717819187

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.