### PR TITLE
Fixes 'hidden' failures in Bolt_Boltpay_Block_Rewrite_OnepageTest

### DIFF
--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Rewrite/OnepageTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Rewrite/OnepageTest.php
@@ -32,6 +32,7 @@ class Bolt_Boltpay_Block_Rewrite_OnepageTest extends PHPUnit_Framework_TestCase
     public function testStepsWhenSkipPaymentIsTrue()
     {
         $this->app->getStore()->setConfig('payment/boltpay/skip_payment', 1);
+        $this->app->getStore()->setConfig('payment/boltpay/active', 1);
         $onepageRewrite = new $this->onepageRewriteClass;
 
         $result = array(


### PR DESCRIPTION
# Description
Due to an oversight with output buffering affecting the reporting of unit test failures, several failed test have been going unnoticed under the radar.  These changes fix the test and/or tested object to restore M1 Unit test is good standing.

Fixes: https://app.asana.com/0/544708310157130/1151537717819189

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.