### PR TITLE
Correct Varien Object Data Key Format

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/Adminhtml/Sales/Order/CreateController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/Adminhtml/Sales/Order/CreateController.php
@@ -271,7 +271,7 @@ class Bolt_Boltpay_Adminhtml_Sales_Order_CreateController
             'bolt_boltpay_admin_normalize_order_data_after',
             array(
                 'request' => $this->getRequest(),
-                'orderCreateModel' => $this->_getOrderCreateModel()
+                'order_create_model' => $this->_getOrderCreateModel()
             )
         );
     }


### PR DESCRIPTION
# Description
In order for the magic getter and setter methods to be able to find find the property as `$observer->getEvent()->getOrderCreateModel()` or `$observer->getOrderCreateModel()`, the array key must be set in snake case as `order_create_model`

Fixes: https://app.asana.com/0/941895179897714/1155064778904945

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
