### PR TITLE
Complete unit test for Bolt_Boltpay_Block_Checkout_Boltpay

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -75,29 +75,27 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
 
                 $cartData = Mage::getModel('boltpay/boltOrder')->getBoltOrderTokenPromise($checkoutType);
 
-                if (@!$cartData->error) {
-                    ///////////////////////////////////////////////////////////////////////////////////////
-                    // Merchant scope: get "bolt_user_id" if the user is logged in or should be registered,
-                    // sign it and add to hints.
-                    ///////////////////////////////////////////////////////////////////////////////////////
-                    $reservedUserId = $this->getReservedUserId($sessionQuote);
-                    if ($reservedUserId && $this->isEnableMerchantScopedAccount()) {
-                        $signRequest = array(
-                            'merchant_user_id' => $reservedUserId,
+                ///////////////////////////////////////////////////////////////////////////////////////
+                // Merchant scope: get "bolt_user_id" if the user is logged in or should be registered,
+                // sign it and add to hints.
+                ///////////////////////////////////////////////////////////////////////////////////////
+                $reservedUserId = $this->getReservedUserId($sessionQuote);
+                if ($reservedUserId && $this->isEnableMerchantScopedAccount()) {
+                    $signRequest = array(
+                        'merchant_user_id' => $reservedUserId,
+                    );
+
+                    $signResponse = $this->boltHelper()->transmit('sign', $signRequest);
+
+                    if ($signResponse != null) {
+                        $hintData['signed_merchant_user_id'] = array(
+                            "merchant_user_id" => $signResponse->merchant_user_id,
+                            "signature" => $signResponse->signature,
+                            "nonce" => $signResponse->nonce,
                         );
-
-                        $signResponse = $this->boltHelper()->transmit('sign', $signRequest);
-
-                        if ($signResponse != null) {
-                            $hintData['signed_merchant_user_id'] = array(
-                                "merchant_user_id" => $signResponse->merchant_user_id,
-                                "signature" => $signResponse->signature,
-                                "nonce" => $signResponse->nonce,
-                            );
-                        }
                     }
-                    ///////////////////////////////////////////////////////////////////////////////////////
                 }
+                ///////////////////////////////////////////////////////////////////////////////////////
 
             } catch (Exception $e) {
                 $metaData = array('quote' => var_export($sessionQuote->debug(), true));

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -1,293 +1,1076 @@
 <?php
 
 require_once('TestHelper.php');
+require_once('MockingTrait.php');
+require_once('CouponHelper.php');
+
+use Bolt_Boltpay_Block_Checkout_Boltpay as BoltpayCheckoutBlock;
+use Bolt_Boltpay_TestHelper as TestHelper;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * @coversDefaultClass Bolt_Boltpay_Block_Checkout_Boltpay
  */
 class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
 {
-    /**
-     * @var Mage_Core_Model_App Used to manipulate the Magento application environment
-     */
-    private $app = null;
+    use Bolt_Boltpay_MockingTrait;
 
-    /**
-     * @var PHPUnit_Framework_MockObject_MockObject|Bolt_Boltpay_Helper_Data The mocked Bolt Helper class which is used by the current mock
-     */
-    private $helperMock;
+    /** @var int dummy quote id */
+    const QUOTE_ID = 1234;
 
-    /**
-     * @var PHPUnit_Framework_MockObject_MockObject|Bolt_Boltpay_Block_Checkout_Boltpay The mocked instance of the block being tested
-     */
+    /** @var int dummy reserved customer id */
+    const RESERVED_CUSTOMER_ID = 1234;
+
+    /** @var string dummy IP address */
+    const DEFAULT_IP = '4.17.138.68';
+
+    /** @var string dummy location info from IPStack */
+    const LOCATION_INFO = '{"ip":"4.17.138.68","type":"ipv4","continent_code":"NA","continent_name":"North America","country_code":"US","country_name":"United States","region_code":"MA","region_name":"Massachusetts","city":"Westford","zip":"01460","latitude":42.537960052490234,"longitude":-71.48497009277344}';
+
+    /** @var string dummy function for transforming hint data for checkout JS */
+    const HINTS_TRANSFORM_FUNCTION = 'function(a){return a;}';
+
+    /** @var string dummy custom check function for checkout JS */
+    const CHECK_FUNCTION = 'if(false)return;';
+
+    /** @var string dummy on check callback for chekout JS */
+    const ON_CHECK_CALLBACK = 'if (!checkout.validate()) return false;';
+
+    /** @var string dummy order token */
+    const TOKEN = '6dbyZ9XuB33n9sgZ';
+
+    /** @var string Test class name */
+    protected $testClassName = 'Bolt_Boltpay_Block_Checkout_Boltpay';
+
+    /** @var MockObject|BoltpayCheckoutBlock */
     private $currentMock;
 
     /**
-     * @var $testHelper Bolt_Boltpay_TestHelper
+     * @var MockObject|Bolt_Boltpay_Helper_Data
      */
-    private $testHelper = null;
+    private $boltHelperMock;
+
+    /**
+     * @var MockObject|Bolt_Boltpay_Model_BoltOrder
+     */
+    private $boltOrderMock;
+
+    /**
+     * @var MockObject|Mage_Customer_Model_Session
+     */
+    private $customerSessionMock;
+
+    /**
+     * @var MockObject|Mage_Checkout_Model_Type_Onepage
+     */
+    private $checkoutTypeOnepageMock;
+
+    /**
+     * @var MockObject|Boltpay_Guzzle_ApiClient
+     */
+    private $apiClientMock;
 
     /**
      * Setup test dependencies, called before each test
+     *
+     * @throws ReflectionException if unable to stub BoltOrder model
+     * @throws Exception if test class name is not set
      */
     public function setUp()
     {
-        $this->app = Mage::app('default');
-
-        $this->currentMock = $this->getMockBuilder('Bolt_Boltpay_Block_Checkout_Boltpay')
-            ->setMethods(array('isAdminAndUseJsInAdmin'))
+        $this->currentMock = $this->getTestClassPrototype()
+            ->setMethods()
             ->disableOriginalConstructor()
             ->disableOriginalClone()
             ->disableArgumentCloning()
-            ->getMock()
-        ;
-
-        Mage::unregister('_helper/boltpay');
-        $this->helperMock = $this->getMockBuilder('Bolt_Boltpay_Helper_Data')
-            ->setMethods(
-                array('notifyException', 'logException')
-            )
             ->getMock();
 
-        Mage::register('_helper/boltpay', $this->helperMock);
+        $this->apiClientMock = $this->getClassPrototype('Boltpay_Guzzle_ApiClient')
+            ->setMethods(array('get', 'getBody'))->getMock();
 
-        $this->testHelper = new Bolt_Boltpay_TestHelper();
+        $this->boltHelperMock = $this->getClassPrototype('Bolt_Boltpay_Helper_Data')->getMock();
+        $this->boltHelperMock->method('getApiClient')->willReturn($this->apiClientMock);
+
+        $this->boltOrderMock = $this->getClassPrototype('Bolt_Boltpay_Model_BoltOrder', false )
+            ->setMethods(array('getBoltOrderTokenPromise', 'transmit'))
+            ->enableProxyingToOriginalMethods()->getMock();
+
+        TestHelper::stubModel('boltpay/boltOrder', $this->boltOrderMock);
+
+        $this->customerSessionMock = $this->getClassPrototype('Mage_Customer_Model_Session')
+            ->setMethods(array('isLoggedIn', 'getId', 'setBoltUserId'))->getMock();
+
+        $this->checkoutTypeOnepageMock = $this->getClassPrototype('Mage_Checkout_Model_Type_Onepage')
+            ->getMock();
     }
 
     /**
-     * Resets Magento registry values after all test have run
+     * Restore original stubbed values and reset route
+     *
+     * @throws ReflectionException if unable to restore _config property of Mage class
+     * @throws Mage_Core_Model_Store_Exception if unable to restore original config values due to missing store
+     * @throws Mage_Core_Exception if unable to restore original registry value due to key already been defined
      */
-    public static function tearDownAfterClass()
+    protected function tearDown()
     {
-        Mage::unregister('_helper/boltpay');
+        Mage::app()->getRequest()->setRouteName(null)->setControllerName(null);
+        TestHelper::restoreOriginals();
     }
 
     /**
-     * @inheritdoc
-     * @group Block
+     * @test
+     * that Mage internal constructor sets _jsUrl property to expected value when module is in sandbox mode
+     *
+     * @covers ::_construct
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function testBuildCartData()
+    public function _construct_inSandbox_setsJSUrlFromHelper()
     {
-        $autoCapture = true;
-        $this->app->getStore()->setConfig('payment/boltpay/auto_capture', $autoCapture);
+        TestHelper::stubConfigValue('payment/boltpay/test', 1);
+        $currentObject = new BoltpayCheckoutBlock();
+        $this->assertAttributeEquals('https://connect-sandbox.bolt.com/connect.js', '_jsUrl', $currentObject);
+    }
 
-        // Prepare test response object
-        $testBoltResponse = new stdClass();
-        $testBoltResponse->token = md5('bolt');
+    /**
+     * @test
+     * that getTrackJsUrl constructor returns expected value when module is in production mode
+     *
+     * @covers ::_construct
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function _construct_inProduction_setsJSUrlFromHelper()
+    {
+        TestHelper::stubConfigValue('payment/boltpay/test', 0);
+        $currentObject = new BoltpayCheckoutBlock();
+        $this->assertAttributeEquals('https://connect.bolt.com/connect.js', '_jsUrl', $currentObject);
+    }
 
-        $result = $this->currentMock->buildCartData($testBoltResponse);
-
-        $cartData = array(
-            'orderToken' => md5('bolt'),
+    /**
+     * @test
+     * that getTrackJsUrl constructor returns expected value when module is in sandbox mode
+     *
+     * @covers ::getTrackJsUrl
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getTrackJsUrl_inSandbox_returnsJSUrlFromHelperWithSuffix()
+    {
+        TestHelper::stubConfigValue('payment/boltpay/test', 1);
+        $this->assertEquals(
+            'https://connect-sandbox.bolt.com/track.js',
+            $this->currentMock->getTrackJsUrl()
         );
-
-        $this->assertEquals($cartData, $result);
     }
 
     /**
-     * @inheritdoc
-     * @group Block
+     * @test
+     * that Mage internal constructor sets _jsUrl property to expected value when module is in production mode
+     *
+     * @covers ::getTrackJsUrl
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function testBuildCartDataWithEmptyTokenField()
+    public function getTrackJsUrl_inProduction_returnsJSUrlFromHelperWithSuffix()
     {
-        $autoCapture = true;
-        $this->app->getStore()->setConfig('payment/boltpay/auto_capture', $autoCapture);
-
-        // Prepare test response object
-        $testBoltResponse = new stdClass();
-
-        $result = $this->currentMock->buildCartData($testBoltResponse);
-
-        $cartData = array(
-            'orderToken'    => '',
+        TestHelper::stubConfigValue('payment/boltpay/test', 0);
+        $this->assertEquals(
+            'https://connect.bolt.com/track.js',
+            $this->currentMock->getTrackJsUrl()
         );
-
-        $this->assertEquals($cartData, $result, 'Something wrong with testBuildCartDataWithEmptyTokenField()');
     }
 
     /**
-     * @inheritdoc
-     * @group Block
+     * Setup method for tests covering {@see Bolt_Boltpay_Block_Checkout_Boltpay::getCartDataJs}
+     *
+     * @param string $checkoutType
+     * @return array consisting of quote and current class mock
+     * @throws Mage_Core_Exception if unable to stub Boltpay helper
+     * @throws Exception if test class name is not defined
      */
-    public function testBuildCartDataWithoutAutoCapture()
+    private function getCartDataJsSetUp($checkoutType)
     {
-        $autoCapture = false;
-        $this->app->getStore()->setConfig('payment/boltpay/auto_capture', $autoCapture);
+        $quote = Mage::getModel('sales/quote');
+        TestHelper::stubHelper('boltpay', $this->boltHelperMock);
+        $currentMock = $this->getTestClassPrototype(true)
+            ->setMethods(
+                array(
+                    'getSessionQuote',
+                    'getAddressHints',
+                    'getReservedUserId',
+                    'isEnableMerchantScopedAccount',
+                    'buildBoltCheckoutJavascript'
+                )
+            )
+            ->getMock();
+        $currentMock->expects($this->once())->method('getSessionQuote')->with($checkoutType)->willReturn($quote);
+        return array($quote, $currentMock);
+    }
 
-        // Prepare test response object
-        $testBoltResponse = new stdClass();
-        $testBoltResponse->token = md5('bolt');
+    /**
+     * @test
+     * that getCartDataJs adds signed_merchant_user_id to hint data if reserved user id exists in session
+     * and merchant scoped account is enabled and proceeds to build Bolt checkout javascript
+     *
+     * @covers ::getCartDataJs
+     * @covers ::getAddressHints
+     *
+     * @throws Mage_Core_Exception if unable to setup test dependencies
+     */
+    public function getCartDataJs_withReservedCustomerIdAndMerchantScopedAccountEnabled_buildsBoltCheckoutJSWithSignedMerchantUserId()
+    {
+        $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE;
+        list($quote, $currentMock) = $this->getCartDataJsSetUp($checkoutType);
 
-        $result = $this->currentMock->buildCartData($testBoltResponse);
+        $this->boltOrderMock->expects($this->atLeastOnce())->method('getBoltOrderTokenPromise')->with($checkoutType);
+        $currentMock->expects($this->once())->method('getReservedUserId')->with($quote)
+            ->willReturn(self::RESERVED_CUSTOMER_ID);
+        $currentMock->expects($this->once())->method('isEnableMerchantScopedAccount')->willReturn(true);
 
-        $cartData = array(
-            'orderToken' => md5('bolt'),
+        $signedApiResponse = array(
+            "merchant_user_id" => self::RESERVED_CUSTOMER_ID,
+            "signature"        => sha1('test'),
+            "nonce"            => rand(100000000, 999999999),
         );
+        $this->boltHelperMock->expects($this->once())->method('transmit')
+            ->with('sign', array('merchant_user_id' => self::RESERVED_CUSTOMER_ID))
+            ->willReturn((object)$signedApiResponse);
 
-        $this->assertEquals($cartData, $result, 'Something wrong with testBuildCartDataWithoutAutoCapture()');
+        $currentMock->expects($this->once())->method('buildBoltCheckoutJavascript')
+            ->with(
+                $checkoutType,
+                $quote,
+                new PHPUnit_Framework_Constraint_ArraySubset(array('signed_merchant_user_id' => $signedApiResponse)),
+                $this->equalTo(Mage::getModel('boltpay/boltOrder')->getBoltOrderTokenPromise($checkoutType))
+            );
+        $currentMock->getCartDataJs($checkoutType);
     }
 
     /**
-     * @inheritdoc
-     * @group Block
+     * @test
+     * that getCartDataJs logs exception if thrown from getBoltOrderTokenPromise and proceeds to build Bolt Checkout JS
+     *
+     * @covers ::getCartDataJs
+     *
+     * @throws Mage_Core_Exception if unable to setup test dependencies
      */
-    public function testBuildCartDataWithApiError()
+    public function getCartDataJs_whenGetBoltOrderTokenPromiseThrowsException_logsExceptionAndBuildsBoltCheckoutJS()
     {
-        $autoCapture = true;
-        $this->app->getStore()->setConfig('payment/boltpay/auto_capture', $autoCapture);
+        $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE;
+        list($quote, $currentMock) = $this->getCartDataJsSetUp($checkoutType);
+        $metaData = array('quote' => var_export($quote->debug(), true));
 
-        // Prepare test response object
-        $testBoltResponse = new stdClass();
-        $testBoltResponse->token = md5('bolt');
+        $exception = new Exception('Expected exception');
+        $this->boltOrderMock->expects($this->once())->method('getBoltOrderTokenPromise')->with($checkoutType)
+            ->willThrowException($exception);
+        $this->boltHelperMock->expects($this->once())->method('logException')->with($exception, $metaData);
+        $this->boltHelperMock->expects($this->once())->method('notifyException')
+            ->with(new Exception($exception), $metaData);
 
-        $apiErrorMessage = 'Some error from api.';
-        Mage::register('bolt_api_error', $apiErrorMessage);
+        $currentMock->expects($this->once())->method('buildBoltCheckoutJavascript')
+            ->with($checkoutType, $quote, $this->anything(), null);
+        $currentMock->getCartDataJs($checkoutType);
+    }
 
-        $result = $this->currentMock->buildCartData($testBoltResponse);
+    /**
+     * @test
+     * that getCartDataJs logs exception thrown from buildBoltCheckoutJavascript and returns null
+     *
+     * @covers ::getCartDataJs
+     *
+     * @throws Mage_Core_Exception if unable to setup test dependencies
+     */
+    public function getCartDataJs_buildBoltCheckoutJavascriptThrowsException_logsExceptionAndReturnsNull()
+    {
+        list(, $currentMock) = $this->getCartDataJsSetUp(BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE);
 
-        $cartData = array(
-            'orderToken' => md5('bolt'),
-            'error' => $apiErrorMessage
+        $exception = new Exception('Expected exception');
+        $this->boltHelperMock->expects($this->once())->method('logException')->with($exception);
+        $this->boltHelperMock->expects($this->once())->method('notifyException')->with($exception);
+
+        $currentMock->expects($this->once())->method('buildBoltCheckoutJavascript')->willThrowException($exception);
+        $this->assertNull($currentMock->getCartDataJs(BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE));
+    }
+
+    /**
+     * @test
+     * that isAdminAndUseJsInAdmin returns true only if checkout type is admin and use js in admin is enabled
+     *
+     * @covers ::isAdminAndUseJsInAdmin
+     *
+     * @dataProvider isAdminAndUseJsInAdmin_withVariousCheckoutTypesAndConfigurations_returnsExpectedBooleanProvider
+     *
+     * @param string $checkoutType currently used
+     * @param bool   $useJavascriptInAdmin configuration value
+     * @param bool   $expectedResult of method call
+     *
+     * @throws Mage_Core_Model_Store_Exception
+     * @throws ReflectionException
+     */
+    public function isAdminAndUseJsInAdmin_withVariousCheckoutTypesAndConfigurations_returnsExpectedBoolean($checkoutType, $useJavascriptInAdmin, $expectedResult)
+    {
+        TestHelper::stubConfigValue('payment/boltpay/use_javascript_in_admin', $useJavascriptInAdmin);
+        $this->assertEquals(
+            $expectedResult,
+            TestHelper::callNonPublicFunction($this->currentMock, 'isAdminAndUseJsInAdmin', array($checkoutType))
         );
-
-        $this->assertEquals($cartData, $result, 'Something wrong with testBuildCartDataWithApiError()');
-        Mage::unregister('bolt_api_error');
     }
 
     /**
-     * @inheritdoc
-     * @group Block
+     * Data provider for {@see isAdminAndUseJsInAdmin_withVariousCheckoutTypesAndConfigurations_returnsExpectedBoolean}
+     *
+     * @return array containing checkout type, config value for using js in admin and expected result of method call
      */
-    public function testGetCartURL()
+    public function isAdminAndUseJsInAdmin_withVariousCheckoutTypesAndConfigurations_returnsExpectedBooleanProvider()
     {
-        $expected = Mage::helper('boltpay')->getMagentoUrl('checkout/cart');
-
-        $result = $this->currentMock->getCartUrl();
-
-        $this->assertEquals($expected, $result);
-    }
-
-    public function testGetSelectorsCSS()
-    {
-        $style = '.test-selector { color: red; }';
-
-        $this->app->getStore()->setConfig('payment/boltpay/additional_css', $style);
-
-        $result = $this->currentMock->getAdditionalCSS();
-
-        $this->assertEquals($style, $result);
-    }
-
-    /**
-     * Test that additional Js is present
-     * @group Block
-     */
-    public function testGetAdditionalJs()
-    {
-        $js = 'jQuery("body div").text("Hello, world.")';
-
-        $this->app->getStore()->setConfig('payment/boltpay/additional_js', $js);
-
-        $result = $this->currentMock->getAdditionalJs();
-
-        $this->assertEquals($js, $result);
+        return array(
+            'Admin and use disabled'      => array(
+                'checkoutType'         => BoltpayCheckoutBlock::CHECKOUT_TYPE_ADMIN,
+                'useJavascriptInAdmin' => false,
+                'expectedResult'       => true
+            ),
+            'Admin and use enabled'       => array(
+                'checkoutType'         => BoltpayCheckoutBlock::CHECKOUT_TYPE_ADMIN,
+                'useJavascriptInAdmin' => true,
+                'expectedResult'       => false
+            ),
+            'Multi-page and use disabled' => array(
+                'checkoutType'         => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE,
+                'useJavascriptInAdmin' => false,
+                'expectedResult'       => false
+            ),
+            'Multi-page and use enabled'  => array(
+                'checkoutType'         => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE,
+                'useJavascriptInAdmin' => true,
+                'expectedResult'       => false
+            ),
+        );
     }
 
     /**
-     * @inheritdoc
-     * @group Block
+     * @test
+     * that buildCartData returns array containing order token from provided input object
+     *
+     * @covers ::buildCartData
      */
-    public function testGetSuccessURL()
+    public function buildCartData_withoutError_returnsArrayContainingOrderToken()
     {
-        $url = 'checkout/onepage/success';
-        $this->app->getStore()->setConfig('payment/boltpay/successpage', $url);
-        $expected = Mage::helper('boltpay')->getMagentoUrl($url);
-
-        $result = $this->currentMock->getSuccessUrl();
-
-        $this->assertEquals($expected, $result);
+        $this->assertEquals(
+            array('orderToken' => self::TOKEN),
+            $this->currentMock->buildCartData((object)array('token' => self::TOKEN))
+        );
     }
 
     /**
-     * @inheritdoc
-     * @group Block
+     * @test
+     * that buildCartData returns array containing empty order token if provided with empty array
+     *
+     * @covers ::buildCartData
      */
-    public function testBuildBoltCheckoutJavascript()
+    public function buildCartData_withEmptyOrderCreationResponse_returnsEmptyStringAsOrderToken()
     {
-        $this->currentMock = $this->getMockBuilder('Bolt_Boltpay_Block_Checkout_Boltpay')
-            ->setMethods(array('buildOnCheckCallback', 'buildOnSuccessCallback', 'buildOnCloseCallback'))
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->getMock()
-        ;
+        $this->assertEquals(
+            array('orderToken' => ''),
+            $this->currentMock->buildCartData(array())
+        );
+    }
 
-        $autoCapture = true;
-        $this->app->getStore()->setConfig('payment/boltpay/auto_capture', $autoCapture);
-        Mage::app()->getRequest()->setRouteName('checkout')->setControllerName('cart');
+    /**
+     * @test
+     * that buildCartData returns array containing error message if it exists in Magento registry
+     *
+     * @covers ::buildCartData
+     *
+     * @throws Mage_Core_Exception if unable to stub registry value
+     */
+    public function buildCartData_withApiError_returnsArrayContainingError()
+    {
+        $apiErrorMessage = 'Expected API array';
+        TestHelper::stubRegistryValue('bolt_api_error', $apiErrorMessage);
 
-        $cartData = json_encode (
-            array(
-                'orderToken' => md5('bolt')
+        $this->assertEquals(
+            array('orderToken' => self::TOKEN, 'error' => $apiErrorMessage),
+            $this->currentMock->buildCartData((object)array('token' => self::TOKEN))
+        );
+    }
+
+    /**
+     * @test
+     * that buildCartData returns array containing both token and error message if present in object provided
+     *
+     * @covers ::buildCartData
+     */
+    public function buildCartData_withErrorInOrderCreationResponse_returnsArrayContainingBothErrorMessageAndOrderToken()
+    {
+        $errorMessage = 'Expected error.';
+
+        $this->assertEquals(
+            array('orderToken' => self::TOKEN, 'error' => $errorMessage),
+            $this->currentMock->buildCartData((object)array('token' => self::TOKEN, 'error' => $errorMessage))
+        );
+    }
+
+    /**
+     * @test
+     * that getSessionObject returns adminhtml/session_quote singleton if checkout type provided is admin
+     *
+     * @covers ::getSessionObject
+     *
+     * @throws Mage_Core_Exception if unable to stub singleton
+     * @throws ReflectionException if current mock doesn't have getSessionObject method
+     */
+    public function getSessionObject_withAdminCheckoutType_returnsAdminSessionQuote()
+    {
+        $adminSessionCartMock = $this->getClassPrototype('Mage_Adminhtml_Model_Session_Quote')->getMock();
+        TestHelper::stubSingleton('adminhtml/session_quote', $adminSessionCartMock);
+        $this->assertEquals(
+            $adminSessionCartMock,
+            TestHelper::callNonPublicFunction(
+                $this->currentMock,
+                'getSessionObject',
+                array(BoltpayCheckoutBlock::CHECKOUT_TYPE_ADMIN)
             )
         );
+    }
 
-        $promiseOfCartData =
-            "
-            new Promise( 
-                function (resolve, reject) {
-                    resolve($cartData);
-                }
+    /**
+     * @test
+     * that getSessionObject returns checkout/session singleton for any non-admin checkout type
+     *
+     * @covers ::getSessionObject
+     *
+     * @param string $checkoutType code currently in use
+     * @throws Mage_Core_Exception if unable to stub checkout session
+     * @throws ReflectionException if method tested doesn't exist
+     */
+    public function getSessionObject_withNonAdminCheckoutType_returnCheckoutSession($checkoutType)
+    {
+        $checkoutSession = $this->getClassPrototype('Mage_Checkout_Model_Session')->getMock();
+        TestHelper::stubSingleton('checkout/session', $checkoutSession);
+        $this->assertEquals(
+            $checkoutSession,
+            TestHelper::callNonPublicFunction(
+                $this->currentMock,
+                'getSessionObject',
+                array($checkoutType)
             )
-            "
-        ;
+        );
+    }
 
-        $hintData = array();
+    /**
+     * Data provider for {@see getSessionObject_withNonAdminCheckoutType_returnCheckoutSession}
+     * Provides all checkout type codes except admin
+     *
+     * @return array of checkout type codes
+     */
+    public function getSessionObject_withNonAdminCheckoutType_returnCheckoutSessionProvider()
+    {
+        return array(
+            'Multi-page checkout' => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE),
+            'Firecheckout'        => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_FIRECHECKOUT),
+            'One-page checkout'   => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_ONE_PAGE),
+            'Product page'        => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_PRODUCT_PAGE),
+        );
+    }
 
-        $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE;
-
-        $this->app->getStore()->setConfig('payment/boltpay/check', '');
-        $this->app->getStore()->setConfig('payment/boltpay/on_checkout_start', '');
-        $this->app->getStore()->setConfig('payment/boltpay/on_shipping_details_complete', '');
-        $this->app->getStore()->setConfig('payment/boltpay/on_shipping_options_complete', '');
-        $this->app->getStore()->setConfig('payment/boltpay/on_payment_submit', '');
-        $this->app->getStore()->setConfig('payment/boltpay/success', '');
-        $this->app->getStore()->setConfig('payment/boltpay/close', '');
+    /**
+     * Setup method for tests covering {@see Bolt_Boltpay_Block_Checkout_Boltpay::getAddressHints}
+     *
+     * @param int|null                            $customerId to be set as customer session id
+     * @param Mage_Sales_Model_Quote_Address|null $shippingAddress to be set as shipping address to quote returned
+     * @return Mage_Sales_Model_Quote instance with configured shipping address if provided
+     * @throws Mage_Core_Exception if unable to stub customer/session singleton
+     */
+    private function getAddressHintsSetUp($customerId = null, $shippingAddress = null)
+    {
+        $this->customerSessionMock->method('isLoggedIn')->willReturn($customerId !== null);
+        $this->customerSessionMock->method('getId')->willReturn($customerId);
+        TestHelper::stubSingleton('customer/session', $this->customerSessionMock);
 
         $quote = Mage::getModel('sales/quote');
-        $quote->setId(6);
+        if ($shippingAddress) {
+            $quote->setShippingAddress($shippingAddress);
+        }
 
-        $jsonHints = json_encode($hintData, JSON_FORCE_OBJECT);
-        $onSuccessCallback = 'function(transaction, callback) { console.log(test) }';
-
-        $expected = $this->testHelper->buildCartDataJs($checkoutType, $promiseOfCartData, $quote, $jsonHints);
-
-        $this->currentMock
-            ->method('buildOnCheckCallback')
-            ->will($this->returnValue(''));
-        $this->currentMock
-            ->method('buildOnSuccessCallback')
-            ->will($this->returnValue($onSuccessCallback));
-        $this->currentMock
-            ->method('buildOnCloseCallback')
-            ->will($this->returnValue(''));
-
-        $result = $this->currentMock->buildBoltCheckoutJavascript($checkoutType, $quote, $hintData, $promiseOfCartData);
-
-        $this->assertEquals(preg_replace('/\s/', '', $expected), preg_replace('/\s/', '', $result));
+        return $quote;
     }
 
     /**
-     * @inheritdoc
-     * @group Block
+     * @test
+     * that getAddressHints returns quote shipping address data as hints
+     *
+     * @covers ::getAddressHints
+     *
+     * @throws ReflectionException if getAddressHints method doesn't exist
+     * @throws Mage_Core_Exception from test setup if unable to stub customer session singleton
      */
-    public function testGetSaveOrderURL()
+    public function getAddressHints_withQuoteContainingValidShippingAddress_returnsArrayContainingAddressDataInPrefill()
     {
-        $expected = Mage::helper('boltpay')->getMagentoUrl('boltpay/order/save');
+        $shippingAddress = Mage::getModel('sales/quote_address');
+        $shippingAddress
+            ->setEmail('test@example.com')
+            ->setFirstname('Test')
+            ->setLastname('Test')
+            ->setStreet("Address line 1\nAddress line 2")
+            ->setCity('Test city')
+            ->setRegion('Test region')
+            ->setZip('11000')
+            ->setTelephone('0123456789')
+            ->setCountryId('test');
+        $quote = $this->getAddressHintsSetUp(null, $shippingAddress);
+        $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE;
 
-        $result = $this->currentMock->getSaveOrderUrl();
+        $result = TestHelper::callNonPublicFunction(
+            $this->currentMock,
+            'getAddressHints',
+            array($quote, $checkoutType)
+        );
 
-        $this->assertEquals($expected, $result);
+        $this->assertEquals(
+            array(
+                'prefill' => array(
+                    'email'        => 'test@example.com',
+                    'firstName'    => 'Test',
+                    'lastName'     => 'Test',
+                    'addressLine1' => 'Address line 1',
+                    'addressLine2' => 'Address line 2',
+                    'city'         => 'Test city',
+                    'state'        => 'Test region',
+                    'phone'        => '0123456789',
+                    'country'      => 'test',
+                )
+            ),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     * that getAddressHints doesn't return pre-fill data when quote address is Apple Pay related
+     *
+     * @covers ::getAddressHints
+     * @throws ReflectionException if getAddressHints method doesn't exist
+     * @throws Mage_Core_Exception from test setup if unable to stub customer session singleton
+     */
+    public function getAddressHints_withApplePayRelatedData_returnsArrayWithoutPrefill()
+    {
+        $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE;
+        $shippingAddress = Mage::getModel('sales/quote_address');
+        $shippingAddress
+            ->setEmail('fake@email.com')
+            ->setTelephone('1111111111');
+        $quote = $this->getAddressHintsSetUp(null, $shippingAddress);
+
+        $result = TestHelper::callNonPublicFunction(
+            $this->currentMock,
+            'getAddressHints',
+            array($quote, $checkoutType)
+        );
+
+        $this->assertArrayNotHasKey('prefill', $result);
+    }
+
+    /**
+     * @test
+     * that getAddressHints returns pre-fill data from customer primary shipping address if quote doesn't have
+     * shipping address
+     *
+     * @covers ::getAddressHints
+     *
+     * @throws ReflectionException if getAddressHints method doesn't exist
+     * @throws Mage_Core_Exception from test setup if unable to stub session singleton
+     */
+    public function getAddressHints_customerLoggedInAndNoQuoteShippingAddress_returnsPrefillFromPrimaryShippingAddress()
+    {
+        $customerAddress = Mage::getModel('customer/address');
+        $customerAddress
+            ->setEmail('test@example.com')
+            ->setFirstname('Test')
+            ->setLastname('Test')
+            ->setStreet("Address line 1\nAddress line 2")
+            ->setCity('Test city')
+            ->setRegion('Test region')
+            ->setZip('11000')
+            ->setTelephone('0123456789')
+            ->setCountryId('test');
+
+        $quote = $this->getAddressHintsSetUp(self::RESERVED_CUSTOMER_ID, null);
+        $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE;
+
+        $customerMock = $this->getClassPrototype('Mage_Customer_Model_Customer')
+            ->setMethods(array('load', 'getPrimaryShippingAddress', 'getEmail'))->getMock();
+        $customerMock->expects($this->once())->method('load')->with(self::RESERVED_CUSTOMER_ID)->willReturnSelf();
+        $customerMock->expects($this->once())->method('getPrimaryShippingAddress')->willReturn($customerAddress);
+        $customerMock->expects($this->once())->method('getEmail')->willReturn('test2@example.com');
+        TestHelper::stubModel('customer/customer', $customerMock);
+
+        $result = TestHelper::callNonPublicFunction(
+            $this->currentMock,
+            'getAddressHints',
+            array($quote, $checkoutType)
+        );
+
+        $this->assertEquals(
+            array(
+                'prefill' => array(
+                    'email'        => 'test@example.com',
+                    'firstName'    => 'Test',
+                    'lastName'     => 'Test',
+                    'addressLine1' => 'Address line 1',
+                    'addressLine2' => 'Address line 2',
+                    'city'         => 'Test city',
+                    'state'        => 'Test region',
+                    'phone'        => '0123456789',
+                    'country'      => 'test',
+                )
+            ),
+            $result
+        );
+    }
+
+    /**
+     * @test
+     * that getAddressHints returns pre-fill data from customer primary shipping address if quote doesn't have
+     * shipping address
+     *
+     * @covers ::getAddressHints
+     *
+     * @throws ReflectionException if getAddressHints method doesn't exist
+     * @throws Mage_Core_Exception if unable to stub singleton
+     */
+    public function getAddressHints_adminCheckout_returnsVirtualTerminalModeTrueAndEmailPrefillFromAdminSession()
+    {
+        $quote = $this->getAddressHintsSetUp(self::RESERVED_CUSTOMER_ID, null);
+        $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_ADMIN;
+        $adminSessionMock = $this->getClassPrototype('Mage_Adminhtml_Model_Session')
+            ->setMethods(array('getOrderShippingAddress'))->getMock();
+        $adminSessionMock->expects($this->once())->method('getOrderShippingAddress')
+            ->willReturn(array('email' => 'test@example.com'));
+        TestHelper::stubSingleton('admin/session', $adminSessionMock);
+        $result = TestHelper::callNonPublicFunction(
+            $this->currentMock,
+            'getAddressHints',
+            array($quote, $checkoutType)
+        );
+        $this->assertEquals(
+            array(
+                'prefill'               => array(
+                    'email' => 'test@example.com',
+                ),
+                'virtual_terminal_mode' => true
+            ),
+            $result
+        );
+    }
+
+    /**
+     * Setup method for tests covering {@see Bolt_Boltpay_Block_Checkout_Boltpay::getAddressHints}
+     *
+     * @param null|string $checkoutMethod to be set ase current checkout method to onepage checkout
+     * @param null|int    $customerId to be set as current session customer id
+     *
+     * @return Mage_Sales_Model_Quote dummy quote
+     *
+     * @throws Mage_Core_Exception if unable to stub customer/session or checkout/type_onepage singleton
+     */
+    private function getReservedUserIdSetUp($customerId = null, $checkoutMethod = null)
+    {
+        $this->customerSessionMock->method('isLoggedIn')->willReturn($customerId !== null);
+        $this->customerSessionMock->method('getId')->willReturn($customerId);
+        $this->checkoutTypeOnepageMock->method('getCheckoutMethod')->willReturn($checkoutMethod);
+
+        TestHelper::stubSingleton('customer/session', $this->customerSessionMock);
+        TestHelper::stubSingleton('checkout/type_onepage', $this->checkoutTypeOnepageMock);
+        return $quote = Mage::getModel('sales/quote')->setStoreId(1);
+    }
+
+    /**
+     * @test
+     * that getReservedUserId returns new Bolt user id from customer increment id
+     * after setting it to current customer if customer is logged in
+     *
+     * @covers ::getReservedUserId
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to create dummy customer
+     * @throws Varien_Exception if unable to delete dummy customer
+     * @throws Mage_Core_Exception from test setup if unable to stub required singletons
+     */
+    public function getReservedUserId_withCustomerLoggedInWithoutBoltUserId_setsBoltUserIdAndSaves()
+    {
+        $customerId = Bolt_Boltpay_CouponHelper::createDummyCustomer(array(), 'getreserveduserid@bolt.com');
+
+        $quote = $this->getReservedUserIdSetUp($customerId);
+
+        $boltUserId = $this->currentMock->getReservedUserId($quote);
+
+        $customer = Mage::getModel('customer/customer')->load($customerId);
+        $this->assertEquals($boltUserId, $customer->getBoltUserId());
+
+        Bolt_Boltpay_CouponHelper::deleteDummyCustomer($customerId);
+    }
+
+    /**
+     * @test
+     * that getReservedUserId returns new Bolt user id from customer increment id after setting it on session
+     * if onepage checkout method is equal to register
+     *
+     * @covers ::getReservedUserId
+     *
+     * @throws Mage_Core_Exception from test setup if unable to stub singletons
+     */
+    public function getReservedUserId_withRegisterCheckoutMethod_setsBoltUserIdToSession()
+    {
+        $quote = $this->getReservedUserIdSetUp(null, Mage_Checkout_Model_Type_Onepage::METHOD_REGISTER);
+        $boltUserId = null;
+        $this->customerSessionMock->expects($this->once())->method('setBoltUserId')->willReturnCallback(
+            function ($value) use (&$boltUserId) {
+                $boltUserId = $value;
+            }
+        );
+        $reservedUserId = $this->currentMock->getReservedUserId($quote);
+        $this->assertEquals($boltUserId, $reservedUserId);
+        $this->assertNotNull($reservedUserId);
+
+    }
+
+    /**
+     * @test
+     * that getReservedUserId returns null if customer is not logged in and checkout method is not register
+     *
+     * @covers ::getReservedUserId
+     *
+     * @throws Mage_Core_Exception from test setup if unable to stub singleton
+     */
+    public function getReservedUserId_customerNotSignedInAndCheckoutMethodIsNotRegister_returnsNull()
+    {
+        $quote = $this->getReservedUserIdSetUp(null, null);
+        $this->assertNull($this->currentMock->getReservedUserId($quote));
+
+    }
+
+    /**
+     * @test
+     * that getCssSuffix returns CSS_SUFFIX class constant
+     *
+     * @covers ::getCssSuffix
+     */
+    public function getCssSuffix_always_returnsCSSSuffixConstant()
+    {
+        $this->assertEquals(BoltpayCheckoutBlock::CSS_SUFFIX, $this->currentMock->getCssSuffix());
+    }
+
+    /**
+     * @test
+     * that getSelectorsCSS follows expected formula when returning CSS based on stored configuration
+     *
+     * @covers ::getSelectorsCSS
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getSelectorsCSS_withFormula_returnsExpectedOutput()
+    {
+        $parentSelector = '.btn-proceed-checkout';
+        $parentSelectorWithSuffix = $parentSelector . '-' . BoltpayCheckoutBlock::CSS_SUFFIX;
+        $childSelector = 'body';
+        $style = '{ max-width: 95%;}';
+
+        $css = "$parentSelector { $childSelector $style}";
+
+        TestHelper::stubConfigValue('payment/boltpay/selector_styles', $css);
+        $result = $this->currentMock->getSelectorsCSS();
+        $this->assertEquals(
+            $childSelector . $parentSelectorWithSuffix . $style . $parentSelectorWithSuffix . " " . $childSelector . $style,
+            $result
+        );
+    }
+
+    /**
+     * @test
+     * that getSelectorsCSS returns expected CSS output when provided with example that is displayed on Magento backend
+     *
+     * @covers ::getSelectorsCSS
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getSelectorsCSS_withExample_returnsExpectedOutput()
+    {
+        $css = /** @lang SCSS */
+            <<<SCSS
+  .btn-proceed-checkout {
+    body { max-width: 95%;}
+    li.button-box { float: right; margin: 2px;}
+  }
+  ||
+  .btn-quickbuy {
+    li.button-container { float: left; }
+    .btn-quickbuy { width: 10px; }
+  }
+SCSS;
+
+        TestHelper::stubConfigValue('payment/boltpay/selector_styles', $css);
+        $result = $this->currentMock->getSelectorsCSS();
+        $this->assertEquals(
+            /** @lang CSS */
+            "body.btn-proceed-checkout-bolt-css-suffix{ max-width: 95%;}.btn-proceed-checkout-bolt-css-suffix body{ max-width: 95%;}li.button-box.btn-proceed-checkout-bolt-css-suffix{ float: right; margin: 2px;}.btn-proceed-checkout-bolt-css-suffix li.button-box{ float: right; margin: 2px;}li.button-container.btn-quickbuy-bolt-css-suffix{ float: left; }.btn-quickbuy-bolt-css-suffix li.button-container{ float: left; }.btn-quickbuy.btn-quickbuy-bolt-css-suffix{ width: 10px; }.btn-quickbuy-bolt-css-suffix .btn-quickbuy{ width: 10px; }",
+            $result
+        );
+    }
+
+    /**
+     * @test
+     * that getPublishableKey returns result of appropriate helper method
+     * depending on checkout type provided as parameter
+     *
+     * @covers ::getPublishableKey
+     *
+     * @dataProvider getPublishableKey_withVariousCheckoutTypes_callsRelatedHelperMethodProvider
+     *
+     * @param string $checkoutType currently used
+     * @param string $methodExpected to be called on helper
+     *
+     * @throws Mage_Core_Exception if unable to stub helper
+     */
+    public function getPublishableKey_withVariousCheckoutTypes_callsRelatedHelperMethod($checkoutType, $methodExpected)
+    {
+        $expectedResult = sha1('bolt');
+        $this->boltHelperMock->expects($this->once())->method($methodExpected)->willReturn($expectedResult);
+        TestHelper::stubHelper('boltpay', $this->boltHelperMock);
+        $this->assertEquals(
+            $expectedResult,
+            $this->currentMock->getPublishableKey($checkoutType)
+        );
+    }
+
+    /**
+     * Data provider for {@see getPublishableKey_withVariousCheckoutTypes_callsRelatedHelperMethod}
+     *
+     * @return array containing checkout type and method that is expected to be called
+     */
+    public function getPublishableKey_withVariousCheckoutTypes_callsRelatedHelperMethodProvider()
+    {
+        return array(
+            array('checkoutType' => 'multi-page', 'methodExpected' => 'getPublishableKeyMultiPage'),
+            array('checkoutType' => 'multipage', 'methodExpected' => 'getPublishableKeyMultiPage'),
+            array('checkoutType' => 'back-office', 'methodExpected' => 'getPublishableKeyBackOffice'),
+            array('checkoutType' => 'backoffice', 'methodExpected' => 'getPublishableKeyBackOffice'),
+            array('checkoutType' => 'admin', 'methodExpected' => 'getPublishableKeyBackOffice'),
+            array('checkoutType' => 'one-page', 'methodExpected' => 'getPublishableKeyOnePage'),
+            array('checkoutType' => 'onepage', 'methodExpected' => 'getPublishableKeyOnePage'),
+            array('checkoutType' => '', 'methodExpected' => 'getPublishableKeyOnePage'),
+        );
+    }
+
+    /**
+     * @test
+     * that getIpAddress returns IP address from provided request headers
+     *
+     * @covers ::getIpAddress
+     *
+     * @dataProvider getIpAddress_withVariousHeaders_willReturnExpectedIPProvider
+     *
+     * @param array  $headers to be added to $_SERVER
+     * @param string $expectedResult of the method call
+     */
+    public function getIpAddress_withVariousHeaders_willReturnExpectedIP($headers, $expectedResult)
+    {
+        $previousHeaders = $_SERVER;
+        $_SERVER = array_merge($_SERVER, $headers);
+        $this->assertEquals(
+            $expectedResult,
+            $this->currentMock->getIpAddress()
+        );
+        $_SERVER = $previousHeaders;
+    }
+
+    /**
+     * Data provider for {@see getIpAddress_withVariousHeaders_willReturnExpectedIP}
+     *
+     * @return array containing array of IP-related headers and expected result of the method call
+     */
+    public function getIpAddress_withVariousHeaders_willReturnExpectedIPProvider()
+    {
+        return array(
+            'Only REMOTE_ADDR with trim'         => array(
+                'headers'        => array('REMOTE_ADDR' => sprintf(" %s ", self::DEFAULT_IP)),
+                'expectedResult' => self::DEFAULT_IP
+            ),
+            'No headers'                         => array(
+                'headers'        => array(),
+                'expectedResult' => null
+            ),
+            'Loopback IP'                        => array(
+                'headers'        => array('REMOTE_ADDR' => '127.0.0.1'),
+                'expectedResult' => null
+            ),
+            'Local IP'                           => array(
+                'headers'        => array('REMOTE_ADDR' => '192.168.1.1'),
+                'expectedResult' => null
+            ),
+            'Additional loopback IP'             => array(
+                'headers'        => array('REMOTE_ADDR' => '::1'),
+                'expectedResult' => null
+            ),
+            'Invalid IP'                         => array(
+                'headers'        => array('REMOTE_ADDR' => 'TEST12345'),
+                'expectedResult' => null
+            ),
+            'Priorities'                         => array(
+                'headers'        => array(
+                    'HTTP_FORWARDED_FOR' => sprintf("%s ", self::DEFAULT_IP),
+                    'HTTP_CLIENT_IP'     => ' 5.67.89.9'
+                ),
+                'expectedResult' => '5.67.89.9'
+            ),
+            'Skip invalid even when prioritized' => array(
+                'headers'        => array(
+                    'HTTP_FORWARDED_FOR' => sprintf("%s ", self::DEFAULT_IP),
+                    'HTTP_CLIENT_IP'     => ' 5.67.89.9'
+                ),
+                'expectedResult' => '5.67.89.9'
+            ),
+        );
+    }
+
+    /**
+     * Setup method for tests covering {@see BoltpayCheckoutBlock::getLocationEstimate}
+     *
+     * @param null|string $locationInfo to be returned from session as cached data
+     *
+     * @return MockObject|BoltpayCheckoutBlock preconfigured mocked instance of class tested
+     *
+     * @throws Mage_Core_Exception if unable to stub singleton
+     */
+    public function getLocationEstimateSetUp($locationInfo = null)
+    {
+        $sessionMock = $this->getClassPrototype('Mage_Core_Model_Session')
+            ->setMethods(array('getLocationInfo', 'setLocationInfo'))->getMock();
+        $sessionMock->expects($this->once())->method('getLocationInfo')->willReturn($locationInfo);
+        TestHelper::stubSingleton('core/session', $sessionMock);
+        TestHelper::stubHelper('boltpay', $this->boltHelperMock);
+        return $sessionMock;
+    }
+
+    /**
+     * @test
+     * that getLocationEstimate returns data from session cache if present
+     *
+     * @covers ::getLocationEstimate
+     *
+     * @throws Mage_Core_Exception from test setup if unable to stub singleton
+     */
+    public function getLocationEstimate_withExistingLocationInfoInSession_returnsFromSession()
+    {
+        $this->apiClientMock->expects($this->never())->method('get');
+        $this->getLocationEstimateSetUp(self::LOCATION_INFO);
+        $this->assertEquals(self::LOCATION_INFO, $this->currentMock->getLocationEstimate());
+    }
+
+    /**
+     * @test
+     * that getLocationEstimate will request IP info from API if it's not cached in session
+     *
+     * @covers ::getLocationEstimate
+     * @covers ::url_get_contents
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     * @throws Mage_Core_Exception from test setup if unable to stub singleton
+     */
+    public function getLocationEstimate_withoutExistingLocationInfoInSession_requestsFromAPIAndSavesToSession()
+    {
+        $ipStackAccessKey = sha1('bolt');
+        TestHelper::stubConfigValue(
+            'payment/boltpay/ipstack_key',
+            Mage::helper('core')->encrypt($ipStackAccessKey)
+        );
+
+        $previousIp = $_SERVER['REMOTE_ADDR'];
+        $_SERVER['REMOTE_ADDR'] = self::DEFAULT_IP;
+
+        $this->apiClientMock->expects($this->once())->method('get')
+            ->with(
+                "http://api.ipstack.com/" . self::DEFAULT_IP . "?access_key=" . $ipStackAccessKey . "&output=json&legacy=1"
+            )
+            ->willReturnSelf();
+        $this->apiClientMock->expects($this->once())->method('getBody')->willReturn(self::LOCATION_INFO);
+        $sessionMock = $this->getLocationEstimateSetUp();
+        $sessionMock->expects($this->once())->method('setLocationInfo')->with(self::LOCATION_INFO);
+        $this->assertEquals(self::LOCATION_INFO, $this->currentMock->getLocationEstimate());
+        $_SERVER['REMOTE_ADDR'] = $previousIp;
+    }
+
+    /**
+     * @test
+     * that url_get_contents logs exception and returns null if an exception happens inside API client call
+     *
+     * @covers ::url_get_contents
+     *
+     * @throws Mage_Core_Exception if unable to stub helper
+     */
+    public function url_get_contents_whenApiClientThrowsException_logsExceptionAndReturnsNULL()
+    {
+        $url = 'https://bolt.com';
+        $exception = new Exception('Request timed out');
+        TestHelper::stubHelper('boltpay', $this->boltHelperMock);
+        $this->apiClientMock->expects($this->once())->method('get')->with($url)->willThrowException($exception);
+        $this->boltHelperMock->expects($this->once())->method('notifyException')->with($exception);
+        $this->boltHelperMock->expects($this->once())->method('logException')->with($exception);
+        $this->assertNull($this->currentMock->url_get_contents($url));
+    }
+
+    /**
+     * @test
+     * that getPublishableKeyForRoute returns publishable key for checkout type that is based on route and controller
+     *
+     * @covers ::getPublishableKeyForRoute
+     *
+     * @dataProvider getPublishableKeyForRoute_withVariousRoutesAndControllers_returnsResultOfGetPublishableKeyProvider
+     *
+     * @param string $route current Magento route
+     * @param string $controller current Magento controller
+     * @param string $checkoutType that is expected to be used
+     *
+     * @throws Exception if test class name is not defined
+     */
+    public function getPublishableKeyForRoute_withVariousRoutesAndControllers_returnsPublishableKeyForExpectedCheckoutType($route, $controller, $checkoutType)
+    {
+        /** @var MockObject|BoltpayCheckoutBlock $currentMock */
+        $currentMock = $this->getTestClassPrototype()->setMethods(array('getPublishableKey'))->getMock();
+        Mage::app()->getRequest()->setRouteName($route);
+        Mage::app()->getRequest()->setControllerName($controller);
+        $currentMock->expects($this->once())->method('getPublishableKey')->with($checkoutType);
+        $currentMock->getPublishableKeyForRoute();
+    }
+
+    /**
+     * Data provider for {@see getPublishableKeyForRoute_withVariousRoutesAndControllers_returnsResultOfGetPublishableKey}
+     *
+     * @return array containing route, controller and checkout type
+     */
+    public function getPublishableKeyForRoute_withVariousRoutesAndControllers_returnsResultOfGetPublishableKeyProvider()
+    {
+        return array(
+            'Admin'        => array(
+                'route'        => 'adminhtml',
+                'controller'   => 'index',
+                'checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_ADMIN
+            ),
+            'Firecheckout' => array(
+                'route'        => 'firecheckout',
+                'controller'   => 'index',
+                'checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_ONE_PAGE
+            ),
+            'One-page'     => array(
+                'route'        => 'checkout',
+                'controller'   => 'onepage',
+                'checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_ONE_PAGE
+            ),
+            'Multi-page'   => array(
+                'route'        => '',
+                'controller'   => '',
+                'checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE
+            ),
+        );
     }
 
     /**
@@ -314,13 +1097,13 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
 
         $mockProxy = new Bolt_Boltpay_Block_Checkout_Boltpay();
 
-        $this->app->getStore()->setConfig('payment/boltpay/publishable_key_multipage', $multiStepKey);
-        $this->app->getStore()->setConfig('payment/boltpay/publishable_key_onepage', $paymentOnlyKey);
+        TestHelper::stubConfigValue('payment/boltpay/publishable_key_multipage', $multiStepKey);
+        TestHelper::stubConfigValue('payment/boltpay/publishable_key_onepage', $paymentOnlyKey);
 
         $this->currentMock->expects($this->exactly(2))->method('getPublishableKey')
             ->withConsecutive(
-                [$this->equalTo('multi-page')],
-                [$this->equalTo('one-page')]
+                array($this->equalTo('multi-page')),
+                array($this->equalTo('one-page'))
             )
             ->willReturnOnConsecutiveCalls(
                 $mockProxy->getPublishableKey('multi-page'),
@@ -349,11 +1132,11 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
     {
         $this->setUp_getPublishableKeyForThisPage($multiStepKey, $paymentOnlyKey, $routeName, $controllerName);
 
-        $this->helperMock->expects($this->never())->method('logException');
-        $this->helperMock->expects($this->never())->method('notifyException');
+        $this->boltHelperMock->expects($this->never())->method('logException');
+        $this->boltHelperMock->expects($this->never())->method('notifyException');
 
-        $actualMultiStepKey =  $this->app->getStore()->getConfig('payment/boltpay/publishable_key_multipage');
-        $actualPaymentOnlyKey = $this->app->getStore()->getConfig('payment/boltpay/publishable_key_onepage');
+        $actualMultiStepKey =  Mage::app()->getStore()->getConfig('payment/boltpay/publishable_key_multipage');
+        $actualPaymentOnlyKey = Mage::app()->getStore()->getConfig('payment/boltpay/publishable_key_onepage');
 
         $actualReturnedValue = $this->currentMock->getPublishableKeyForThisPage();
         $this->assertTrue($actualMultiStepKey || $actualPaymentOnlyKey);
@@ -372,136 +1155,136 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      */
     public function getPublishableKeyForThisPage_withAtLeastOneKeyConfiguredProvider()
     {
-        return [
+        return array(
             "When both keys exist on standard cart page, multi-step is used" =>
-            [
-                "multiStepKey" => "multi+payOnly-key-on-standard-cart",
-                "paymentOnlyKey" => "payOnly+multi-key-on-standard-cart",
-                "routeName" => "checkout",
-                "controllerName" => "cart",
-                "expectedReturnValue" => "multi+payOnly-key-on-standard-cart"
-            ],
+                array(
+                    "multiStepKey" => "multi+payOnly-key-on-standard-cart",
+                    "paymentOnlyKey" => "payOnly+multi-key-on-standard-cart",
+                    "routeName" => "checkout",
+                    "controllerName" => "cart",
+                    "expectedReturnValue" => "multi+payOnly-key-on-standard-cart"
+                ),
             "When only multi-step key exists on standard cart page, empty string payment-only, multi-step is used" =>
-            [
-                "multiStepKey" => "multi-key-on-standard-cart",
-                "paymentOnlyKey" => "",
-                "routeName" => "checkout",
-                "controllerName" => "cart",
-                "expectedReturnValue" => "multi-key-on-standard-cart"
-            ],
+                array(
+                    "multiStepKey" => "multi-key-on-standard-cart",
+                    "paymentOnlyKey" => "",
+                    "routeName" => "checkout",
+                    "controllerName" => "cart",
+                    "expectedReturnValue" => "multi-key-on-standard-cart"
+                ),
             "When only multi-step key exists on standard cart page, null payment-only, multi-step is used" =>
-            [
-                "multiStepKey" => "multi-key-on-standard-cart",
-                "paymentOnlyKey" => null,
-                "routeName" => "checkout",
-                "controllerName" => "cart",
-                "expectedReturnValue" => "multi-key-on-standard-cart"
-            ],
+                array(
+                    "multiStepKey" => "multi-key-on-standard-cart",
+                    "paymentOnlyKey" => null,
+                    "routeName" => "checkout",
+                    "controllerName" => "cart",
+                    "expectedReturnValue" => "multi-key-on-standard-cart"
+                ),
             "When only payment-only key exists on standard cart page, null multi-step, payment-only is used" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => "payOnly-key-on-standard-cart",
-                "routeName" => "checkout",
-                "controllerName" => "cart",
-                "expectedReturnValue" => "payOnly-key-on-standard-cart"
-            ],
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => "payOnly-key-on-standard-cart",
+                    "routeName" => "checkout",
+                    "controllerName" => "cart",
+                    "expectedReturnValue" => "payOnly-key-on-standard-cart"
+                ),
             "When both keys exist on custom cart page, multi-step is used" =>
-            [
-                "multiStepKey" => "multi+payOnly-key-on-custom-cart",
-                "paymentOnlyKey" => "payOnly+multi-key-on-custom-cart",
-                "routeName" => "custom",
-                "controllerName" => "cart",
-                "expectedReturnValue" => "multi+payOnly-key-on-custom-cart"
-            ],
+                array(
+                    "multiStepKey" => "multi+payOnly-key-on-custom-cart",
+                    "paymentOnlyKey" => "payOnly+multi-key-on-custom-cart",
+                    "routeName" => "custom",
+                    "controllerName" => "cart",
+                    "expectedReturnValue" => "multi+payOnly-key-on-custom-cart"
+                ),
             "When only multi-step key exists on custom cart page, null payment-only, multi-step is used" =>
-            [
-                "multiStepKey" => "multi-key-on-custom-cart",
-                "paymentOnlyKey" => null,
-                "routeName" => "custom",
-                "controllerName" => "cart",
-                "expectedReturnValue" => "multi-key-on-custom-cart"
-            ],
+                array(
+                    "multiStepKey" => "multi-key-on-custom-cart",
+                    "paymentOnlyKey" => null,
+                    "routeName" => "custom",
+                    "controllerName" => "cart",
+                    "expectedReturnValue" => "multi-key-on-custom-cart"
+                ),
             "When only payment-only key exists on custom cart page, null multi-step, payment-only is used" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => "payOnly-key-on-custom-cart",
-                "routeName" => "custom",
-                "controllerName" => "cart",
-                "expectedReturnValue" => "payOnly-key-on-custom-cart"
-            ],
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => "payOnly-key-on-custom-cart",
+                    "routeName" => "custom",
+                    "controllerName" => "cart",
+                    "expectedReturnValue" => "payOnly-key-on-custom-cart"
+                ),
             "When both keys exist on standard onepage, payment-only is used" =>
-            [
-                "multiStepKey" => "multi+payOnly-key-on-onepage",
-                "paymentOnlyKey" => "payOnly+multi-key-on-onepage",
-                "routeName" => "checkout",
-                "controllerName" => "onepage",
-                "expectedReturnValue" => "payOnly+multi-key-on-onepage"
-            ],
+                array(
+                    "multiStepKey" => "multi+payOnly-key-on-onepage",
+                    "paymentOnlyKey" => "payOnly+multi-key-on-onepage",
+                    "routeName" => "checkout",
+                    "controllerName" => "onepage",
+                    "expectedReturnValue" => "payOnly+multi-key-on-onepage"
+                ),
             "When only payment-only key exists on standard onepage, null multi-step, payment-only is used" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => "payOnly-key-on-onepage",
-                "routeName" => "checkout",
-                "controllerName" => "onepage",
-                "expectedReturnValue" => "payOnly-key-on-onepage"
-            ],
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => "payOnly-key-on-onepage",
+                    "routeName" => "checkout",
+                    "controllerName" => "onepage",
+                    "expectedReturnValue" => "payOnly-key-on-onepage"
+                ),
             "When only multi-step key exists on standard onepage, empty string payment-only, multi-step is used" =>
-            [
-                "multiStepKey" => "multi-key-on-onepage",
-                "paymentOnlyKey" => "",
-                "routeName" => "checkout",
-                "controllerName" => "onepage",
-                "expectedReturnValue" => "multi-key-on-onepage"
-            ],
+                array(
+                    "multiStepKey" => "multi-key-on-onepage",
+                    "paymentOnlyKey" => "",
+                    "routeName" => "checkout",
+                    "controllerName" => "onepage",
+                    "expectedReturnValue" => "multi-key-on-onepage"
+                ),
             "When both keys exist on unexpected page, payment-only is used" =>
-            [
-                "multiStepKey" => "multi+payOnly-key-on-homepage",
-                "paymentOnlyKey" => "payOnly+multi-key-on-homepage",
-                "routeName" => "cms",
-                "controllerName" => "index",
-                "expectedReturnValue" => "payOnly+multi-key-on-homepage"
-            ],
+                array(
+                    "multiStepKey" => "multi+payOnly-key-on-homepage",
+                    "paymentOnlyKey" => "payOnly+multi-key-on-homepage",
+                    "routeName" => "cms",
+                    "controllerName" => "index",
+                    "expectedReturnValue" => "payOnly+multi-key-on-homepage"
+                ),
             "When only payment-only key exists on unexpected page, empty string multi-step, payment-only is used" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => "payOnly-key-on-homepage",
-                "routeName" => "cms",
-                "controllerName" => "index",
-                "expectedReturnValue" => "payOnly-key-on-homepage"
-            ],
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => "payOnly-key-on-homepage",
+                    "routeName" => "cms",
+                    "controllerName" => "index",
+                    "expectedReturnValue" => "payOnly-key-on-homepage"
+                ),
             "When only multi-step key exists on unexpected page, empty string payment-only, multi-step is used" =>
-            [
-                "multiStepKey" => "multi+payOnly-key-on-homepage",
-                "paymentOnlyKey" => "",
-                "routeName" => "cms",
-                "controllerName" => "index",
-                "expectedReturnValue" => "multi+payOnly-key-on-homepage"
-            ],
+                array(
+                    "multiStepKey" => "multi+payOnly-key-on-homepage",
+                    "paymentOnlyKey" => "",
+                    "routeName" => "cms",
+                    "controllerName" => "index",
+                    "expectedReturnValue" => "multi+payOnly-key-on-homepage"
+                ),
             "When both keys exist on product page, multi-step is used" =>
-            [
-                "multiStepKey" => "multi+payOnly-key-on-product",
-                "paymentOnlyKey" => "payOnly+multi-key-on-product",
-                "routeName" => "catalog",
-                "controllerName" => "product",
-                "expectedReturnValue" => "multi+payOnly-key-on-product"
-            ],
+                array(
+                    "multiStepKey" => "multi+payOnly-key-on-product",
+                    "paymentOnlyKey" => "payOnly+multi-key-on-product",
+                    "routeName" => "catalog",
+                    "controllerName" => "product",
+                    "expectedReturnValue" => "multi+payOnly-key-on-product"
+                ),
             "When only multi-step key exists on product page, null payment-only, multi-step is used" =>
-            [
-                "multiStepKey" => "multi-key-on-product",
-                "paymentOnlyKey" => null,
-                "routeName" => "catalog",
-                "controllerName" => "product",
-                "expectedReturnValue" => "multi-key-on-product"
-            ],
+                array(
+                    "multiStepKey" => "multi-key-on-product",
+                    "paymentOnlyKey" => null,
+                    "routeName" => "catalog",
+                    "controllerName" => "product",
+                    "expectedReturnValue" => "multi-key-on-product"
+                ),
             "When only payment-only key exists on product page, null multi-step, payment-only is used" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => "payOnly-key-on-product",
-                "routeName" => "catalog",
-                "controllerName" => "product",
-                "expectedReturnValue" => "payOnly-key-on-product"
-            ]
-        ];
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => "payOnly-key-on-product",
+                    "routeName" => "catalog",
+                    "controllerName" => "product",
+                    "expectedReturnValue" => "payOnly-key-on-product"
+                )
+        );
     }
 
     /**
@@ -523,12 +1306,13 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
     public function getPublishableKeyForThisPage_whenNoKeyIsConfigured($multiStepKey, $paymentOnlyKey, $routeName, $controllerName)
     {
         $this->setUp_getPublishableKeyForThisPage($multiStepKey, $paymentOnlyKey, $routeName, $controllerName);
+        TestHelper::stubHelper('boltpay', $this->boltHelperMock);
 
-        $this->helperMock->expects($this->once())->method('logException');
-        $this->helperMock->expects($this->once())->method('notifyException');
+        $this->boltHelperMock->expects($this->once())->method('logException');
+        $this->boltHelperMock->expects($this->once())->method('notifyException');
 
-        $actualMultiStepKey =  $this->app->getStore()->getConfig('payment/boltpay/publishable_key_multipage');
-        $actualPaymentOnlyKey = $this->app->getStore()->getConfig('payment/boltpay/publishable_key_onepage');
+        $actualMultiStepKey =  Mage::app()->getStore()->getConfig('payment/boltpay/publishable_key_multipage');
+        $actualPaymentOnlyKey = Mage::app()->getStore()->getConfig('payment/boltpay/publishable_key_onepage');
 
         $this->currentMock->getPublishableKeyForThisPage();
         $this->assertFalse($actualMultiStepKey || $actualPaymentOnlyKey, "No key should be configured: multi [$actualMultiStepKey], paymentOnly [$actualPaymentOnlyKey]");
@@ -545,512 +1329,1004 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      */
     public function getPublishableKeyForThisPage_whenNoKeyIsConfiguredProvider()
     {
-        return [
-            "When no keys are configure, null multi-step and empty string payment-only, on standard cart page" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => "",
-                "routeName" => "checkout",
-                "controllerName" => "cart"
-            ],
-            "When no keys are configure, empty string multi-step and null payment-only, on standard cart page" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => null,
-                "routeName" => "checkout",
-                "controllerName" => "cart"
-            ],
-            "When no keys are configure, empty strings, on standard cart page" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => "",
-                "routeName" => "checkout",
-                "controllerName" => "cart"
-            ],
-            "When no keys are configure, nulls, on standard cart page" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => null,
-                "routeName" => "checkout",
-                "controllerName" => "cart"
-            ],
-            "When no keys are configure, null multi-step and empty string payment-only, on custom cart page" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => "",
-                "routeName" => "custom",
-                "controllerName" => "cart"
-            ],
-            "When no keys are configure, empty string multi-step and null payment-only, on custom cart page" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => null,
-                "routeName" => "custom",
-                "controllerName" => "cart"
-            ],
-            "When no keys are configure, empty strings, on custom cart page" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => "",
-                "routeName" => "custom",
-                "controllerName" => "cart"
-            ],
-            "When no keys are configure, nulls, on custom cart page" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => null,
-                "routeName" => "custom",
-                "controllerName" => "cart"
-            ],
-            "When no keys are configure, null multi-step and empty string payment-only, on standard onepage" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => "",
-                "routeName" => "checkout",
-                "controllerName" => "onepage"
-            ],
-            "When no keys are configure, empty string multi-step and null payment-only, on standard onepage" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => null,
-                "routeName" => "checkout",
-                "controllerName" => "onepage"
-            ],
-            "When no keys are configure, empty strings, on standard onepage" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => "",
-                "routeName" => "checkout",
-                "controllerName" => "onepage"
-            ],
-            "When no keys are configure, nulls, on standard onepage" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => null,
-                "routeName" => "checkout",
-                "controllerName" => "onepage"
-            ],
-            "When no keys are configure, null multi-step and empty string payment-only, on unexpected page" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => "",
-                "routeName" => "cms",
-                "controllerName" => "index"
-            ],
-            "When no keys are configure, empty string multi-step and null payment-only, on unexpected page" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => null,
-                "routeName" => "cms",
-                "controllerName" => "index"
-            ],
-            "When no keys are configure, empty strings, on unexpected page" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => "",
-                "routeName" => "cms",
-                "controllerName" => "index"
-            ],
-            "When no keys are configure, nulls, on unexpected page" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => null,
-                "routeName" => "cms",
-                "controllerName" => "index"
-            ],
-            "When no keys are configure, null multi-step and empty string payment-only, on product page" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => "",
-                "routeName" => "catalog",
-                "controllerName" => "product"
-            ],
-            "When no keys are configure, empty string multi-step and null payment-only, on product page" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => null,
-                "routeName" => "catalog",
-                "controllerName" => "product"
-            ],
-            "When no keys are configure, empty strings, on product page" =>
-            [
-                "multiStepKey" => "",
-                "paymentOnlyKey" => "",
-                "routeName" => "catalog",
-                "controllerName" => "product"
-            ],
-            "When no keys are configure, nulls, on product page" =>
-            [
-                "multiStepKey" => null,
-                "paymentOnlyKey" => null,
-                "routeName" => "catalog",
-                "controllerName" => "product"
-            ]
-        ];
+        return array(
+            "When no keys are configured, null multi-step and empty string payment-only, on standard cart page" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => "",
+                    "routeName" => "checkout",
+                    "controllerName" => "cart"
+                ),
+            "When no keys are configured, empty string multi-step and null payment-only, on standard cart page" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => null,
+                    "routeName" => "checkout",
+                    "controllerName" => "cart"
+                ),
+            "When no keys are configured, empty strings, on standard cart page" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => "",
+                    "routeName" => "checkout",
+                    "controllerName" => "cart"
+                ),
+            "When no keys are configured, nulls, on standard cart page" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => null,
+                    "routeName" => "checkout",
+                    "controllerName" => "cart"
+                ),
+            "When no keys are configured, null multi-step and empty string payment-only, on custom cart page" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => "",
+                    "routeName" => "custom",
+                    "controllerName" => "cart"
+                ),
+            "When no keys are configured, empty string multi-step and null payment-only, on custom cart page" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => null,
+                    "routeName" => "custom",
+                    "controllerName" => "cart"
+                ),
+            "When no keys are configured, empty strings, on custom cart page" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => "",
+                    "routeName" => "custom",
+                    "controllerName" => "cart"
+                ),
+            "When no keys are configured, nulls, on custom cart page" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => null,
+                    "routeName" => "custom",
+                    "controllerName" => "cart"
+                ),
+            "When no keys are configured, null multi-step and empty string payment-only, on standard onepage" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => "",
+                    "routeName" => "checkout",
+                    "controllerName" => "onepage"
+                ),
+            "When no keys are configured, empty string multi-step and null payment-only, on standard onepage" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => null,
+                    "routeName" => "checkout",
+                    "controllerName" => "onepage"
+                ),
+            "When no keys are configured, empty strings, on standard onepage" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => "",
+                    "routeName" => "checkout",
+                    "controllerName" => "onepage"
+                ),
+            "When no keys are configured, nulls, on standard onepage" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => null,
+                    "routeName" => "checkout",
+                    "controllerName" => "onepage"
+                ),
+            "When no keys are configured, null multi-step and empty string payment-only, on unexpected page" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => "",
+                    "routeName" => "cms",
+                    "controllerName" => "index"
+                ),
+            "When no keys are configured, empty string multi-step and null payment-only, on unexpected page" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => null,
+                    "routeName" => "cms",
+                    "controllerName" => "index"
+                ),
+            "When no keys are configured, empty strings, on unexpected page" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => "",
+                    "routeName" => "cms",
+                    "controllerName" => "index"
+                ),
+            "When no keys are configured, nulls, on unexpected page" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => null,
+                    "routeName" => "cms",
+                    "controllerName" => "index"
+                ),
+            "When no keys are configured, null multi-step and empty string payment-only, on product page" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => "",
+                    "routeName" => "catalog",
+                    "controllerName" => "product"
+                ),
+            "When no keys are configured, empty string multi-step and null payment-only, on product page" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => null,
+                    "routeName" => "catalog",
+                    "controllerName" => "product"
+                ),
+            "When no keys are configured, empty strings, on product page" =>
+                array(
+                    "multiStepKey" => "",
+                    "paymentOnlyKey" => "",
+                    "routeName" => "catalog",
+                    "controllerName" => "product"
+                ),
+            "When no keys are configured, nulls, on product page" =>
+                array(
+                    "multiStepKey" => null,
+                    "paymentOnlyKey" => null,
+                    "routeName" => "catalog",
+                    "controllerName" => "product"
+                )
+        );
     }
 
     /**
      * @test
-     * @group Block
-     * @dataProvider isTestModeData
+     * that getCartURL returns checkout cart Magento URL
+     *
+     * @covers ::getCartURL
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to get Magento url
      */
