### PR TITLE
Make sure plugin doesn't return negative shipping amount

### DIFF
--- a/tests/unit/testsuite/Bolt/Boltpay/Model/ShippingAndTaxTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/ShippingAndTaxTest.php
@@ -348,6 +348,26 @@ class Bolt_Boltpay_Model_ShippingAndTaxTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @test make sure we don't return negative amount in following case
+     * - subtotal : $100
+     * - shipping amount: $0
+     * - discount amount: $10
+     */
+    public function getAdjustedShippingAmount_noNegativeAmount()
+    {
+        $cart = $this->testHelper->addProduct(self::$productId, 2);
+        $quote = $cart->getQuote();
+
+        $quote->getShippingAddress()->setShippingAmount(0);
+        $quote->setSubtotal(100);
+        $quote->setSubtotalWithDiscount(90);
+
+        $result = $this->currentMock->getAdjustedShippingAmount(0, $quote);
+
+        $this->assertEquals(0, $result);
+    }
+
     public function testShippingLabel()
     {
         $rate = $this->getMockBuilder('Mage_Sales_Model_Quote_Address_Rate')


### PR DESCRIPTION
# Description
One of our merchant returned negative amount as shipping cost. Bolt API doesn't expect negative shipping cost so this PR add quick fix to converting negative amount to 0. This PR also adds bugsnag for such case so we can get more detailed insight and fix the root cause.

Fixes: https://app.asana.com/0/941895179897714/1153873085475794/f (partial fix)

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog Add logic to handle negative shipping amount

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server

only unit test

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
