### PR TITLE
expectations for exceptions implemented with deprecated setExpectedException

### DIFF
--- a/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
@@ -222,20 +222,13 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
 
         $mockBoltHelper->expects($this->never())->method('logWarning');
 
-        try {
-            TestHelper::callNonPublicFunction(
-                $this->testClassMock,
-                'validateTotals',
-                [$mockImmutableQuote, $mockTransaction]
-            );
-        } catch (Bolt_Boltpay_OrderCreationException $oce ) {
-            $this->assertContains(
-                'Discount total has changed',
-                $oce->getMessage()
-            );
-            return;
-        }
-        $this->fail("Expected a Bolt_Boltpay_OrderCreationException to be thrown but it was not.");
+        $this->setExpectedException(Bolt_Boltpay_OrderCreationException::class, 'Discount total has changed');
+
+        TestHelper::callNonPublicFunction(
+            $this->testClassMock,
+            'validateTotals',
+            [$mockImmutableQuote, $mockTransaction]
+        );
     }
 
     /**
@@ -256,24 +249,16 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
         $mockImmutableQuote->setCouponCode('BOLT10POFF');
         $mockBoltHelper->expects($this->never())->method('logWarning');
 
-        try {
-            TestHelper::callNonPublicFunction(
-                $this->testClassMock,
-                'validateTotals',
-                [$mockImmutableQuote, $mockTransaction]
-            );
-        } catch (Bolt_Boltpay_OrderCreationException $oce ) {
-            $this->assertContains(
-                'Discount amount has changed',
-                $oce->getMessage()
-            );
-            $this->assertContains(
-                'BOLT10POFF',
-                $oce->getMessage()
-            );
-            return;
-        }
-        $this->fail("Expected a Bolt_Boltpay_OrderCreationException to be thrown but it was not.");
+        $this->setExpectedExceptionRegExp(
+            Bolt_Boltpay_OrderCreationException::class,
+            "/.*Discount amount has changed.*BOLT10POFF.*/"
+        );
+
+        TestHelper::callNonPublicFunction(
+            $this->testClassMock,
+            'validateTotals',
+            [$mockImmutableQuote, $mockTransaction]
+        );
     }
 
 


### PR DESCRIPTION
# Description
Exception expectations implemented with PHPUnit5.2 deprecated setExpectedException

Fixes: https://app.asana.com/0/544708310157130/1147324810049189

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
