### PR TITLE
Bugfix/track js on normal pages

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -516,6 +516,9 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
      * page and which key has been set in the admin.  Cart and Product pages prioritize the multi-step key
      * and falls back to the payment only key.  All other pages prioritize the payment only key and falls back
      * to the multi-step key.
+     *
+     * @return string   The publishable key to be used on this page
+     * @throws Bolt_Boltpay_BoltException when neither a multi-step nor a payment-only publishable key is configured
      */
     public function getPublishableKeyForThisPage() {
         $routeName = $this->getRequest()->getRouteName();
@@ -534,7 +537,7 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
         if (!$multiStepPublishableKey && !$paymentOnlyPublishableKey) {
             $noPublishableKeyException = new Bolt_Boltpay_BoltException("No publishable key has been configured.");
             $this->boltHelper()->logException($noPublishableKeyException);
-            $this->boltHelper()->notifyException($noPublishableKeyException,[],'error');
+            $this->boltHelper()->notifyException($noPublishableKeyException, [], 'error');
             throw $noPublishableKeyException;
         }
 

--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -512,6 +512,36 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
     }
 
     /**
+     * Returns the One Page or Multi-Page checkout Publishable key depending on the requested
+     * page and which key has been set in the admin.  Cart and Product pages prioritize the multi-step key
+     * and falls back to the payment only key.  All other pages prioritize the payment only key and falls back
+     * to the multi-step key.
+     */
+    public function getPublishableKeyForThisPage() {
+        $routeName = $this->getRequest()->getRouteName();
+        $controllerName = $this->getRequest()->getControllerName();
+
+        $multiStepPublishableKey = $this->getPublishableKey('multi-page');
+        $paymentOnlyPublishableKey = $this->getPublishableKey('one-page');
+
+        $thisPagesPublishableKey =
+            $controllerName === 'cart'
+            || ($routeName === 'catalog' && $controllerName === 'product')
+                ? $multiStepPublishableKey
+                : $paymentOnlyPublishableKey
+        ;
+
+        if (!$multiStepPublishableKey && !$paymentOnlyPublishableKey) {
+            $noPublishableKeyException = new Bolt_Boltpay_BoltException("No publishable key has been configured.");
+            $this->boltHelper()->logException($noPublishableKeyException);
+            $this->boltHelper()->notifyException($noPublishableKeyException,[],'error');
+            throw $noPublishableKeyException;
+        }
+
+        return $thisPagesPublishableKey ?: max($multiStepPublishableKey, $paymentOnlyPublishableKey);
+    }
+
+    /**
      * Returns the One Page / Multi-Page checkout Publishable key.
      *
      * @param  string $checkoutType  'multi-page' | 'one-page' | 'admin'

--- a/app/design/frontend/base/default/template/boltpay/track.phtml
+++ b/app/design/frontend/base/default/template/boltpay/track.phtml
@@ -19,18 +19,13 @@
 <?php
 $versionElm =  Mage::getConfig()->getModuleConfig("Bolt_Boltpay")->xpath("version");
 $version = (string)$versionElm[0];
-$routeName = $this->getRequest()->getRouteName();
-$controllerName = $this->getRequest()->getControllerName();
-/* TODO: extend key selection for mini-cart if necessary */
 ?>
 <?php if($this->isBoltActive()): ?>
     <script
             id="bolt-track"
             type="text/javascript"
             src="<?= $this->getTrackJsUrl(); ?>"
-            data-publishable-key="<?=$this->getPublishableKey((Mage::app()->getRequest()->getControllerName() === 'cart'
-                || ($routeName === 'catalog' && $controllerName === 'product'))
-                ? 'multi-page' : 'one-page'); ?>">
+            data-publishable-key="<?=$this->getPublishableKeyForThisPage();?>">
     </script>
     <script>console.log("Bolt M1 Version: <?=$version?>");</script>
 <?php endif; ?>

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -45,7 +45,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         Mage::unregister('_helper/boltpay');
         $this->helperMock = $this->getMockBuilder('Bolt_Boltpay_Helper_Data')
             ->setMethods(
-                ['notifyException', 'logException']
+                array('notifyException', 'logException')
             )
             ->getMock();
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -530,7 +530,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         $actualPaymentOnlyKey = $this->app->getStore()->getConfig('payment/boltpay/publishable_key_onepage');
 
         $this->currentMock->getPublishableKeyForThisPage();
