### PR TITLE
Fixes 'hidden' failures in Bolt_Boltpay_ShippingControllerTest

### DIFF
--- a/tests/unit/testsuite/Bolt/Boltpay/controllers/ShippingControllerTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/controllers/ShippingControllerTest.php
@@ -10,7 +10,7 @@ require_once 'Bolt/Boltpay/controllers/ShippingController.php';
 class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var Bolt_Boltpay_ShippingController The stubbed shipping controller
+     * @var Bolt_Boltpay_ShippingController|PHPUnit_Framework_MockObject_MockObject The stubbed shipping controller
      */
     private $_shippingController;
 
@@ -44,9 +44,12 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
+        // Empty shopping cart
+        Mage::getSingleton('checkout/cart')->truncate();
+
         $this->_shippingController = $this->getMockBuilder( "Bolt_Boltpay_ShippingController")
             ->setConstructorArgs( array( new Mage_Core_Controller_Request_Http(), new Mage_Core_Controller_Response_Http()) )
-            ->setMethods(['boltHelper', 'getResponse'])
+            ->setMethods(['boltHelper', 'getResponse', 'sendResponse'])
             ->getMock();
 
         $stubbedBoltHelper = $this->getMockBuilder('Bolt_Boltpay_Helper_Data')
@@ -110,11 +113,10 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
         // Create some dummy product:
         self::$_productIds = array
         (
-            Bolt_Boltpay_ProductProvider::createDummyProduct('PHPUNIT_SC_TEST_PROD_01'),
-            Bolt_Boltpay_ProductProvider::createDummyProduct('PHPUNIT_SC_TEST_PROD_02'),
-            Bolt_Boltpay_ProductProvider::createDummyProduct('PHPUNIT_SC_TEST_PROD_03'),
+            Bolt_Boltpay_ProductProvider::createDummyProduct(uniqid('PHPUNIT_TEST_')),
+            Bolt_Boltpay_ProductProvider::createDummyProduct(uniqid('PHPUNIT_TEST_')),
+            Bolt_Boltpay_ProductProvider::createDummyProduct(uniqid('PHPUNIT_TEST_'))
         );
-
     }
 
     /**
@@ -143,6 +145,17 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
 
         /** @var Mage_Sales_Model_Quote $quote */
         $quote = Mage::getSingleton('checkout/session')->getQuote();
+        $store = Mage::app()->getStore();
+        $quote->setStore($store);
+
+        $quoteSubtotal = 0;
+        foreach(self::$_productIds as $productId) {
+            $product = Mage::getModel('catalog/product')->load($productId);
+            $qty = rand(1,3);
+            $quoteItem = Mage::getModel('sales/quote_item')->setProduct($product)->setQty($qty);
+            $quote->addItem($quoteItem);
+            $quoteSubtotal += ($qty * $product->getPrice());
+        }
 
         $shipping_address = array(
             'firstname' => $this->_customer->getFirstname(),
@@ -156,15 +169,11 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
         $quote->getShippingAddress()->addData($shipping_address);
 
         $quote->setCustomer($this->_customer);
-
         $quote->setCustomerTaxClassId(3);
 
-        foreach(self::$_productIds as $productId) {
-            $this->testHelper->addProduct($productId, rand(1,3));
-        }
-
+        $quote->setParentQuoteId($quote->getId());  # stub the parent quote by assigning the ID to the cloned quote
         $quote->setTotalsCollectedFlag(false);
-        $quote->collectTotals()->save();
+        $quote->collectTotals()->setBaseSubtotalWithDiscount($quoteSubtotal)->save();
 
         $expectedAddressData = array(
             'city'       => 'Beverly Hills',
@@ -173,9 +182,9 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
             'region' => 'California',
             'postcode' => '90210'
         );
+
         $expectedCacheId = $this->_shippingController->getEstimateCacheIdentifier($quote, $expectedAddressData);
         $estimatePreCall = unserialize(Mage::app()->getCache()->load($expectedCacheId));
-
 
         $geoIpAddressData = array(
             'city'       => 'Beverly Hills',
@@ -190,10 +199,22 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
         $reflectedPayload->setAccessible(true);
         $reflectedPayload->setValue($this->_shippingController, json_encode($geoIpAddressData));
 
+        $actualResponse = '';
+        $this->_shippingController->expects($this->once())
+            ->method('sendResponse')
+            ->with(
+                200,
+                $this->callback(
+                    function($response) use (&$actualResponse) {
+                        return $actualResponse = $response;
+                    }
+                )
+            )
+        ;
+
         $this->_shippingController->prefetchEstimateAction();
 
-        $actualAddressData = json_decode($this->_shippingController->getResponse()->getBody(), true)['address_data'];
-
+        $actualAddressData =  json_decode($actualResponse, true)['address_data'];
         $actualCacheId = $this->_shippingController->getEstimateCacheIdentifier($quote, $actualAddressData);
         $estimatePostCall = unserialize(Mage::app()->getCache()->load($actualCacheId));
 
@@ -267,17 +288,23 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
             'shipping_address' => $boltFormatShippingAddress
         );
 
-
-        $reflectedPayload = $reflectedShippingController->getProperty('payload');
-        $reflectedPayload->setAccessible(true);
-        $reflectedPayload->setValue($this->_shippingController, json_encode($mockBoltRequestData));
-
         ////////////////////////////////////////////////////////
         // Make first call that should not have a cache value
         ////////////////////////////////////////////////////////
+        $firstCallEstimate = '';
+        Bolt_Boltpay_TestHelper::setNonPublicProperty( $this->_shippingController, 'payload', json_encode($mockBoltRequestData));
+        $this->_shippingController->expects($this->once())
+            ->method('sendResponse')
+            ->with(
+                200,
+                $this->callback(
+                    function($response) use (&$firstCallEstimate) {
+                        return $firstCallEstimate = $response;
+                    }
+                )
+            )
+        ;
         $this->_shippingController->indexAction();
-        $firstCallEstimate = json_decode($this->_shippingController->getResponse()->getBody(), true);
-        $firstCallHeaders = $this->_shippingController->getResponse()->getHeaders();
         $firstCallHitOrMiss = $this->_cacheBoltHeader;
         ////////////////////////////////////////////////////////
 
@@ -285,9 +312,21 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
         ////////////////////////////////////////////////////////
         // Make a second call that should be read from the cache
         ////////////////////////////////////////////////////////
+        $this->reset();
+        $secondCallEstimate = '';
+        Bolt_Boltpay_TestHelper::setNonPublicProperty( $this->_shippingController, 'payload', json_encode($mockBoltRequestData));
+        $this->_shippingController->expects($this->once())
+            ->method('sendResponse')
+            ->with(
+                200,
+                $this->callback(
+                    function($response) use (&$secondCallEstimate) {
+                        return $secondCallEstimate = $response;
+                    }
+                )
+            )
+        ;
         $this->_shippingController->indexAction();
-        $secondCallEstimate = json_decode($this->_shippingController->getResponse()->getBody(), true);
-        $secondCallHeaders = $this->_shippingController->getResponse()->getHeaders();
         $secondCallHitOrMiss = $this->_cacheBoltHeader;
         ////////////////////////////////////////////////////////
 
@@ -296,6 +335,7 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
         // Make a third call with a different address.
         // It should not be read from the cache
         ////////////////////////////////////////////////////////
+        $this->reset();
         $boltFormatShippingAddress['locality'] = 'Columbus';
         $boltFormatShippingAddress['region'] = 'Ohio';
         $boltFormatShippingAddress['postal_code'] = '43235';
@@ -310,12 +350,21 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
         );
         $modifiedAddressExpectedCacheId = $this->_shippingController->getEstimateCacheIdentifier($quote, $modifiedMagentoFormatAddressData);
 
