### PR TITLE
Fixing codecov by adding "max_report_age: off"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+    max_report_age: off


### PR DESCRIPTION
Message form codecov support:
```
After more investigation, we have located the problem, but it will take some time to fix. As a workaround, can you add the following to your codecov.yml file?

codecov:
  max_report_age: off
​
This should get things working again, please let me know if it does not.


Ticket: https://codecov.freshdesk.com/helpdesk/tickets/2806
```


documentation about this option
https://docs.codecov.io/docs/codecov-yaml#section-expired-reports