-        $this->assertFalse($actualMultiStepKey || $actualPaymentOnlyKey);
+        $this->assertFalse($actualMultiStepKey || $actualPaymentOnlyKey, "No key should be configured: multi [$actualMultiStepKey], paymentOnly [$actualPaymentOnlyKey]");
         $this->assertEquals($multiStepKey, $actualMultiStepKey);
         $this->assertEquals($paymentOnlyKey, $actualPaymentOnlyKey);
     }

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -367,138 +367,138 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      * unexpected page identified by route and controller name for
      * {@see Bolt_Boltpay_Block_Checkout_BoltpayTest::getPublishableKeyForThisPage_withAtLeastOneKeyConfigured()}
      *
-     * @return array[] in the format of [$multiStepKey, $paymentOnlyKey, $routeName, $controllerName, $predictedReturnValue]
+     * @return array[] in the format of [$multiStepKey, $paymentOnlyKey, $routeName, $controllerName, $expectedReturnValue]
      */
     public function getPublishableKeyForThisPage_withAtLeastOneKeyConfiguredProvider()
     {
         return [
+            "When both keys exist on standard cart page, multi-step is used" =>
             [
-                # When both keys exist on standard cart page, multi-step is used
                 "multiStepKey" => "multi+payOnly-key-on-standard-cart",
                 "paymentOnlyKey" => "payOnly+multi-key-on-standard-cart",
                 "routeName" => "checkout",
                 "controllerName" => "cart",
-                "predictedReturnValue" => "multi+payOnly-key-on-standard-cart"
+                "expectedReturnValue" => "multi+payOnly-key-on-standard-cart"
             ],
+            "When only multi-step key exists on standard cart page, empty string payment-only, multi-step is used" =>
             [
-                # When only multi-step key exists on standard cart page, empty string payment-only, multi-step is used
                 "multiStepKey" => "multi-key-on-standard-cart",
                 "paymentOnlyKey" => "",
                 "routeName" => "checkout",
                 "controllerName" => "cart",
-                "predictedReturnValue" => "multi-key-on-standard-cart"
+                "expectedReturnValue" => "multi-key-on-standard-cart"
             ],
+            "When only multi-step key exists on standard cart page, null payment-only, multi-step is used" =>
             [
-                # When only multi-step key exists on standard cart page, null payment-only, multi-step is used
                 "multiStepKey" => "multi-key-on-standard-cart",
                 "paymentOnlyKey" => null,
                 "routeName" => "checkout",
                 "controllerName" => "cart",
-                "predictedReturnValue" => "multi-key-on-standard-cart"
+                "expectedReturnValue" => "multi-key-on-standard-cart"
             ],
+            "When only payment-only key exists on standard cart page, null multi-step, payment-only is used" =>
             [
-                # When only payment-only key exists on standard cart page, null multi-step, payment-only is used
                 "multiStepKey" => "",
                 "paymentOnlyKey" => "payOnly-key-on-standard-cart",
                 "routeName" => "checkout",
                 "controllerName" => "cart",
-                "predictedReturnValue" => "payOnly-key-on-standard-cart"
+                "expectedReturnValue" => "payOnly-key-on-standard-cart"
             ],
+            "When both keys exist on custom cart page, multi-step is used" =>
             [
-                # When both keys exist on custom cart page, multi-step is used
                 "multiStepKey" => "multi+payOnly-key-on-custom-cart",
                 "paymentOnlyKey" => "payOnly+multi-key-on-custom-cart",
                 "routeName" => "custom",
                 "controllerName" => "cart",
-                "predictedReturnValue" => "multi+payOnly-key-on-custom-cart"
+                "expectedReturnValue" => "multi+payOnly-key-on-custom-cart"
             ],
+            "When only multi-step key exists on custom cart page, null payment-only, multi-step is used" =>
             [
-                # When only multi-step key exists on custom cart page, null payment-only, multi-step is used
                 "multiStepKey" => "multi-key-on-custom-cart",
                 "paymentOnlyKey" => null,
                 "routeName" => "custom",
                 "controllerName" => "cart",
-                "predictedReturnValue" => "multi-key-on-custom-cart"
+                "expectedReturnValue" => "multi-key-on-custom-cart"
             ],
+            "When only payment-only key exists on custom cart page, null multi-step, payment-only is used" =>
             [
-                # When only payment-only key exists on custom cart page, null multi-step, payment-only is used
                 "multiStepKey" => null,
                 "paymentOnlyKey" => "payOnly-key-on-custom-cart",
                 "routeName" => "custom",
                 "controllerName" => "cart",
-                "predictedReturnValue" => "payOnly-key-on-custom-cart"
+                "expectedReturnValue" => "payOnly-key-on-custom-cart"
             ],
+            "When both keys exist on standard onepage, payment-only is used" =>
             [
-                # When both keys exist on standard onepage, payment-only is used
                 "multiStepKey" => "multi+payOnly-key-on-onepage",
                 "paymentOnlyKey" => "payOnly+multi-key-on-onepage",
                 "routeName" => "checkout",
                 "controllerName" => "onepage",
-                "predictedReturnValue" => "payOnly+multi-key-on-onepage"
+                "expectedReturnValue" => "payOnly+multi-key-on-onepage"
             ],
+            "When only payment-only key exists on standard onepage, null multi-step, payment-only is used" =>
             [
-                # When only payment-only key exists on standard onepage, null multi-step, payment-only is used
                 "multiStepKey" => null,
                 "paymentOnlyKey" => "payOnly-key-on-onepage",
                 "routeName" => "checkout",
                 "controllerName" => "onepage",
-                "predictedReturnValue" => "payOnly-key-on-onepage"
+                "expectedReturnValue" => "payOnly-key-on-onepage"
             ],
+            "When only multi-step key exists on standard onepage, empty string payment-only, multi-step is used" =>
             [
-                # When only multi-step key exists on standard onepage, empty string payment-only, multi-step is used
                 "multiStepKey" => "multi-key-on-onepage",
                 "paymentOnlyKey" => "",
                 "routeName" => "checkout",
                 "controllerName" => "onepage",
-                "predictedReturnValue" => "multi-key-on-onepage"
+                "expectedReturnValue" => "multi-key-on-onepage"
             ],
+            "When both keys exist on unexpected page, payment-only is used" =>
             [
-                # When both keys exist on unexpected page, payment-only is used
                 "multiStepKey" => "multi+payOnly-key-on-homepage",
                 "paymentOnlyKey" => "payOnly+multi-key-on-homepage",
                 "routeName" => "cms",
                 "controllerName" => "index",
-                "predictedReturnValue" => "payOnly+multi-key-on-homepage"
+                "expectedReturnValue" => "payOnly+multi-key-on-homepage"
             ],
+            "When only payment-only key exists on unexpected page, empty string multi-step, payment-only is used" =>
             [
-                # When only payment-only key exists on unexpected page, empty string multi-step, payment-only is used
                 "multiStepKey" => "",
                 "paymentOnlyKey" => "payOnly-key-on-homepage",
                 "routeName" => "cms",
                 "controllerName" => "index",
-                "predictedReturnValue" => "payOnly-key-on-homepage"
+                "expectedReturnValue" => "payOnly-key-on-homepage"
             ],
+            "When only multi-step key exists on unexpected page, empty string payment-only, multi-step is used" =>
             [
-                # When only multi-step key exists on unexpected page, empty string payment-only, multi-step is used
                 "multiStepKey" => "multi+payOnly-key-on-homepage",
                 "paymentOnlyKey" => "",
                 "routeName" => "cms",
                 "controllerName" => "index",
-                "predictedReturnValue" => "multi+payOnly-key-on-homepage"
+                "expectedReturnValue" => "multi+payOnly-key-on-homepage"
             ],
+            "When both keys exist on product page, multi-step is used" =>
             [
-                # When both keys exist on product page, multi-step is used
                 "multiStepKey" => "multi+payOnly-key-on-product",
                 "paymentOnlyKey" => "payOnly+multi-key-on-product",
                 "routeName" => "catalog",
                 "controllerName" => "product",
-                "predictedReturnValue" => "multi+payOnly-key-on-product"
+                "expectedReturnValue" => "multi+payOnly-key-on-product"
             ],
+            "When only multi-step key exists on product page, null payment-only, multi-step is used" =>
             [
-                # When only multi-step key exists on product page, null payment-only, multi-step is used
                 "multiStepKey" => "multi-key-on-product",
                 "paymentOnlyKey" => null,
                 "routeName" => "catalog",
                 "controllerName" => "product",
-                "predictedReturnValue" => "multi-key-on-product"
+                "expectedReturnValue" => "multi-key-on-product"
             ],
+            "When only payment-only key exists on product page, null multi-step, payment-only is used" =>
             [
-                # When only payment-only key exists on product page, null multi-step, payment-only is used
                 "multiStepKey" => null,
                 "paymentOnlyKey" => "payOnly-key-on-product",
                 "routeName" => "catalog",
                 "controllerName" => "product",
-                "predictedReturnValue" => "payOnly-key-on-product"
+                "expectedReturnValue" => "payOnly-key-on-product"
             ]
         ];
     }
