### PR TITLE
Addresses error with zero set as an extra-config value

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
@@ -85,7 +85,7 @@ JS;
         $filterMethod = 'filter'.$methodPostfix;
 
         $allExtraConfigs = (array) json_decode($this->normalizeJSON(Mage::getStoreConfig('payment/boltpay/extra_options')), true);
-        $rawValue = @$allExtraConfigs[$configName] ?: '';
+        $rawValue = isset($allExtraConfigs[$configName]) ? $allExtraConfigs[$configName] : '';
 
         return method_exists($this, $filterMethod)
             ? $this->$filterMethod($rawValue, $filterParameters)

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/Admin/ExtraConfigTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/Admin/ExtraConfigTest.php
@@ -264,12 +264,28 @@ class Bolt_Boltpay_Model_Admin_ExtraConfigTest extends PHPUnit_Framework_TestCas
                     'expectedResult'   => Bolt_Boltpay_Model_Admin_ExtraConfig::DEFAULT_PRICE_FAULT_TOLERANCE
                 )
             ,
-            'Price fault tolerance, if configured with a valid integer, will return the absolute value of that integer' =>
+            'Price fault tolerance, if configured with a negative integer, will return the absolute value of that integer' =>
                 array(
                     'configName'       => 'priceFaultTolerance',
-                    'jsonFromDb'       => '{"priceFaultTolerance": '.($priceFaultTolerance = mt_rand(-10,10)).'}',
+                    'jsonFromDb'       => '{"priceFaultTolerance": '.($priceFaultTolerance = mt_rand(-10,-1)).'}',
                     'filterParameters' => array(),
                     'expectedResult'   => abs($priceFaultTolerance)
+                )
+            ,
+            'Price fault tolerance, if configured with a positive integer, will return that integer' =>
+                array(
+                    'configName'       => 'priceFaultTolerance',
+                    'jsonFromDb'       => '{"priceFaultTolerance": '.($priceFaultTolerance = mt_rand(1,10)).'}',
+                    'filterParameters' => array(),
+                    'expectedResult'   => $priceFaultTolerance
+                )
+            ,
+            'Price fault tolerance, if configured with 0, then 0 is returned' =>
+                array(
+                    'configName'       => 'priceFaultTolerance',
+                    'jsonFromDb'       => '{"priceFaultTolerance": 0}',
+                    'filterParameters' => array(),
+                    'expectedResult'   => 0
                 )
             ,
             'Display pre-auth orders, if not configured, will return false' =>


### PR DESCRIPTION
# Description
The extra config unit test revealed that there is an error in our code in handling the value of zero.  This corrects the interpretation of zero in the `getExtraConfig` method

Fixes: https://boltpay.slack.com/archives/CRGUZABC6/p1578076509001700

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
