### PR TITLE
Reset _baseRoundingDeltas property to an empty array before collecting the total

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Traits/ValidatorTrait.php
+++ b/app/code/community/Bolt/Boltpay/Model/Traits/ValidatorTrait.php
@@ -25,7 +25,7 @@ trait Bolt_Boltpay_Model_Traits_ValidatorTrait {
     use Bolt_Boltpay_BoltGlobalTrait;
 
     /**
-     * Method for resetting rounding delta. Rounding deltas cause percentage discounts applied to an order to often get
+     * Method for resetting rounding delta and base rounding delta. Rounding deltas cause percentage discounts applied to an order to often get
      * off by $0.01 rounding errors because the validator used is a singleton. So every time collectTotals is called
      * it reuses the previous rounding deltas and causes rounding problems. Since Mage_SalesRule_Model_Validator doesn't
      * provide a method for resetting these before calling collectTotals, we created one.
@@ -33,5 +33,6 @@ trait Bolt_Boltpay_Model_Traits_ValidatorTrait {
     public function resetRoundingDeltas()
     {
         $this->_roundingDeltas = array();
+        $this->_baseRoundingDeltas = array();
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/Traits/ValidatorTraitTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/Traits/ValidatorTraitTest.php
@@ -39,4 +39,17 @@ class Bolt_Boltpay_Model_Traits_ValidatorTraitTest extends PHPUnit_Framework_Tes
         $this->currentMock->resetRoundingDeltas();
         $this->assertEquals(array(), $this->currentMock->_roundingDeltas);
     }
+
+    /**
+     * @test
+     * that resetRoundingDeltas method resets _baseRoundingDeltas property to empty array
+     *
+     * @covers Bolt_Boltpay_Model_Traits_ValidatorTrait::resetRoundingDeltas
+     */
+    public function resetRoundingDeltas_always_resetsBaseRoundingDeltasProperty()
+    {
+        $this->currentMock->_baseRoundingDeltas = array('10' => 0.01, '20' => 0.02);
+        $this->currentMock->resetRoundingDeltas();
+        $this->assertEquals(array(), $this->currentMock->_baseRoundingDeltas);
+    }
 }


### PR DESCRIPTION
# Description
Base rounding deltas cause percentage discounts applied to an order to often get off by $0.01 rounding errors because the validator used is a singleton. So every time collectTotals is called, it reuses the previous base rounding deltas and causes the rounding problems on the base grand total.

This PR resets the base rounding deltas to an empty array before collecting the total to prevent the rounding issue on the base grand total

Fixes: 
https://app.asana.com/0/564264490825835/1158615664420009
https://app.asana.com/0/564264490825835/1159584644406577


# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