@@ -540,142 +540,146 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      * the standard checkout page, a standard product page, and any unexpected page identified by route and controller
      * name for {@see Bolt_Boltpay_Block_Checkout_BoltpayTest::getPublishableKeyForThisPage_whenNoKeyIsConfigured()}
      *
-     * @return array[] in the format of [$multiStepKey, $paymentOnlyKey, $routeName, $controllerName, $predictedReturnValue]
+     * @return array[] in the format of [$multiStepKey, $paymentOnlyKey, $routeName, $controllerName]
      */
     public function getPublishableKeyForThisPage_whenNoKeyIsConfiguredProvider()
     {
         return [
+            "When no keys are configure, null multi-step and empty string payment-only, on standard cart page" =>
             [
-                # When no keys are configure, null multi-step and empty string payment-only, on standard cart page
                 "multiStepKey" => null,
                 "paymentOnlyKey" => "",
                 "routeName" => "checkout",
                 "controllerName" => "cart"
-            ],           [
-                # When no keys are configure, empty string multi-step and null payment-only, on standard cart page
+            ],
+            "When no keys are configure, empty string multi-step and null payment-only, on standard cart page" =>
+            [
                 "multiStepKey" => "",
                 "paymentOnlyKey" => null,
                 "routeName" => "checkout",
                 "controllerName" => "cart"
             ],
-
+            "When no keys are configure, empty strings, on standard cart page" =>
             [
-                # When no keys are configure, empty strings, on standard cart page
                 "multiStepKey" => "",
                 "paymentOnlyKey" => "",
                 "routeName" => "checkout",
                 "controllerName" => "cart"
             ],
+            "When no keys are configure, nulls, on standard cart page" =>
             [
-                # When no keys are configure, nulls, on standard cart page
                 "multiStepKey" => null,
                 "paymentOnlyKey" => null,
                 "routeName" => "checkout",
                 "controllerName" => "cart"
             ],
+            "When no keys are configure, null multi-step and empty string payment-only, on custom cart page" =>
             [
-                # When no keys are configure, null multi-step and empty string payment-only, on custom cart page
                 "multiStepKey" => null,
                 "paymentOnlyKey" => "",
                 "routeName" => "custom",
                 "controllerName" => "cart"
-            ],           [
-                # When no keys are configure, empty string multi-step and null payment-only, on custom cart page
+            ],
+            "When no keys are configure, empty string multi-step and null payment-only, on custom cart page" =>
+            [
                 "multiStepKey" => "",
                 "paymentOnlyKey" => null,
                 "routeName" => "custom",
                 "controllerName" => "cart"
             ],
+            "When no keys are configure, empty strings, on custom cart page" =>
             [
-                # When no keys are configure, empty strings, on custom cart page
                 "multiStepKey" => "",
                 "paymentOnlyKey" => "",
                 "routeName" => "custom",
                 "controllerName" => "cart"
             ],
+            "When no keys are configure, nulls, on custom cart page" =>
             [
-                # When no keys are configure, nulls, on custom cart page
                 "multiStepKey" => null,
                 "paymentOnlyKey" => null,
                 "routeName" => "custom",
                 "controllerName" => "cart"
             ],
+            "When no keys are configure, null multi-step and empty string payment-only, on standard onepage" =>
             [
-                # When no keys are configure, null multi-step and empty string payment-only, on standard onepage
                 "multiStepKey" => null,
                 "paymentOnlyKey" => "",
                 "routeName" => "checkout",
                 "controllerName" => "onepage"
-            ],           [
-                # When no keys are configure, empty string multi-step and null payment-only, on standard onepage
+            ],
+            "When no keys are configure, empty string multi-step and null payment-only, on standard onepage" =>
+            [
                 "multiStepKey" => "",
                 "paymentOnlyKey" => null,
                 "routeName" => "checkout",
                 "controllerName" => "onepage"
             ],
+            "When no keys are configure, empty strings, on standard onepage" =>
             [
-                # When no keys are configure, empty strings, on standard onepage
                 "multiStepKey" => "",
                 "paymentOnlyKey" => "",
                 "routeName" => "checkout",
                 "controllerName" => "onepage"
             ],
+            "When no keys are configure, nulls, on standard onepage" =>
             [
-                # When no keys are configure, nulls, on standard onepage
                 "multiStepKey" => null,
                 "paymentOnlyKey" => null,
                 "routeName" => "checkout",
                 "controllerName" => "onepage"
             ],
+            "When no keys are configure, null multi-step and empty string payment-only, on unexpected page" =>
             [
-                # When no keys are configure, null multi-step and empty string payment-only, on unexpected page
                 "multiStepKey" => null,
                 "paymentOnlyKey" => "",
                 "routeName" => "cms",
                 "controllerName" => "index"
-            ],           [
-                # When no keys are configure, empty string multi-step and null payment-only, on unexpected page
+            ],
+            "When no keys are configure, empty string multi-step and null payment-only, on unexpected page" =>
+            [
                 "multiStepKey" => "",
                 "paymentOnlyKey" => null,
                 "routeName" => "cms",
                 "controllerName" => "index"
             ],
+            "When no keys are configure, empty strings, on unexpected page" =>
             [
-                # When no keys are configure, empty strings, on unexpected page
                 "multiStepKey" => "",
                 "paymentOnlyKey" => "",
                 "routeName" => "cms",
                 "controllerName" => "index"
             ],
+            "When no keys are configure, nulls, on unexpected page" =>
             [
-                # When no keys are configure, nulls, on unexpected page
                 "multiStepKey" => null,
                 "paymentOnlyKey" => null,
                 "routeName" => "cms",
                 "controllerName" => "index"
             ],
+            "When no keys are configure, null multi-step and empty string payment-only, on product page" =>
             [
-                # When no keys are configure, null multi-step and empty string payment-only, on product page
                 "multiStepKey" => null,
                 "paymentOnlyKey" => "",
                 "routeName" => "catalog",
                 "controllerName" => "product"
-            ],           [
-                # When no keys are configure, empty string multi-step and null payment-only, on product page
+            ],
+            "When no keys are configure, empty string multi-step and null payment-only, on product page" =>
+            [
                 "multiStepKey" => "",
                 "paymentOnlyKey" => null,
                 "routeName" => "catalog",
                 "controllerName" => "product"
             ],
+            "When no keys are configure, empty strings, on product page" =>
             [
-                # When no keys are configure, empty strings, on product page
                 "multiStepKey" => "",
                 "paymentOnlyKey" => "",
                 "routeName" => "catalog",
                 "controllerName" => "product"
             ],
+            "When no keys are configure, nulls, on product page" =>
             [
-                # When no keys are configure, nulls, on product page
                 "multiStepKey" => null,
                 "paymentOnlyKey" => null,
                 "routeName" => "catalog",

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -359,7 +359,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
 
         try {
             $actualReturnedValue = $this->currentMock->getPublishableKeyForThisPage();
-            $this->assertNotFalse($multiStepKey || $paymentOnlyKey);
+            $this->assertTrue($multiStepKey || $paymentOnlyKey);
             $this->assertNotEmpty($expectedReturnedValue);
             $this->assertEquals($expectedReturnedValue, $actualReturnedValue);
         } catch (Bolt_Boltpay_BoltException $bbbe) {

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -346,7 +346,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         if ($predictedReturnValue) {
             $this->assertEquals($expectedReturnedValue, $predictedReturnValue);
         } else {
-            $this->assertEmpty($expectedReturnedValue, $predictedReturnValue);
+            $this->assertEmpty($expectedReturnedValue);
         }
 
         if (!$multiStepKey && !$paymentOnlyKey) {


### PR DESCRIPTION
# Description
track.js is was not loaded on pages that where neither the product page nor the shopping cart page when the one page checkout publishable key was not present.  This is addressed as follows

```
    /**
     * Returns the One Page or Multi-Page checkout Publishable key depending on the requested
     * page and which key has been set in the admin.  Cart and Product pages prioritize the multi-step key
     * and falls back to the payment only key.  All other pages prioritize the payment only key and falls back
     * to the multi-step key.
     */
```

Fixes: https://app.asana.com/0/544708310157130/1150319197435017

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