-    public function isTestMode($data)
+    public function getCartURL_always_returnsCheckoutCartMagentoUrl()
     {
-        $this->app->getStore()->resetConfig();
-        $this->app->getStore()->setConfig('payment/boltpay/test', $data['test']);
+        $expected = Mage::helper('boltpay')->getMagentoUrl('checkout/cart');
+
+        $this->assertEquals($expected, $this->currentMock->getCartURL());
+    }
+
+    /**
+     * @test
+     * that getAdditionalJs returns value from store configuration
+     *
+     * @covers ::getAdditionalCSS
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getAdditionalCSS_always_returnsAdditionalCSSFromConfiguration()
+    {
+        $style = '.test-selector { color: red; }';
+
+        TestHelper::stubConfigValue('payment/boltpay/additional_css', $style);
+
+        $this->assertEquals($style, $this->currentMock->getAdditionalCSS());
+    }
+
+    /**
+     * @test
+     * that getAdditionalJs returns value from store configuration
+     *
+     * @covers ::getAdditionalJs
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getAdditionalJs_always_returnsValueFromConfiguration()
+    {
+        $js = 'jQuery("body div").text("Hello, world.")';
+
+        TestHelper::stubConfigValue('payment/boltpay/additional_js', $js);
+
+        $this->assertEquals($js, $this->currentMock->getAdditionalJs());
+    }
+
+    /**
+     * @test
+     * that getSuccessUrl returns Magento url based on successpage config value
+     *
+     * @covers ::getSuccessURL
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getSuccessURL_always_returnsMagentoUrlBasedOnSuccessPageConfigValue()
+    {
+        $url = 'checkout/onepage/success';
+        TestHelper::stubConfigValue('payment/boltpay/successpage', $url);
+        $this->assertEquals(Mage::helper('boltpay')->getMagentoUrl($url), $this->currentMock->getSuccessURL());
+    }
+
+    /**
+     * Setup method for {@see Bolt_Boltpay_Block_Checkout_BoltpayTest::buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJs}
+     *
+     * @param string $checkoutType currently in use
+     * @param bool   $cloneOnClick extra-config flag for cloneOnClick
+     * @param bool   $isShoppingCartPage whether current page is checkout/cart
+     *
+     * @return array containing hint data, cart data, mock instance and quote mock
+     * @throws Mage_Core_Exception if unable to stub helper
+     * @throws Exception if test class name is not set
+     */
+    private function buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJsSetUp($checkoutType, $cloneOnClick = false, $isShoppingCartPage = false)
+    {
+        $hintData = array(
+            'signed_merchant_user_id' => array(
+                "merchant_user_id" => self::RESERVED_CUSTOMER_ID,
+                "signature"        => sha1('test'),
+                "nonce"            => rand(100000000, 999999999),
+            )
+        );
+        $cartData = Mage::getModel('boltpay/boltOrder')->getBoltOrderTokenPromise($checkoutType);
+        TestHelper::stubHelper('boltpay', $this->boltHelperMock);
+        /** @var MockObject|Bolt_Boltpay_Block_Checkout_Boltpay $currentMock */
+        $currentMock = $this->getTestClassPrototype()
+            ->setMethods(array('buildOnCheckCallback', 'buildOnSuccessCallback', 'buildOnCloseCallback'))
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+
+        /** @var MockObject|Mage_Sales_Model_Quote $quoteMock */
+        $quoteMock = $this->getClassPrototype('Mage_Sales_Model_Quote')->getMock();
+        $quoteMock->method('getId')->willReturn(self::QUOTE_ID);
+
+        $boltCallbacksDummyValue = '/*BOLT-CALLBACKS*/';
+        $this->boltHelperMock->expects($this->once())->method('getBoltCallbacks')->with($checkoutType, $quoteMock)
+            ->willReturn($boltCallbacksDummyValue);
+        $this->boltHelperMock->expects($this->once())->method('getPaymentBoltpayConfig')->with('check', $checkoutType)
+            ->willReturn(self::CHECK_FUNCTION);
+        $this->boltHelperMock->expects($this->once())->method('buildOnCheckCallback')->with($checkoutType, $quoteMock)
+            ->willReturn(self::ON_CHECK_CALLBACK);
+        $this->boltHelperMock->method('getExtraConfig')->willReturnMap(
+            array(
+                array('hintsTransform', array(), self::HINTS_TRANSFORM_FUNCTION),
+                array('cloneOnClick', array(), $cloneOnClick)
+            )
+        );
+        $this->boltHelperMock->method('isShoppingCartPage')->willReturn($isShoppingCartPage);
+        return array($hintData, $cartData, $currentMock, $quoteMock);
+    }
+
+    /**
+     * @test
+     * that buildBoltCheckoutJavascript returns normal or postponed configuration depending on parameters
+     *
+     * @covers ::buildBoltCheckoutJavascript
+     *
+     * @dataProvider buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJsProvider
+     *
+     * @param string $checkoutType currently in use
+     * @param bool   $isShoppingCartPage whether current page is checkout/cart
+     * @param bool   $shouldCloneImmediately inverse of extra-config flag for cloneOnClick
+     * @param bool   $expectPostponedConfiguration is postponed or normal configuration expected
+     *
+     * @throws Mage_Core_Exception from test setup if unable to stub helper
+     */
+    public function buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJs($checkoutType, $isShoppingCartPage, $shouldCloneImmediately, $expectPostponedConfiguration)
+    {
+        list($hintData, $cartData, $currentMock, $quoteMock) = $this->buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJsSetUp(
+            $checkoutType,
+            !$shouldCloneImmediately,
+            $isShoppingCartPage
+        );
+        $this->boltHelperMock->expects($this->once())->method('doFilterEvent')
+            ->with(
+                'bolt_boltpay_filter_bolt_checkout_javascript',
+                $this->callback(
+                    function ($js) use ($cartData, $hintData, $expectPostponedConfiguration) {
+                        $this->assertContains(
+                            sprintf('var $hints_transform = %s;', self::HINTS_TRANSFORM_FUNCTION),
+                            $js
+                        );
+                        $this->assertContains(
+                            sprintf(
+                                'var get_json_cart = function() { return %s };',
+                                (is_string($cartData)) ? $cartData : json_encode($cartData)
+                            ),
+                            $js
+                        );
+                        $this->assertContains(
+                            sprintf(
+                                'var json_hints = $hints_transform(%s);',
+                                json_encode($hintData, JSON_FORCE_OBJECT)
+                            ),
+                            $js
+                        );
+                        $this->assertContains(sprintf("var quote_id = '%s';", self::QUOTE_ID), $js);
+                        $this->assertContains('var order_completed = false;', $js);
+                        $this->assertContains(sprintf('var do_checks = %d;', !$expectPostponedConfiguration), $js);
+                        $windowBoltModal = explode('window.BoltModal = ', $js)[1];
+                        $this->assertContains(
+                            'BoltCheckout.configure(get_json_cart(),json_hints,/*BOLT-CALLBACKS*/);',
+                            preg_replace('/\s*/', '', $windowBoltModal)
+                        );
+
+                        if ($expectPostponedConfiguration) {
+                            $this->assertRegExp(
+                                /** @lang PhpRegExp */ '/BoltCheckout\.configure\(\s*new Promise/',
+                                $windowBoltModal
+                            );
+                            $this->assertRegExp(
+                                sprintf(
+                                    /** @lang PhpRegExp */ '/\{\s*check: function\(\) \{\s*%s\s*%s/',
+                                    preg_quote(self::CHECK_FUNCTION),
+                                    preg_quote(self::ON_CHECK_CALLBACK)
+                                ),
+                                $windowBoltModal
+                            );
+                        }
+
+                        return true;
+                    }
+                ),
+                array(
+                    'checkoutType' => $checkoutType,
+                    'quote'        => $quoteMock,
+                    'hintData'     => $hintData,
+                    'cartData'     => $cartData
+                )
+            );
+
+        $currentMock->buildBoltCheckoutJavascript($checkoutType, $quoteMock, $hintData, $cartData);
+    }
+
+    /**
+     * Data provider for {@see buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJs}
+     *
+     * @return array containing checkout type, is current page cart flag, should clone immediately config and flag whether to expect postponed configuration
+     */
+    public function buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJsProvider()
+    {
+        return array(
+            array(
+                'checkoutType'                 => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE,
+                'isShoppingCartPage'           => true,
+                'shouldCloneImmediately'       => true,
+                'expectPostponedConfiguration' => false
+            ),
+            array(
+                'checkoutType'                 => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE,
+                'isShoppingCartPage'           => true,
+                'shouldCloneImmediately'       => false,
+                'expectPostponedConfiguration' => true
+            ),
+            array(
+                'checkoutType'                 => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE,
+                'isShoppingCartPage'           => false,
+                'shouldCloneImmediately'       => false,
+                'expectPostponedConfiguration' => true
+            ),
+            array(
+                'checkoutType'                 => BoltpayCheckoutBlock::CHECKOUT_TYPE_ONE_PAGE,
+                'isShoppingCartPage'           => true,
+                'shouldCloneImmediately'       => true,
+                'expectPostponedConfiguration' => false
+            ),
+            array(
+                'checkoutType'                 => BoltpayCheckoutBlock::CHECKOUT_TYPE_ONE_PAGE,
+                'isShoppingCartPage'           => true,
+                'shouldCloneImmediately'       => false,
+                'expectPostponedConfiguration' => true
+            ),
+            array(
+                'checkoutType'                 => BoltpayCheckoutBlock::CHECKOUT_TYPE_ADMIN,
+                'isShoppingCartPage'           => false,
+                'shouldCloneImmediately'       => false,
+                'expectPostponedConfiguration' => true
+            ),
+            array(
+                'checkoutType'                 => BoltpayCheckoutBlock::CHECKOUT_TYPE_FIRECHECKOUT,
+                'isShoppingCartPage'           => false,
+                'shouldCloneImmediately'       => false,
+                'expectPostponedConfiguration' => true
+            ),
+        );
+    }
+
+    /**
+     * @test
+     * that getSaveOrderURL returns save order URL
+     *
+     * @covers ::getSaveOrderURL
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to get Magento url
+     */
+    public function getSaveOrderURL_always_returnsBoltSaveOrderUrl()
+    {
+        $expected = Mage::helper('boltpay')->getMagentoUrl('boltpay/order/save');
+
+        $result = $this->currentMock->getSaveOrderURL();
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @test
+     * that isTestMode returns flag value from configuration for test field
+     *
+     * @covers ::isTestMode
+     *
+     * @dataProvider isTestMode_always_determinesIfTestModeIsSetInConfigurationProvider
+     *
+     * @param mixed $isTestModeConfig config value for_test_mode
+     * @param bool  $expectedResult of the method call
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function isTestMode_always_determinesIfTestModeIsSetInConfiguration($isTestModeConfig, $expectedResult)
+    {
+        TestHelper::stubConfigValue('payment/boltpay/test', $isTestModeConfig);
         $result = $this->currentMock->isTestMode();
         $this->assertInternalType('boolean', $result);
-        $this->assertEquals($data['expect'], $result);
+        $this->assertEquals($expectedResult, $result);
     }
 
     /**
-     * Test cases
-     * @return boolean[][][]
+     * Data provider for {@see isTestMode_always_determinesIfTestModeIsSetInConfiguration}
+     *
+     * @return array[] containing configuration value for test and expected result of the method call
      */
-    public function isTestModeData()
+    public function isTestMode_always_determinesIfTestModeIsSetInConfigurationProvider()
     {
         return array(
-            array(
-                'data' => array(
-                    'expect' => true,
-                    'test' => true
-                )
-            ),
-            array(
-                'data' => array(
-                    'expect' => false,
-                    'test' => false
-                )
-            )
+            'Empty value should return false'   => array('isTestModeConfig' => '', 'expectedResult' => false),
+            'Zero should return false'          => array('isTestModeConfig' => '0', 'expectedResult' => false),
+            'Null should return false'          => array('isTestModeConfig' => null, 'expectedResult' => false),
+            'Boolean false should return false' => array('isTestModeConfig' => 'false', 'expectedResult' => false),
+            'String false should return false'  => array('isTestModeConfig' => false, 'expectedResult' => false),
+            'String true should return true'    => array('isTestModeConfig' => 'true', 'expectedResult' => true),
+            'String one should return true'     => array('isTestModeConfig' => '1', 'expectedResult' => true),
+            'Integer one should return true'    => array('isTestModeConfig' => 1, 'expectedResult' => true),
         );
     }
 
     /**
      * @test
-     * @group Block
-     * @dataProvider getConfigSelectorsData
+     * that getConfigSelectors returns config value for selectors in JSON format
+     *
+     * @dataProvider getConfigSelectors_withVariousConfigurations_returnsJsonEncodedAndFilteredSelectorsProvider
+     *
+     * @param string $selectors configuration value for selectors
+     * @param string $expectedResult of the method call
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function getConfigSelectors($data)
+    public function getConfigSelectors_withVariousConfigurations_returnsJsonEncodedAndFilteredSelectors($selectors, $expectedResult)
     {
-        $this->app->getStore()->resetConfig();
-        $this->app->getStore()->setConfig('payment/boltpay/selectors', $data['selectors']);
+        TestHelper::stubConfigValue('payment/boltpay/selectors', $selectors);
         $result = $this->currentMock->getConfigSelectors();
-        $this->assertInternalType('string', $result);
-        $this->assertEquals($data['expect'], $result);
+        $this->assertJson($result);
+        $this->assertEquals($expectedResult, $result);
     }
 
     /**
-     * Test cases
-     * @return string[][][]
+     * Data provider for {@see getConfigSelectors_withVariousConfigurations_returnsJsonEncodedAndFilteredSelectors}
+     *
+     * @return string[][] containing configuration value for selectors and expected result of the method call
      */
-    public function getConfigSelectorsData()
+    public function getConfigSelectors_withVariousConfigurations_returnsJsonEncodedAndFilteredSelectorsProvider()
     {
         return array(
-            array(
-                'data' => array(
-                    'expect' => '[]',
-                    'selectors' => ''
-                )
+            'Empty config returns empty JSON array' => array(
+                'selectors' => '',
+                'expect'    => '[]',
             ),
-            array(
-                'data' => array(
-                    'expect' => '[".btn"]',
-                    'selectors' => '.btn'
-                )
+            'Single selector returns JSON array'    => array(
+                'selectors' => '.btn',
+                'expect'    => '[".btn"]',
             ),
-            array(
-                'data' => array(
-                    'expect' => '[".btn"," div.checkout"]',
-                    'selectors' => '.btn, div.checkout'
-                )
+            'Multiple selectors returns JSON array' => array(
+                'selectors' => '.btn, div.checkout',
+                'expect'    => '[".btn"," div.checkout"]',
             ),
         );
     }
 
     /**
      * @test
-     * @group Block
-     * @dataProvider isBoltOnlyPaymentData
+     * that isBoltOnlyPayment returns config value for payment/boltpay/skip_payment config path
+     *
+     * @covers ::isBoltOnlyPayment
+     *
+     * @dataProvider isBoltOnlyPayment_withVariousConfigurationValues_determinesIsBoltOnlyPaymentProvider
+     *
+     * @param mixed $skipPayment value in configuration for skip payment
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isBoltOnlyPayment($data)
+    public function isBoltOnlyPayment_withVariousConfigurationValues_determinesIsBoltOnlyPayment($skipPayment)
     {
-        $this->app->getStore()->resetConfig();
-        $this->app->getStore()->setConfig('payment/boltpay/skip_payment', $data['skip_payment']);
-        $result = $this->currentMock->isBoltOnlyPayment();
-        $this->assertInternalType('string', $result);
-        $this->assertEquals($data['expect'], $result);
+        TestHelper::stubConfigValue('payment/boltpay/skip_payment', $skipPayment);
+        $this->assertSame($skipPayment, $this->currentMock->isBoltOnlyPayment());
     }
 
     /**
-     * Test cases
-     * @return array[]
+     * Data provider for {@see isBoltOnlyPayment_withVariousConfigurationValues_determinesIsBoltOnlyPayment}
+     *
+     * @return array[] containing various configuration values for skip_payment
      */
-    public function isBoltOnlyPaymentData()
+    public function isBoltOnlyPayment_withVariousConfigurationValues_determinesIsBoltOnlyPaymentProvider()
     {
         return array(
-            array(
-                'data' => array(
-                    'expect' => '1',
-                    'skip_payment' => true
-                )
-            ),
-            array(
-                'data' => array(
-                    'expect' => '',
-                    'skip_payment' => false
-                )
-            ),
+            array('skipPayment' => 1),
+            array('skipPayment' => 0),
+            array('skipPayment' => '1'),
+            array('skipPayment' => '0'),
         );
     }
 
     /**
      * @test
-     * @group Block
-     * @dataProvider isCustomerGroupDisabledData
+     * that isCustomerGroupDisabled checks for presence for provided customer group id in disabled groups config
+     *
+     * @covers ::isCustomerGroupDisabled
+     *
+     * @dataProvider isCustomerGroupDisabled_withVariousConfigurationsAndCustomerGroups_determinesIsCustomerGroupIsDisabledProvider
+     *
+     * @param int    $customerGroupId dummy customer group id
+     * @param string $disabledCustomerGroupIds configuration value for disabled customer groups
+     * @param bool   $expectedResult of method call
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     * @throws ReflectionException if class tested doesn't have isCustomerGroupDisabled method
      */
-    public function isCustomerGroupDisabled($data)
+    public function isCustomerGroupDisabled_withVariousConfigurationsAndCustomerGroups_determinesIsCustomerGroupIsDisabled($customerGroupId, $disabledCustomerGroupIds, $expectedResult)
     {
-        $this->app->getStore()->resetConfig();
-        $this->app->getStore()->setConfig('payment/boltpay/bolt_disabled_customer_groups', $data['groups']);
-        $result = $this->testHelper->callNonPublicFunction($this->currentMock, 'isCustomerGroupDisabled', array($data['customerGroupId']));
+        TestHelper::stubConfigValue('payment/boltpay/bolt_disabled_customer_groups', $disabledCustomerGroupIds);
+        $result = TestHelper::callNonPublicFunction(
+            $this->currentMock,
+            'isCustomerGroupDisabled',
+            array($customerGroupId)
+        );
         $this->assertInternalType('boolean', $result);
-        $this->assertEquals($data['expect'], $result);
+        $this->assertEquals($expectedResult, $result);
     }
 
     /**
-     * Test cases
-     * @return array
+     * Data provider for (@see isCustomerGroupDisabled_withVariousConfigurationsAndCustomerGroups_determinesIsCustomerGroupIsDisabled}
+     *
+     * @return array[] containing dummy customer group, disabled customer group ids and expected result of method call
      */
-    public function isCustomerGroupDisabledData()
+    public function isCustomerGroupDisabled_withVariousConfigurationsAndCustomerGroups_determinesIsCustomerGroupIsDisabledProvider()
     {
         return array(
-            array(
-                'data' => array(
-                    'expect' => false,
-                    'customerGroupId' => 0,
-                    'groups' => ''
-                )
+            'Empty disabled customer group ids config - should return false'                       => array(
+                'customerGroupId'          => 0,
+                'disabledCustomerGroupIds' => '',
+                'expectedResult'           => false,
             ),
-            array(
-                'data' => array(
-                    'expect' => false,
-                    'customerGroupId' => 0,
-                    'groups' => '0'
-                )
+            'Zero for disabled customer group ids - should return false'                           => array(
+                'customerGroupId'          => 0,
+                'disabledCustomerGroupIds' => '0',
+                'expectedResult'           => false,
             ),
-            array(
-                'data' => array(
-                    'expect' => false,
-                    'customerGroupId' => 1,
-                    'groups' => ''
-                )
+            'General customer group with empty disabled customer groups - should return false'     => array(
+                'customerGroupId'          => 1,
+                'disabledCustomerGroupIds' => '',
+                'expectedResult'           => false,
             ),
-            array(
-                'data' => array(
-                    'expect' => true,
-                    'customerGroupId' => 1,
-                    'groups' => '1,2'
-                )
+            'General customer group with group id in disabled ids - should return true'            => array(
+                'customerGroupId'          => 1,
+                'disabledCustomerGroupIds' => '1,2',
+                'expectedResult'           => true,
             ),
-            array(
-                'data' => array(
-                    'expect' => false,
-                    'customerGroupId' => 0,
-                    'groups' => '1,2'
-                )
+            'Not logged in customer group with group id not in disabled ids - should return false' => array(
+                'customerGroupId'          => 0,
+                'disabledCustomerGroupIds' => '1,2',
+                'expectedResult'           => false,
             ),
         );
     }
 
     /**
      * @test
-     * @group Block
-     * @dataProvider isBoltActiveData
+     * that isBoltActive returns config flag value for payment/boltpay/active
+     *
+     * @covers ::isBoltActive
+     *
+     * @dataProvider isBoltActive_withVariousConfigurations_determinesIfBoltModuleShouldBeActiveProvider
+     *
+     * @param mixed $activeConfig configuration value
+     * @param book  $expectedResult returned from method call
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub configuration
      */
-    public function isBoltActive($data)
+    public function isBoltActive_withVariousConfigurations_determinesIfBoltModuleShouldBeActive($activeConfig, $expectedResult)
     {
-        $this->app->getStore()->resetConfig();
-        $this->app->getStore()->setConfig('payment/boltpay/active', $data['active']);
+        TestHelper::stubConfigValue('payment/boltpay/active', $activeConfig);
         $result = $this->currentMock->isBoltActive();
         $this->assertInternalType('boolean', $result);
-        $this->assertEquals($data['expect'], $result);
+        $this->assertEquals($expectedResult, $result);
     }
 
     /**
-     * Test cases
-     * @return boolean[][][]
+     * Data provider for {@see isBoltActive_withVariousConfigurations_determinesIfBoltModuleShouldBeActive}
+     *
+     * @return mixed[][] containing configuration value for Bolt module and expected result
      */
-    public function isBoltActiveData()
+    public function isBoltActive_withVariousConfigurations_determinesIfBoltModuleShouldBeActiveProvider()
     {
         return array(
-            array(
-                'data' => array(
-                    'expect' => true,
-                    'active' => true
-                )
-            )
+            'Empty value should return false'   => array('activeConfig' => '', 'expectedResult' => false),
+            'Zero should return false'          => array('activeConfig' => '0', 'expectedResult' => false),
+            'Null should return false'          => array('activeConfig' => null, 'expectedResult' => false),
+            'Boolean false should return false' => array('activeConfig' => 'false', 'expectedResult' => false),
+            'String false should return false'  => array('activeConfig' => false, 'expectedResult' => false),
+            'String true should return true'    => array('activeConfig' => 'true', 'expectedResult' => true),
+            'String one should return true'     => array('activeConfig' => '1', 'expectedResult' => true),
+            'Integer one should return true'    => array('activeConfig' => 1, 'expectedResult' => true),
         );
     }
 
     /**
      * @test
-     * @group Block
-     * @dataProvider isEnableMerchantScopedAccountData
+     * that isEnableMerchantScopedAccount returns configuration value for payment/boltpay/enable_merchant_scoped_account
+     *
+     * @covers ::isEnableMerchantScopedAccount
+     *
+     * @dataProvider isEnableMerchantScopedAccount_withVariousConfigurations_determinesIfMerchantScopedAccountIsEnabledProvider
+     *
+     * @param mixed $merchantEnabledConfig configuration value
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isEnableMerchantScopedAccount($data)
+    public function isEnableMerchantScopedAccount_withVariousConfigurations_determinesIfMerchantScopedAccountIsEnabled($merchantEnabledConfig)
     {
-        $this->app->getStore()->resetConfig();
-        $this->app->getStore()->setConfig('payment/boltpay/enable_merchant_scoped_account', $data['enabled']);
+        TestHelper::stubConfigValue('payment/boltpay/enable_merchant_scoped_account', $merchantEnabledConfig);
         $result = $this->currentMock->isEnableMerchantScopedAccount();
-        $this->assertInternalType('string', $result);
-        $this->assertEquals($data['expect'], $result);
+        $this->assertEquals($merchantEnabledConfig, $result);
     }
 
     /**
-     * Test cases
-     * @return boolean[][][]
+     * Data provider for {@see isEnableMerchantScopedAccount_withVariousConfigurations_determinesIfMerchantScopedAccountIsEnabled}
+     *
+     * @return mixed[][] containing configuration values for isEnableMerchantScopedAccount
      */
-    public function isEnableMerchantScopedAccountData()
+    public function isEnableMerchantScopedAccount_withVariousConfigurations_determinesIfMerchantScopedAccountIsEnabledProvider()
     {
         return array(
-            array(
-                'data' => array(
-                    'expect' => '1',
-                    'enabled' => true
-                )
-            ),
-            array(
-                'data' => array(
-                    'expect' => '',
-                    'enabled' => false
-                )
-            ),
-            
+            array('merchantEnabledConfig' => '1'),
+            array('merchantEnabledConfig' => '0'),
+            array('merchantEnabledConfig' => 'false'),
+            array('merchantEnabledConfig' => 'true'),
+            array('merchantEnabledConfig' => null),
+            array('merchantEnabledConfig' => true),
+            array('merchantEnabledConfig' => false),
         );
     }
 
     /**
      * @test
-     * @group Block
-     * @dataProvider isAllowedConnectJsOnCurrentPageData
+     * that getQuote returns quote from checkout/session singleton
+     *
+     * @coves ::getQuote
      */
-    public function isAllowedConnectJsOnCurrentPage($data)
-    {
-        $quote = $this->currentMock->getQuote();
-        $quote->setCustomerGroupId($data['customerGroupId']);
-
-        Mage::app()->getRequest()->setRouteName($data['route'])->setControllerName($data['controller']);
-
-        $this->app->getStore()->resetConfig();
-        $this->app->getStore()->setConfig('payment/boltpay/bolt_disabled_customer_groups', $data['groups']);
-        $this->app->getStore()->setConfig('payment/boltpay/active', $data['active']);
-        $this->app->getStore()->setConfig('payment/boltpay/add_button_everywhere', $data['everywhere']);
-
-        $result = $this->currentMock->isAllowedConnectJsOnCurrentPage();
-        $this->assertInternalType('boolean', $result);
-        $this->assertEquals($data['expected'], $result);
-    }
-
-    public function isAllowedConnectJsOnCurrentPageData()
-    {
-        return array(
-            array(
-                'data' => array(
-                    'expected' => true,
-                    'active' => true,// Bolt is active
-                    'customerGroupId' => 0,//Guest
-                    'groups' => '',//all groups are allowed
-                    'route' => 'checkout',//checkout
-                    'controller' => 'cart',// cart
-                    'everywhere' => true// Bolt allow everywhree
-                )
-            ),
-            array(
-                'data' => array(
-                    'expected' => true,
-                    'active' => true,
-                    'customerGroupId' => 0,
-                    'groups' => '',
-                    'route' => 'checkout',
-                    'controller' => 'cart',
-                    'everywhere' => false
-                )
-            ),
-            array(
-                'data' => array(
-                    'expected' => true,
-                    'active' => true,
-                    'customerGroupId' => 0,
-                    'groups' => '1,2,3',
-                    'route' => 'checkout',
-                    'controller' => 'cart',
-                    'everywhere' => false
-                )
-            ),
-            array(
-                'data' => array(
-                    'expected' => false,
-                    'active' => true,
-                    'customerGroupId' => 1,
-                    'groups' => '1,2,3',
-                    'route' => 'checkout',
-                    'controller' => 'cart',
-                    'everywhere' => false
-                )
-            ),
-            array(
-                'data' => array(
-                    'expected' => true,
-                    'active' => true,
-                    'customerGroupId' => 1,
-                    'groups' => '2,3',
-                    'route' => 'checkout',
-                    'controller' => 'cart',
-                    'everywhere' => false
-                )
-            ),
-            array(
-                'data' => array(
-                    'expected' => false,
-                    'active' => false,
-                    'customerGroupId' => 1,
-                    'groups' => '2,3',
-                    'route' => 'product',
-                    'controller' => 'view',
-                    'everywhere' => false
-                )
-            ),
-            
-        );
-    }
-
-    /**
-     * @test
-     * @group Block
-     * @dataProvider getQuoteData
-     */
-    public function getQuote($data)
+    public function getQuote_always_returnsQuoteFromCheckoutSession()
     {
         $quote = Mage::getSingleton('checkout/session')->getQuote();
-        $quote->setIsActive($data['active']);
-        $quote->setIsVirtual($data['virtual']);
         $this->assertEquals($quote, $this->currentMock->getQuote());
     }
 
     /**
-     * Test cases
-     * @return boolean[][][]
+     * @test
+     * that canUseBolt returns result of {@see Bolt_Boltpay_Helper_Data::canUseBolt} method call
+     * provided with quote from session and false for checkCountry parameter
+     *
+     * @covers ::canUseBolt
+     *
+     * @dataProvider canUseBolt_always_determinesIfBoltCanBeUsedProvider
+     *
+     * @param bool $canUseBolt stubbed result of Bolt helper method call
+     *
+     * @throws Mage_Core_Exception if unable to stub Bolt helper
+     * @throws Mage_Core_Model_Store_Exception from method tested if store is undefined
      */
-    public function getQuoteData()
+    public function canUseBolt_always_determinesIfBoltCanBeUsed($canUseBolt)
+    {
+        TestHelper::stubHelper('boltpay', $this->boltHelperMock);
+        $this->boltHelperMock->expects($this->once())->method('canUseBolt')
+            ->with($this->currentMock->getQuote(), false)->willReturn($canUseBolt);
+        $this->assertEquals($canUseBolt, $this->currentMock->canUseBolt());
+    }
+
+    /**
+     * Data provider for {@see canUseBolt_always_determinesIfBoltCanBeUsed}
+     *
+     * @return array containing possible results of helper method call
+     */
+    public function canUseBolt_always_determinesIfBoltCanBeUsedProvider()
     {
         return array(
-            array(
-                'data' => array(
-                    'active' => 1,
-                    'virtual' => 0
-                )
+            'Bolt enabled'  => array('canUseBolt' => true),
+            'Bolt disabled' => array('canUseBolt' => false),
+        );
+    }
+
+    /**
+     * @test
+     * that Connect JS is allowed for current page only if current route is in custom routes configuration
+     * or one of the following:
+     * checkout/cart, firecheckout, catalog/product, adminhtml/sales_order_create and adminhtml/sales_order_edit
+     *
+     * @covers ::isAllowedOnCurrentPageByRoute
+     *
+     * @dataProvider isAllowedOnCurrentPageByRoute_withVariousConfigurations_returnsExpectedResultProvider
+     *
+     * @param string $route current Magento route
+     * @param string $controller current Magento controller
+     * @param bool   $isEnabledPDP configuration if Bolt should be enabled on product details page
+     * @param string $customRoutes configuration value containing custom routes for which Bolt should be enabled
+     * @param bool   $expectedResult of the method call
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     * @throws ReflectionException if isAllowedOnCurrentPageByRoute method doesn't exist
+     */
+    public function isAllowedOnCurrentPageByRoute_withVariousConfigurations_returnsExpectedResult($route, $controller, $isEnabledPDP, $customRoutes, $expectedResult)
+    {
+        Mage::app()->getRequest()->setRouteName($route);
+        Mage::app()->getRequest()->setControllerName($controller);
+        TestHelper::stubConfigValue('payment/boltpay/enable_product_page_checkout', $isEnabledPDP);
+        TestHelper::stubConfigValue('payment/boltpay/allowed_button_by_custom_routes', $customRoutes);
+        $this->assertEquals(
+            $expectedResult,
+            Bolt_Boltpay_TestHelper::callNonPublicFunction(
+                $this->currentMock,
+                'isAllowedOnCurrentPageByRoute'
+            )
+        );
+    }
+
+    /**
+     * Data provider for {@see isAllowedOnCurrentPageByRoute_withVariousConfigurations_returnsExpectedResult}
+     *
+     * @return array containing route, controller, isEnabledPDP, customRoutes and expectedResult
+     */
+    public function isAllowedOnCurrentPageByRoute_withVariousConfigurations_returnsExpectedResultProvider()
+    {
+        return array(
+            'Route in custom routes'                     => array(
+                'route'          => 'custom_route',
+                'controller'     => '',
+                'isEnabledPDP'   => false,
+                'customRoutes'   => ' custom_route ',
+                'expectedResult' => true
+            ),
+            'Route in multiple custom routes'            => array(
+                'route'          => 'another_custom_route',
+                'controller'     => '',
+                'isEnabledPDP'   => false,
+                'customRoutes'   => ' custom_route ,another_custom_route ',
+                'expectedResult' => true
+            ),
+            'Checkout cart'                              => array(
+                'route'          => 'checkout',
+                'controller'     => 'cart',
+                'isEnabledPDP'   => false,
+                'customRoutes'   => false,
+                'expectedResult' => true
+            ),
+            'Firecheckout'                               => array(
+                'route'          => 'firecheckout',
+                'controller'     => '',
+                'isEnabledPDP'   => false,
+                'customRoutes'   => false,
+                'expectedResult' => true
+            ),
+            'Catalog product with PDP checkout enabled'  => array(
+                'route'          => 'catalog',
+                'controller'     => 'product',
+                'isEnabledPDP'   => true,
+                'customRoutes'   => false,
+                'expectedResult' => true
+            ),
+            'Catalog product with PDP checkout disabled' => array(
+                'route'          => 'catalog',
+                'controller'     => 'product',
+                'isEnabledPDP'   => false,
+                'customRoutes'   => false,
+                'expectedResult' => false
+            ),
+            'Admin sales order create'                   => array(
+                'route'          => 'adminhtml',
+                'controller'     => 'sales_order_create',
+                'isEnabledPDP'   => false,
+                'customRoutes'   => false,
+                'expectedResult' => true
+            ),
+            'Admin sales order edit'                     => array(
+                'route'          => 'adminhtml',
+                'controller'     => 'sales_order_edit',
+                'isEnabledPDP'   => false,
+                'customRoutes'   => false,
+                'expectedResult' => true
+            ),
+            'Admin customer edit'                        => array(
+                'route'          => 'adminhtml',
+                'controller'     => 'customer_edit',
+                'isEnabledPDP'   => false,
+                'customRoutes'   => false,
+                'expectedResult' => false
             ),
         );
     }
 
+    /**
+     * @test
+     * that isAllowedConnectJsOnCurrentPage returns true only if current customer group is not configured to be disabled
+     * and current page is allowed by route, or everywhere config is enabled
+     *
+     * @dataProvider isAllowedConnectJsOnCurrentPage_withVariousConfigurations_determinesIfConnectJsIsAllowedOnCurrentPageProvider
+     *
+     * @covers ::isAllowedConnectJsOnCurrentPage
+     * @covers ::isCustomerGroupDisabled
+     * @covers ::isAllowedOnCurrentPageByRoute
+     *
+     * @param bool   $expected result of the method call
+     * @param bool   $active configuration value for Bolt
+     * @param int    $customerGroupId current customer group id
+     * @param string $groups configuration value for disabled customer groups
+     * @param string $route current Magento route
+     * @param string $controller current Magento controller
+     * @param bool   $everywhere configuration value for add_button_everywhere
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function isAllowedConnectJsOnCurrentPage_withVariousConfigurations_determinesIfConnectJsIsAllowedOnCurrentPage($expected, $active, $customerGroupId, $groups, $route, $controller, $everywhere)
+    {
+        $quote = $this->currentMock->getQuote();
+        $quote->setCustomerGroupId($customerGroupId);
+
+        Mage::app()->getRequest()->setRouteName($route)->setControllerName($controller);
+
+        TestHelper::stubConfigValue('payment/boltpay/bolt_disabled_customer_groups', $groups);
+        TestHelper::stubConfigValue('payment/boltpay/active', $active);
+        TestHelper::stubConfigValue('payment/boltpay/add_button_everywhere', $everywhere);
+
+        $result = $this->currentMock->isAllowedConnectJsOnCurrentPage();
+        $this->assertInternalType('boolean', $result);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Data provider for {@see isAllowedConnectJsOnCurrentPage_withVariousConfigurations_determinesIfConnectJsIsAllowedOnCurrentPage}
+     * Provides data sets to verify that {@see BoltpayCheckoutBlock::isAllowedConnectJsOnCurrentPage}} returns false
+     * when current customer group id is in disabled customer groups configuration
+     *
+     * @return array containing ($expected, $active, $customerGroupId, $groups, $route, $controller, $everywhere)
+     */
+    public function isAllowedConnectJsOnCurrentPage_withVariousConfigurations_determinesIfConnectJsIsAllowedOnCurrentPageProvider()
+    {
+        return array(
+            'Checkout cart when button everywhere enabled should return true'                         => array(
+                'expected'        => true,
+                'active'          => true,
+                'customerGroupId' => 0,
+                'groups'          => '',
+                'route'           => 'checkout',
+                'controller'      => 'cart',
+                'everywhere'      => true
+            ),
+            'Checkout cart when button everywhere disabled should return true'                        => array(
+                'expected'        => true,
+                'active'          => true,
+                'customerGroupId' => 0,
+                'groups'          => '',
+                'route'           => 'checkout',
+                'controller'      => 'cart',
+                'everywhere'      => false
+            ),
+            'Checkout cart when customer group is not in disabled customer groups should return true' => array(
+                'expected'        => true,
+                'active'          => true,
+                'customerGroupId' => 0,
+                'groups'          => '1,2,3',
+                'route'           => 'checkout',
+                'controller'      => 'cart',
+                'everywhere'      => false
+            ),
+            'Checkout cart when customer group is in disabled customer groups should return false'    => array(
+                'expected'        => false,
+                'active'          => true,
+                'customerGroupId' => 1,
+                'groups'          => '1,2,3',
+                'route'           => 'checkout',
+                'controller'      => 'cart',
+                'everywhere'      => false
+            ),
+        );
+    }
+
+    /**
+     * @test
+     * that isAllowedReplaceScriptOnCurrentPage returns expected output with provided route
+     * and stubbed result of isAllowedConnectJsOnCurrentPage method call
+     *
+     * @covers ::isAllowedReplaceScriptOnCurrentPage
+     *
+     * @dataProvider isAllowedReplaceScriptOnCurrentPage_withVariousRoutesAndStubbedIsAllowedConnectJsOnCurrentPage_returnsExpectedOutputProvider
+     *
+     * @param string $route request route
+     * @param bool   $isAllowedConnectJsOnCurrentPage stubbed result of isAllowedConnectJsOnCurrentPage method call
+     * @param bool   $expectedResult of the method call
+     *
+     * @throws Exception if test class name is not defined
+     */
+    public function isAllowedReplaceScriptOnCurrentPage_withVariousRoutesAndStubbedIsAllowedConnectJsOnCurrentPage_returnsExpectedOutput($route, $isAllowedConnectJsOnCurrentPage, $expectedResult)
+    {
+        $currentMock = $this->getTestClassPrototype()->setMethods(array('isAllowedConnectJsOnCurrentPage'))->getMock();
+        $currentMock->method('isAllowedConnectJsOnCurrentPage')->willReturn($isAllowedConnectJsOnCurrentPage);
+        $currentMock->getRequest()->setRouteName($route);
+        $this->assertEquals($expectedResult, $currentMock->isAllowedReplaceScriptOnCurrentPage());
+    }
+
+    /**
+     * Data provider for {@see isAllowedReplaceScriptOnCurrentPage_withVariousRoutesAndStubbedIsAllowedConnectJsOnCurrentPage_returnsExpectedOutput}
+     *
+     * @return array containing route, stubbed result of isAllowedConnectJsOnCurrentPage and expectedResult
+     */
+    public function isAllowedReplaceScriptOnCurrentPage_withVariousRoutesAndStubbedIsAllowedConnectJsOnCurrentPage_returnsExpectedOutputProvider()
+    {
+        return array(
+            'Firecheckout and allowed on current page'       => array(
+                'route'                           => 'firecheckout',
+                'isAllowedConnectJsOnCurrentPage' => true,
+                'expectedResult'                  => false
+            ),
+            'Checkout route and allowed on current page'     => array(
+                'route'                           => 'checkout',
+                'isAllowedConnectJsOnCurrentPage' => true,
+                'expectedResult'                  => true
+            ),
+            'Checkout route and not allowed on current page' => array(
+                'route'                           => 'checkout',
+                'isAllowedConnectJsOnCurrentPage' => false,
+                'expectedResult'                  => false
+            ),
+            'Firecheckout and not allowed on current page'   => array(
+                'route'                           => 'firecheckout',
+                'isAllowedConnectJsOnCurrentPage' => false,
+                'expectedResult'                  => false
+            ),
+        );
+    }
+
+    /**
+     * @test
+     * that getSessionQuote returns quote from session object retrieved using checkout type
+     *
+     * @covers ::getSessionQuote
+     *
+     * @dataProvider getSessionQuote_withVariousCheckoutTypes_returnsQuoteFromSessionObjectProvider
+     *
+     * @param string $checkoutType to be used to retrieve session object
+     *
+     * @throws Exception if test class name is not defined
+     */
+    public function getSessionQuote_withVariousCheckoutTypes_returnsQuoteFromSessionObject($checkoutType)
+    {
+        $session = $this->getClassPrototype('Mage_Checkout_Model_Session')->getMock();
+        $quote = Mage::getModel('sales/quote');
+        $session->expects($this->once())->method('getQuote')->willReturn($quote);
+        /** @var MockObject|BoltpayCheckoutBlock $currentMock */
+        $currentMock = $this->getTestClassPrototype()->setMethods(array('getSessionObject'))->getMock();
+        $currentMock->expects($this->once())->method('getSessionObject')->willReturn($session);
+        $this->assertSame($quote, $currentMock->getSessionQuote($checkoutType));
+    }
+
+    /**
+     * Setup method for tests covering {@see Bolt_Boltpay_Block_Checkout_Boltpay::getSessionQuote}
+     *
+     * @return string[][] containing every checkout type
+     */
+    public function getSessionQuote_withVariousCheckoutTypes_returnsQuoteFromSessionObjectProvider()
+    {
+        return array(
+            'Multi-page checkout' => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE),
+            'Firecheckout'        => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_FIRECHECKOUT),
+            'One-page checkout'   => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_ONE_PAGE),
+            'Product page'        => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_PRODUCT_PAGE),
+            'Admin'               => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_ADMIN),
+        );
+    }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -218,7 +218,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      *
      * @throws Mage_Core_Exception if unable to setup test dependencies
      */
-    public function getCartDataJs_withReservedCustomerIdAndMerchantScopedAccountEnabled_buildsBoltCheckoutJSWithSignedMerchantUserId()
+    public function getCartDataJs_withCustomerIdAndMerchantScoped_buildsJsWithMerchantUserId()
     {
         $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE;
         list($quote, $currentMock) = $this->getCartDataJsSetUp($checkoutType);
@@ -255,7 +255,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      *
      * @throws Mage_Core_Exception if unable to setup test dependencies
      */
-    public function getCartDataJs_whenGetBoltOrderTokenPromiseThrowsException_logsExceptionAndBuildsBoltCheckoutJS()
+    public function getCartDataJs_whenGetPromiseThrowsException_logsExceptionAndBuildsJS()
     {
         $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE;
         list($quote, $currentMock) = $this->getCartDataJsSetUp($checkoutType);
@@ -281,7 +281,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      *
      * @throws Mage_Core_Exception if unable to setup test dependencies
      */
-    public function getCartDataJs_buildBoltCheckoutJavascriptThrowsException_logsExceptionAndReturnsNull()
+    public function getCartDataJs_whenBuildingJSThrowsException_logsExceptionAndReturnsNull()
     {
         list(, $currentMock) = $this->getCartDataJsSetUp(BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE);
 
@@ -299,7 +299,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      *
      * @covers ::isAdminAndUseJsInAdmin
      *
-     * @dataProvider isAdminAndUseJsInAdmin_withVariousCheckoutTypesAndConfigurations_returnsExpectedBooleanProvider
+     * @dataProvider isAdminAndUseJsInAdmin_withVariousConfigs_returnsExpectedBooleanProvider
      *
      * @param string $checkoutType currently used
      * @param bool   $useJavascriptInAdmin configuration value
@@ -308,7 +308,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      * @throws Mage_Core_Model_Store_Exception
      * @throws ReflectionException
      */
-    public function isAdminAndUseJsInAdmin_withVariousCheckoutTypesAndConfigurations_returnsExpectedBoolean($checkoutType, $useJavascriptInAdmin, $expectedResult)
+    public function isAdminAndUseJsInAdmin_withVariousConfigs_returnsExpectedBoolean($checkoutType, $useJavascriptInAdmin, $expectedResult)
     {
         TestHelper::stubConfigValue('payment/boltpay/use_javascript_in_admin', $useJavascriptInAdmin);
         $this->assertEquals(
@@ -318,11 +318,11 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Data provider for {@see isAdminAndUseJsInAdmin_withVariousCheckoutTypesAndConfigurations_returnsExpectedBoolean}
+     * Data provider for {@see isAdminAndUseJsInAdmin_withVariousConfigs_returnsExpectedBoolean}
      *
      * @return array containing checkout type, config value for using js in admin and expected result of method call
      */
-    public function isAdminAndUseJsInAdmin_withVariousCheckoutTypesAndConfigurations_returnsExpectedBooleanProvider()
+    public function isAdminAndUseJsInAdmin_withVariousConfigs_returnsExpectedBooleanProvider()
     {
         return array(
             'Admin and use disabled'      => array(
@@ -505,7 +505,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      * @throws ReflectionException if getAddressHints method doesn't exist
      * @throws Mage_Core_Exception from test setup if unable to stub customer session singleton
      */
-    public function getAddressHints_withQuoteContainingValidShippingAddress_returnsArrayContainingAddressDataInPrefill()
+    public function getAddressHints_withValidShippingAddress_returnsArrayWithAddressInPrefill()
     {
         $shippingAddress = Mage::getModel('sales/quote_address');
         $shippingAddress
@@ -581,7 +581,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      * @throws ReflectionException if getAddressHints method doesn't exist
      * @throws Mage_Core_Exception from test setup if unable to stub session singleton
      */
-    public function getAddressHints_customerLoggedInAndNoQuoteShippingAddress_returnsPrefillFromPrimaryShippingAddress()
+    public function getAddressHints_whehLoggedInAndNoShippingAddress_returnsPrefillFromPrimaryShippingAddress()
     {
         $customerAddress = Mage::getModel('customer/address');
         $customerAddress
@@ -639,7 +639,7 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      * @throws ReflectionException if getAddressHints method doesn't exist
      * @throws Mage_Core_Exception if unable to stub singleton
      */
-    public function getAddressHints_adminCheckout_returnsVirtualTerminalModeTrueAndEmailPrefillFromAdminSession()
+    public function getAddressHints_fromAdminCheckout_returnsEmailPrefillFromAdminSession()
     {
         $quote = $this->getAddressHintsSetUp(self::RESERVED_CUSTOMER_ID, null);
         $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_ADMIN;
@@ -976,7 +976,7 @@ SCSS;
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      * @throws Mage_Core_Exception from test setup if unable to stub singleton
      */
-    public function getLocationEstimate_withoutExistingLocationInfoInSession_requestsFromAPIAndSavesToSession()
+    public function getLocationEstimate_withoutLocationInSession_requestsFromAPIAndSavesToSession()
     {
         $ipStackAccessKey = sha1('bolt');
         TestHelper::stubConfigValue(
@@ -1007,7 +1007,7 @@ SCSS;
      *
      * @throws Mage_Core_Exception if unable to stub helper
      */
-    public function url_get_contents_whenApiClientThrowsException_logsExceptionAndReturnsNULL()
+    public function url_get_contents_whenApiClientThrowsException_logsExceptionAndReturnsNull()
     {
         $url = 'https://bolt.com';
         $exception = new Exception('Request timed out');
@@ -1024,7 +1024,7 @@ SCSS;
      *
      * @covers ::getPublishableKeyForRoute
      *
-     * @dataProvider getPublishableKeyForRoute_withVariousRoutesAndControllers_returnsResultOfGetPublishableKeyProvider
+     * @dataProvider getPublishableKeyForRoute_withVariousRoutes_returnsKeyForExpectedCheckoutTypeProvider
      *
      * @param string $route current Magento route
      * @param string $controller current Magento controller
@@ -1032,7 +1032,7 @@ SCSS;
      *
      * @throws Exception if test class name is not defined
      */
-    public function getPublishableKeyForRoute_withVariousRoutesAndControllers_returnsPublishableKeyForExpectedCheckoutType($route, $controller, $checkoutType)
+    public function getPublishableKeyForRoute_withVariousRoutes_returnsKeyForExpectedCheckoutType($route, $controller, $checkoutType)
     {
         /** @var MockObject|BoltpayCheckoutBlock $currentMock */
         $currentMock = $this->getTestClassPrototype()->setMethods(array('getPublishableKey'))->getMock();
@@ -1043,11 +1043,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see getPublishableKeyForRoute_withVariousRoutesAndControllers_returnsResultOfGetPublishableKey}
+     * Data provider for {@see getPublishableKeyForRoute_withVariousRoutes_returnsKeyForExpectedCheckoutType}
      *
      * @return array containing route, controller and checkout type
      */
-    public function getPublishableKeyForRoute_withVariousRoutesAndControllers_returnsResultOfGetPublishableKeyProvider()
+    public function getPublishableKeyForRoute_withVariousRoutes_returnsKeyForExpectedCheckoutTypeProvider()
     {
         return array(
             'Admin'        => array(
@@ -1128,7 +1128,7 @@ SCSS;
      *
      * @throws Exception if there is a problem in setting up test dependencies
      */
-    public function getPublishableKeyForThisPage_withAtLeastOneKeyConfigured($multiStepKey, $paymentOnlyKey, $routeName, $controllerName, $expectedReturnValue)
+    public function getPublishableKeyForThisPage_withAtLeastOneKeyConfigured_returnsExpectedValue($multiStepKey, $paymentOnlyKey, $routeName, $controllerName, $expectedReturnValue)
     {
         $this->setUp_getPublishableKeyForThisPage($multiStepKey, $paymentOnlyKey, $routeName, $controllerName);
 
@@ -1303,7 +1303,7 @@ SCSS;
      *
      * @throws Exception if there is a problem in setting up test dependencies
      */
-    public function getPublishableKeyForThisPage_whenNoKeyIsConfigured($multiStepKey, $paymentOnlyKey, $routeName, $controllerName)
+    public function getPublishableKeyForThisPage_whenNoKeyIsConfigured_throwsException($multiStepKey, $paymentOnlyKey, $routeName, $controllerName)
     {
         $this->setUp_getPublishableKeyForThisPage($multiStepKey, $paymentOnlyKey, $routeName, $controllerName);
         TestHelper::stubHelper('boltpay', $this->boltHelperMock);
@@ -1538,7 +1538,7 @@ SCSS;
     }
 
     /**
-     * Setup method for {@see Bolt_Boltpay_Block_Checkout_BoltpayTest::buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJs}
+     * Setup method for {@see Bolt_Boltpay_Block_Checkout_BoltpayTest::buildBoltCheckoutJavascript_withVariousConfigs_returnsBoltJs}
      *
      * @param string $checkoutType currently in use
      * @param bool   $cloneOnClick extra-config flag for cloneOnClick
@@ -1548,7 +1548,7 @@ SCSS;
      * @throws Mage_Core_Exception if unable to stub helper
      * @throws Exception if test class name is not set
      */
-    private function buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJsSetUp($checkoutType, $cloneOnClick = false, $isShoppingCartPage = false)
+    private function buildBoltCheckoutJavascript_withVariousConfigsSetUp($checkoutType, $cloneOnClick = false, $isShoppingCartPage = false)
     {
         $hintData = array(
             'signed_merchant_user_id' => array(
@@ -1594,7 +1594,7 @@ SCSS;
      *
      * @covers ::buildBoltCheckoutJavascript
      *
-     * @dataProvider buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJsProvider
+     * @dataProvider buildBoltCheckoutJavascript_withVariousConfigsProvider
      *
      * @param string $checkoutType currently in use
      * @param bool   $isShoppingCartPage whether current page is checkout/cart
@@ -1603,9 +1603,9 @@ SCSS;
      *
      * @throws Mage_Core_Exception from test setup if unable to stub helper
      */
-    public function buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJs($checkoutType, $isShoppingCartPage, $shouldCloneImmediately, $expectPostponedConfiguration)
+    public function buildBoltCheckoutJavascript_withVariousConfigs_returnsBoltJs($checkoutType, $isShoppingCartPage, $shouldCloneImmediately, $expectPostponedConfiguration)
     {
-        list($hintData, $cartData, $currentMock, $quoteMock) = $this->buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJsSetUp(
+        list($hintData, $cartData, $currentMock, $quoteMock) = $this->buildBoltCheckoutJavascript_withVariousConfigsSetUp(
             $checkoutType,
             !$shouldCloneImmediately,
             $isShoppingCartPage
@@ -1672,11 +1672,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJs}
+     * Data provider for {@see buildBoltCheckoutJavascript_withVariousConfigs_returnsBoltJs}
      *
      * @return array containing checkout type, is current page cart flag, should clone immediately config and flag whether to expect postponed configuration
      */
-    public function buildBoltCheckoutJavascript_withVariousCheckoutTypesAndConfigurations_willReturnBoltCheckoutJsProvider()
+    public function buildBoltCheckoutJavascript_withVariousConfigsProvider()
     {
         return array(
             array(
@@ -1747,14 +1747,14 @@ SCSS;
      *
      * @covers ::isTestMode
      *
-     * @dataProvider isTestMode_always_determinesIfTestModeIsSetInConfigurationProvider
+     * @dataProvider isTestMode_always_termsIfTestModeIsSetInConfigurationProvider
      *
      * @param mixed $isTestModeConfig config value for_test_mode
      * @param bool  $expectedResult of the method call
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isTestMode_always_determinesIfTestModeIsSetInConfiguration($isTestModeConfig, $expectedResult)
+    public function isTestMode_always_termsIfTestModeIsSetInConfiguration($isTestModeConfig, $expectedResult)
     {
         TestHelper::stubConfigValue('payment/boltpay/test', $isTestModeConfig);
         $result = $this->currentMock->isTestMode();
@@ -1763,11 +1763,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isTestMode_always_determinesIfTestModeIsSetInConfiguration}
+     * Data provider for {@see isTestMode_always_termsIfTestModeIsSetInConfiguration}
      *
      * @return array[] containing configuration value for test and expected result of the method call
      */
-    public function isTestMode_always_determinesIfTestModeIsSetInConfigurationProvider()
+    public function isTestMode_always_termsIfTestModeIsSetInConfigurationProvider()
     {
         return array(
             'Empty value should return false'   => array('isTestModeConfig' => '', 'expectedResult' => false),
@@ -1785,14 +1785,14 @@ SCSS;
      * @test
      * that getConfigSelectors returns config value for selectors in JSON format
      *
-     * @dataProvider getConfigSelectors_withVariousConfigurations_returnsJsonEncodedAndFilteredSelectorsProvider
+     * @dataProvider getConfigSelectors_withVariousConfigsProvider
      *
      * @param string $selectors configuration value for selectors
      * @param string $expectedResult of the method call
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function getConfigSelectors_withVariousConfigurations_returnsJsonEncodedAndFilteredSelectors($selectors, $expectedResult)
+    public function getConfigSelectors_withVariousConfigs_returnsJsonSelectors($selectors, $expectedResult)
     {
         TestHelper::stubConfigValue('payment/boltpay/selectors', $selectors);
         $result = $this->currentMock->getConfigSelectors();
@@ -1801,11 +1801,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see getConfigSelectors_withVariousConfigurations_returnsJsonEncodedAndFilteredSelectors}
+     * Data provider for {@see getConfigSelectors_withVariousConfigs_returnsJsonSelectors}
      *
      * @return string[][] containing configuration value for selectors and expected result of the method call
      */
-    public function getConfigSelectors_withVariousConfigurations_returnsJsonEncodedAndFilteredSelectorsProvider()
+    public function getConfigSelectors_withVariousConfigsProvider()
     {
         return array(
             'Empty config returns empty JSON array' => array(
@@ -1829,24 +1829,24 @@ SCSS;
      *
      * @covers ::isBoltOnlyPayment
      *
-     * @dataProvider isBoltOnlyPayment_withVariousConfigurationValues_determinesIsBoltOnlyPaymentProvider
+     * @dataProvider isBoltOnlyPayment_withVariousConfigsProvider
      *
      * @param mixed $skipPayment value in configuration for skip payment
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isBoltOnlyPayment_withVariousConfigurationValues_determinesIsBoltOnlyPayment($skipPayment)
+    public function isBoltOnlyPayment_withVariousConfigs_termsIsBoltOnlyPayment($skipPayment)
     {
         TestHelper::stubConfigValue('payment/boltpay/skip_payment', $skipPayment);
         $this->assertSame($skipPayment, $this->currentMock->isBoltOnlyPayment());
     }
 
     /**
-     * Data provider for {@see isBoltOnlyPayment_withVariousConfigurationValues_determinesIsBoltOnlyPayment}
+     * Data provider for {@see isBoltOnlyPayment_withVariousConfigs_termsIsBoltOnlyPayment}
      *
      * @return array[] containing various configuration values for skip_payment
      */
-    public function isBoltOnlyPayment_withVariousConfigurationValues_determinesIsBoltOnlyPaymentProvider()
+    public function isBoltOnlyPayment_withVariousConfigsProvider()
     {
         return array(
             array('skipPayment' => 1),
@@ -1862,7 +1862,7 @@ SCSS;
      *
      * @covers ::isCustomerGroupDisabled
      *
-     * @dataProvider isCustomerGroupDisabled_withVariousConfigurationsAndCustomerGroups_determinesIsCustomerGroupIsDisabledProvider
+     * @dataProvider isCustomerGroupDisabled_withVariousConfigsProvider
      *
      * @param int    $customerGroupId dummy customer group id
      * @param string $disabledCustomerGroupIds configuration value for disabled customer groups
@@ -1871,7 +1871,7 @@ SCSS;
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      * @throws ReflectionException if class tested doesn't have isCustomerGroupDisabled method
      */
-    public function isCustomerGroupDisabled_withVariousConfigurationsAndCustomerGroups_determinesIsCustomerGroupIsDisabled($customerGroupId, $disabledCustomerGroupIds, $expectedResult)
+    public function isCustomerGroupDisabled_withVariousConfigs_termsIsCustomerGroupIsDisabled($customerGroupId, $disabledCustomerGroupIds, $expectedResult)
     {
         TestHelper::stubConfigValue('payment/boltpay/bolt_disabled_customer_groups', $disabledCustomerGroupIds);
         $result = TestHelper::callNonPublicFunction(
@@ -1884,11 +1884,11 @@ SCSS;
     }
 
     /**
-     * Data provider for (@see isCustomerGroupDisabled_withVariousConfigurationsAndCustomerGroups_determinesIsCustomerGroupIsDisabled}
+     * Data provider for (@see isCustomerGroupDisabled_withVariousConfigs_termsIsCustomerGroupIsDisabled}
      *
      * @return array[] containing dummy customer group, disabled customer group ids and expected result of method call
      */
-    public function isCustomerGroupDisabled_withVariousConfigurationsAndCustomerGroups_determinesIsCustomerGroupIsDisabledProvider()
+    public function isCustomerGroupDisabled_withVariousConfigsProvider()
     {
         return array(
             'Empty disabled customer group ids config - should return false'                       => array(
@@ -1925,14 +1925,14 @@ SCSS;
      *
      * @covers ::isBoltActive
      *
-     * @dataProvider isBoltActive_withVariousConfigurations_determinesIfBoltModuleShouldBeActiveProvider
+     * @dataProvider isBoltActive_withVariousConfigsProvider
      *
      * @param mixed $activeConfig configuration value
      * @param book  $expectedResult returned from method call
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub configuration
      */
-    public function isBoltActive_withVariousConfigurations_determinesIfBoltModuleShouldBeActive($activeConfig, $expectedResult)
+    public function isBoltActive_withVariousConfigs_termsIfBoltModuleShouldBeActive($activeConfig, $expectedResult)
     {
         TestHelper::stubConfigValue('payment/boltpay/active', $activeConfig);
         $result = $this->currentMock->isBoltActive();
@@ -1941,11 +1941,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isBoltActive_withVariousConfigurations_determinesIfBoltModuleShouldBeActive}
+     * Data provider for {@see isBoltActive_withVariousConfigs_termsIfBoltModuleShouldBeActive}
      *
      * @return mixed[][] containing configuration value for Bolt module and expected result
      */
-    public function isBoltActive_withVariousConfigurations_determinesIfBoltModuleShouldBeActiveProvider()
+    public function isBoltActive_withVariousConfigsProvider()
     {
         return array(
             'Empty value should return false'   => array('activeConfig' => '', 'expectedResult' => false),
@@ -1965,13 +1965,13 @@ SCSS;
      *
      * @covers ::isEnableMerchantScopedAccount
      *
-     * @dataProvider isEnableMerchantScopedAccount_withVariousConfigurations_determinesIfMerchantScopedAccountIsEnabledProvider
+     * @dataProvider isEnableMerchantScopedAccount_withVariousConfigsProvider
      *
      * @param mixed $merchantEnabledConfig configuration value
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isEnableMerchantScopedAccount_withVariousConfigurations_determinesIfMerchantScopedAccountIsEnabled($merchantEnabledConfig)
+    public function isEnableMerchantScopedAccount_withVariousConfigs_termsIfMerchantScopedAccountIsEnabled($merchantEnabledConfig)
     {
         TestHelper::stubConfigValue('payment/boltpay/enable_merchant_scoped_account', $merchantEnabledConfig);
         $result = $this->currentMock->isEnableMerchantScopedAccount();
@@ -1979,11 +1979,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isEnableMerchantScopedAccount_withVariousConfigurations_determinesIfMerchantScopedAccountIsEnabled}
+     * Data provider for {@see isEnableMerchantScopedAccount_withVariousConfigs_termsIfMerchantScopedAccountIsEnabled}
      *
      * @return mixed[][] containing configuration values for isEnableMerchantScopedAccount
      */
-    public function isEnableMerchantScopedAccount_withVariousConfigurations_determinesIfMerchantScopedAccountIsEnabledProvider()
+    public function isEnableMerchantScopedAccount_withVariousConfigsProvider()
     {
         return array(
             array('merchantEnabledConfig' => '1'),
@@ -2015,14 +2015,14 @@ SCSS;
      *
      * @covers ::canUseBolt
      *
-     * @dataProvider canUseBolt_always_determinesIfBoltCanBeUsedProvider
+     * @dataProvider canUseBolt_always_termsIfBoltCanBeUsedProvider
      *
      * @param bool $canUseBolt stubbed result of Bolt helper method call
      *
      * @throws Mage_Core_Exception if unable to stub Bolt helper
      * @throws Mage_Core_Model_Store_Exception from method tested if store is undefined
      */
-    public function canUseBolt_always_determinesIfBoltCanBeUsed($canUseBolt)
+    public function canUseBolt_always_termsIfBoltCanBeUsed($canUseBolt)
     {
         TestHelper::stubHelper('boltpay', $this->boltHelperMock);
         $this->boltHelperMock->expects($this->once())->method('canUseBolt')
@@ -2031,11 +2031,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see canUseBolt_always_determinesIfBoltCanBeUsed}
+     * Data provider for {@see canUseBolt_always_termsIfBoltCanBeUsed}
      *
      * @return array containing possible results of helper method call
      */
-    public function canUseBolt_always_determinesIfBoltCanBeUsedProvider()
+    public function canUseBolt_always_termsIfBoltCanBeUsedProvider()
     {
         return array(
             'Bolt enabled'  => array('canUseBolt' => true),
@@ -2051,7 +2051,7 @@ SCSS;
      *
      * @covers ::isAllowedOnCurrentPageByRoute
      *
-     * @dataProvider isAllowedOnCurrentPageByRoute_withVariousConfigurations_returnsExpectedResultProvider
+     * @dataProvider isAllowedOnCurrentPageByRoute_withVariousConfigsProvider
      *
      * @param string $route current Magento route
      * @param string $controller current Magento controller
@@ -2062,7 +2062,7 @@ SCSS;
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      * @throws ReflectionException if isAllowedOnCurrentPageByRoute method doesn't exist
      */
-    public function isAllowedOnCurrentPageByRoute_withVariousConfigurations_returnsExpectedResult($route, $controller, $isEnabledPDP, $customRoutes, $expectedResult)
+    public function isAllowedOnCurrentPageByRoute_withVariousConfigs_returnsExpectedResult($route, $controller, $isEnabledPDP, $customRoutes, $expectedResult)
     {
         Mage::app()->getRequest()->setRouteName($route);
         Mage::app()->getRequest()->setControllerName($controller);
@@ -2078,11 +2078,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isAllowedOnCurrentPageByRoute_withVariousConfigurations_returnsExpectedResult}
+     * Data provider for {@see isAllowedOnCurrentPageByRoute_withVariousConfigs_returnsExpectedResult}
      *
      * @return array containing route, controller, isEnabledPDP, customRoutes and expectedResult
      */
-    public function isAllowedOnCurrentPageByRoute_withVariousConfigurations_returnsExpectedResultProvider()
+    public function isAllowedOnCurrentPageByRoute_withVariousConfigsProvider()
     {
         return array(
             'Route in custom routes'                     => array(
@@ -2156,7 +2156,7 @@ SCSS;
      * that isAllowedConnectJsOnCurrentPage returns true only if current customer group is not configured to be disabled
      * and current page is allowed by route, or everywhere config is enabled
      *
-     * @dataProvider isAllowedConnectJsOnCurrentPage_withVariousConfigurations_determinesIfConnectJsIsAllowedOnCurrentPageProvider
+     * @dataProvider isAllowedConnectJsOnCurrentPage_withVariousConfigsProvider
      *
      * @covers ::isAllowedConnectJsOnCurrentPage
      * @covers ::isCustomerGroupDisabled
@@ -2172,7 +2172,7 @@ SCSS;
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isAllowedConnectJsOnCurrentPage_withVariousConfigurations_determinesIfConnectJsIsAllowedOnCurrentPage($expected, $active, $customerGroupId, $groups, $route, $controller, $everywhere)
+    public function isAllowedConnectJsOnCurrentPage_withVariousConfigs_termsIfConnectJsIsAllowedOnCurrentPage($expected, $active, $customerGroupId, $groups, $route, $controller, $everywhere)
     {
         $quote = $this->currentMock->getQuote();
         $quote->setCustomerGroupId($customerGroupId);
@@ -2189,13 +2189,13 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isAllowedConnectJsOnCurrentPage_withVariousConfigurations_determinesIfConnectJsIsAllowedOnCurrentPage}
+     * Data provider for {@see isAllowedConnectJsOnCurrentPage_withVariousConfigs_termsIfConnectJsIsAllowedOnCurrentPage}
      * Provides data sets to verify that {@see BoltpayCheckoutBlock::isAllowedConnectJsOnCurrentPage}} returns false
      * when current customer group id is in disabled customer groups configuration
      *
      * @return array containing ($expected, $active, $customerGroupId, $groups, $route, $controller, $everywhere)
      */
-    public function isAllowedConnectJsOnCurrentPage_withVariousConfigurations_determinesIfConnectJsIsAllowedOnCurrentPageProvider()
+    public function isAllowedConnectJsOnCurrentPage_withVariousConfigsProvider()
     {
         return array(
             'Checkout cart when button everywhere enabled should return true'                         => array(
@@ -2244,7 +2244,7 @@ SCSS;
      *
      * @covers ::isAllowedReplaceScriptOnCurrentPage
      *
-     * @dataProvider isAllowedReplaceScriptOnCurrentPage_withVariousRoutesAndStubbedIsAllowedConnectJsOnCurrentPage_returnsExpectedOutputProvider
+     * @dataProvider isAllowedReplaceScriptOnCurrentPage_withVariousConfigsProvider
      *
      * @param string $route request route
      * @param bool   $isAllowedConnectJsOnCurrentPage stubbed result of isAllowedConnectJsOnCurrentPage method call
@@ -2252,7 +2252,7 @@ SCSS;
      *
      * @throws Exception if test class name is not defined
      */
-    public function isAllowedReplaceScriptOnCurrentPage_withVariousRoutesAndStubbedIsAllowedConnectJsOnCurrentPage_returnsExpectedOutput($route, $isAllowedConnectJsOnCurrentPage, $expectedResult)
+    public function isAllowedReplaceScriptOnCurrentPage_withVariousConfigs_returnsExpectedOutput($route, $isAllowedConnectJsOnCurrentPage, $expectedResult)
     {
         $currentMock = $this->getTestClassPrototype()->setMethods(array('isAllowedConnectJsOnCurrentPage'))->getMock();
         $currentMock->method('isAllowedConnectJsOnCurrentPage')->willReturn($isAllowedConnectJsOnCurrentPage);
@@ -2261,11 +2261,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isAllowedReplaceScriptOnCurrentPage_withVariousRoutesAndStubbedIsAllowedConnectJsOnCurrentPage_returnsExpectedOutput}
+     * Data provider for {@see isAllowedReplaceScriptOnCurrentPage_withVariousConfigs_returnsExpectedOutput}
      *
      * @return array containing route, stubbed result of isAllowedConnectJsOnCurrentPage and expectedResult
      */
-    public function isAllowedReplaceScriptOnCurrentPage_withVariousRoutesAndStubbedIsAllowedConnectJsOnCurrentPage_returnsExpectedOutputProvider()
+    public function isAllowedReplaceScriptOnCurrentPage_withVariousConfigsProvider()
     {
         return array(
             'Firecheckout and allowed on current page'       => array(
@@ -2297,7 +2297,7 @@ SCSS;
      *
      * @covers ::getSessionQuote
      *
-     * @dataProvider getSessionQuote_withVariousCheckoutTypes_returnsQuoteFromSessionObjectProvider
+     * @dataProvider getSessionQuote_withVariousCheckoutTypesProvider
      *
      * @param string $checkoutType to be used to retrieve session object
      *
@@ -2319,7 +2319,7 @@ SCSS;
      *
      * @return string[][] containing every checkout type
      */
-    public function getSessionQuote_withVariousCheckoutTypes_returnsQuoteFromSessionObjectProvider()
+    public function getSessionQuote_withVariousCheckoutTypesProvider()
     {
         return array(
             'Multi-page checkout' => array('checkoutType' => BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE),

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -1747,14 +1747,14 @@ SCSS;
      *
      * @covers ::isTestMode
      *
-     * @dataProvider isTestMode_always_termsIfTestModeIsSetInConfigurationProvider
+     * @dataProvider isTestMode_always_pinsIfTestModeIsSetInConfigurationProvider
      *
      * @param mixed $isTestModeConfig config value for_test_mode
      * @param bool  $expectedResult of the method call
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isTestMode_always_termsIfTestModeIsSetInConfiguration($isTestModeConfig, $expectedResult)
+    public function isTestMode_always_pinsIfTestModeIsSetInConfiguration($isTestModeConfig, $expectedResult)
     {
         TestHelper::stubConfigValue('payment/boltpay/test', $isTestModeConfig);
         $result = $this->currentMock->isTestMode();
@@ -1763,11 +1763,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isTestMode_always_termsIfTestModeIsSetInConfiguration}
+     * Data provider for {@see isTestMode_always_pinsIfTestModeIsSetInConfiguration}
      *
      * @return array[] containing configuration value for test and expected result of the method call
      */
-    public function isTestMode_always_termsIfTestModeIsSetInConfigurationProvider()
+    public function isTestMode_always_pinsIfTestModeIsSetInConfigurationProvider()
     {
         return array(
             'Empty value should return false'   => array('isTestModeConfig' => '', 'expectedResult' => false),
@@ -1835,14 +1835,14 @@ SCSS;
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isBoltOnlyPayment_withVariousConfigs_termsIsBoltOnlyPayment($skipPayment)
+    public function isBoltOnlyPayment_withVariousConfigs_pinsIsBoltOnlyPayment($skipPayment)
     {
         TestHelper::stubConfigValue('payment/boltpay/skip_payment', $skipPayment);
         $this->assertSame($skipPayment, $this->currentMock->isBoltOnlyPayment());
     }
 
     /**
-     * Data provider for {@see isBoltOnlyPayment_withVariousConfigs_termsIsBoltOnlyPayment}
+     * Data provider for {@see isBoltOnlyPayment_withVariousConfigs_pinsIsBoltOnlyPayment}
      *
      * @return array[] containing various configuration values for skip_payment
      */
@@ -1871,7 +1871,7 @@ SCSS;
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      * @throws ReflectionException if class tested doesn't have isCustomerGroupDisabled method
      */
-    public function isCustomerGroupDisabled_withVariousConfigs_termsIsCustomerGroupIsDisabled($customerGroupId, $disabledCustomerGroupIds, $expectedResult)
+    public function isCustomerGroupDisabled_withVariousConfigs_pinsIsCustomerGroupIsDisabled($customerGroupId, $disabledCustomerGroupIds, $expectedResult)
     {
         TestHelper::stubConfigValue('payment/boltpay/bolt_disabled_customer_groups', $disabledCustomerGroupIds);
         $result = TestHelper::callNonPublicFunction(
@@ -1884,7 +1884,7 @@ SCSS;
     }
 
     /**
-     * Data provider for (@see isCustomerGroupDisabled_withVariousConfigs_termsIsCustomerGroupIsDisabled}
+     * Data provider for (@see isCustomerGroupDisabled_withVariousConfigs_pinsIsCustomerGroupIsDisabled}
      *
      * @return array[] containing dummy customer group, disabled customer group ids and expected result of method call
      */
@@ -1932,7 +1932,7 @@ SCSS;
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub configuration
      */
-    public function isBoltActive_withVariousConfigs_termsIfBoltModuleShouldBeActive($activeConfig, $expectedResult)
+    public function isBoltActive_withVariousConfigs_pinsIfBoltModuleShouldBeActive($activeConfig, $expectedResult)
     {
         TestHelper::stubConfigValue('payment/boltpay/active', $activeConfig);
         $result = $this->currentMock->isBoltActive();
@@ -1941,7 +1941,7 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isBoltActive_withVariousConfigs_termsIfBoltModuleShouldBeActive}
+     * Data provider for {@see isBoltActive_withVariousConfigs_pinsIfBoltModuleShouldBeActive}
      *
      * @return mixed[][] containing configuration value for Bolt module and expected result
      */
@@ -1971,7 +1971,7 @@ SCSS;
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isEnableMerchantScopedAccount_withVariousConfigs_termsIfMerchantScopedAccountIsEnabled($merchantEnabledConfig)
+    public function isEnableMerchantScopedAccount_withVariousConfigs_pinsIfMerchantScopedAccountIsEnabled($merchantEnabledConfig)
     {
         TestHelper::stubConfigValue('payment/boltpay/enable_merchant_scoped_account', $merchantEnabledConfig);
         $result = $this->currentMock->isEnableMerchantScopedAccount();
@@ -1979,7 +1979,7 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isEnableMerchantScopedAccount_withVariousConfigs_termsIfMerchantScopedAccountIsEnabled}
+     * Data provider for {@see isEnableMerchantScopedAccount_withVariousConfigs_pinsIfMerchantScopedAccountIsEnabled}
      *
      * @return mixed[][] containing configuration values for isEnableMerchantScopedAccount
      */
@@ -2015,14 +2015,14 @@ SCSS;
      *
      * @covers ::canUseBolt
      *
-     * @dataProvider canUseBolt_always_termsIfBoltCanBeUsedProvider
+     * @dataProvider canUseBolt_always_pinsIfBoltCanBeUsedProvider
      *
      * @param bool $canUseBolt stubbed result of Bolt helper method call
      *
      * @throws Mage_Core_Exception if unable to stub Bolt helper
      * @throws Mage_Core_Model_Store_Exception from method tested if store is undefined
      */
-    public function canUseBolt_always_termsIfBoltCanBeUsed($canUseBolt)
+    public function canUseBolt_always_pinsIfBoltCanBeUsed($canUseBolt)
     {
         TestHelper::stubHelper('boltpay', $this->boltHelperMock);
         $this->boltHelperMock->expects($this->once())->method('canUseBolt')
@@ -2031,11 +2031,11 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see canUseBolt_always_termsIfBoltCanBeUsed}
+     * Data provider for {@see canUseBolt_always_pinsIfBoltCanBeUsed}
      *
      * @return array containing possible results of helper method call
      */
-    public function canUseBolt_always_termsIfBoltCanBeUsedProvider()
+    public function canUseBolt_always_pinsIfBoltCanBeUsedProvider()
     {
         return array(
             'Bolt enabled'  => array('canUseBolt' => true),
@@ -2172,7 +2172,7 @@ SCSS;
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function isAllowedConnectJsOnCurrentPage_withVariousConfigs_termsIfConnectJsIsAllowedOnCurrentPage($expected, $active, $customerGroupId, $groups, $route, $controller, $everywhere)
+    public function isAllowedConnectJsOnCurrentPage_withVariousConfigs_pinsIfConnectJsIsAllowedOnCurrentPage($expected, $active, $customerGroupId, $groups, $route, $controller, $everywhere)
     {
         $quote = $this->currentMock->getQuote();
         $quote->setCustomerGroupId($customerGroupId);
@@ -2189,7 +2189,7 @@ SCSS;
     }
 
     /**
-     * Data provider for {@see isAllowedConnectJsOnCurrentPage_withVariousConfigs_termsIfConnectJsIsAllowedOnCurrentPage}
+     * Data provider for {@see isAllowedConnectJsOnCurrentPage_withVariousConfigs_pinsIfConnectJsIsAllowedOnCurrentPage}
      * Provides data sets to verify that {@see BoltpayCheckoutBlock::isAllowedConnectJsOnCurrentPage}} returns false
      * when current customer group id is in disabled customer groups configuration
      *


### PR DESCRIPTION
# Description
Refactor to code coverage 100% for Bolt_Boltpay_Block_Checkout_Boltpay + removal of erroneous legacy if statement `if (@!$cartData->error)`, which will always evaluate to true as 
```
$cartData = Mage::getModel('boltpay/boltOrder')->getBoltOrderTokenPromise($checkoutType);
```
returns a string, and will never have an `error` data member.

Fixes: https://app.asana.com/0/1131034199022699/1157340557191681

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
