### PR TITLE
fixed incorrectly set price, correctly register/unregister mocks

### DIFF
--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Catalog/Product/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Catalog/Product/BoltpayTest.php
@@ -128,8 +128,8 @@ class Bolt_Boltpay_Block_Catalog_Product_BoltpayTest extends PHPUnit_Framework_T
     {
         Mage::app()->getStore()->setCurrentCurrencyCode(self::CURRENCY_CODE);
 
+        $this->productMock->setId(9876543210);
         $this->productMock->method('isInStock')->willReturn(true);
-        $this->productMock->method('getId')->willReturn(9876543210);
         $this->productMock->method('getFinalPrice')->willReturn(self::PRODUCT_PRICE);
         $this->productMock->method('getImageUrl')->willReturn("https://bolt.com/image.png");
         $this->productMock->method('getName')->willReturn("Metal Bolts");


### PR DESCRIPTION
# Description
The price was incorrectly mismatched at 10 and 12.75.  This corrects this.  Also, unregistering of the the singleton mocks is best down after each test class so that there is no chance of accidental use in subsequent test classes.

Fixes: https://app.asana.com/0/search/1151708266934314/1150161568554697

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