+        Bolt_Boltpay_TestHelper::setNonPublicProperty( $this->_shippingController, 'payload', json_encode($mockBoltRequestData));
 
-        $reflectedPayload->setValue($this->_shippingController, json_encode($mockBoltRequestData));
-
+        $thirdCallEstimate = '';
+        $this->_shippingController->expects($this->once())
+            ->method('sendResponse')
+            ->with(
+                200,
+                $this->callback(
+                    function($response) use (&$thirdCallEstimate) {
+                        return $thirdCallEstimate = $response;
+                    }
+                )
+            )
+        ;
         $this->_shippingController->indexAction();
-        $thirdCallEstimate = json_decode($this->_shippingController->getResponse()->getBody(), true);
-        $thirdCallHeaders = $this->_shippingController->getResponse()->getHeaders();
         $thirdCallHitOrMiss = $this->_cacheBoltHeader;
         ////////////////////////////////////////////////////////
 
@@ -324,11 +373,22 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
         // Make a fourth call with the original data
         // It should be read from the cache
         ////////////////////////////////////////////////////////
-        $reflectedPayload->setValue($this->_shippingController, json_encode($originalMockBoltRequestData));
+        $this->reset();
+        Bolt_Boltpay_TestHelper::setNonPublicProperty( $this->_shippingController, 'payload', json_encode($originalMockBoltRequestData));
 
+        $fourthCallEstimate = '';
+        $this->_shippingController->expects($this->once())
+            ->method('sendResponse')
+            ->with(
+                200,
+                $this->callback(
+                    function($response) use (&$fourthCallEstimate) {
+                        return $fourthCallEstimate = $response;
+                    }
+                )
+            )
+        ;
         $this->_shippingController->indexAction();
-        $fourthCallEstimate = json_decode($this->_shippingController->getResponse()->getBody(), true);
-        $fourthCallHeaders = $this->_shippingController->getResponse()->getHeaders();
         $fourthCallHitOrMiss = $this->_cacheBoltHeader;
         ////////////////////////////////////////////////////////
 
@@ -343,5 +403,17 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals( $thirdCallHitOrMiss, 'MISS' );
         $this->assertEquals( $fourthCallHitOrMiss, 'HIT' );
 
+    }
+
+    /**
+     * Resets the conditions for internal retest of the same method
+     * @todo Replace this implementation with annotations using "@dataProvider"
+     *
+     * @throws ReflectionException on unexpected problems with reflection
+     * @throws Zend_Controller_Request_Exception on unexpected problem in creating the controller
+     */
+    private function reset() {
+        $this->tearDown();
+        $this->setUp();
     }
 }


### PR DESCRIPTION
# Description
Due to an oversight with output buffering affecting the reporting of unit test failures, several failed test have been going unnoticed under the radar.  These changes fix the test and/or tested object to restore M1 Unit test is good standing.

Fixes: https://app.asana.com/0/544708310157130/1151537717819191

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.