### PR TITLE
Frontend quantity check for Product Page

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
@@ -186,4 +186,25 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
             Mage_Catalog_Model_Product_Type::TYPE_SIMPLE
         ];
     }
+
+    /**
+     * Get maximum available quantity of product
+     * It is used to show a warning if user tries to buy more then product quantity
+     * @return int -1 Ignore product quantity levels
+     *              0 if product is out of stock
+     *              positive value otherwise
+     */
+    public function getProductMaxQty()
+    {
+        /** @var Mage_Catalog_Model_Product $product */
+        $product = Mage::registry('current_product');
+        $stockItem = $product->getStockItem();
+        if (!$stockItem->getManageStock()) {
+            return -1;
+        } else if (!$stockItem->getIsInStock()) {
+            return 0;
+        } else {
+            return $stockItem->getQty();
+        }
+    }
 }

--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -133,6 +133,17 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
                     "
                     if (!checkout.validate()) return false;
                     ";
+            case Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_PRODUCT_PAGE:
+                return <<<JS
+if(max_qty !== -1 && boltConfigPDP._jsonProductCart.items[0].quantity > max_qty) {
+    if ((typeof BoltPopup !== 'undefined')) {
+        BoltPopup.setMessage('{$this->__("The requested quantity is not available.")}');
+        BoltPopup.show();
+    }
+    return false;
+}
+JS;
+
             default:
                 return '';
         }

--- a/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
@@ -15,13 +15,14 @@
  * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-/* @var $this Bolt_Boltpay_Block_Catalog_Product_Boltpay */
+/* @var Bolt_Boltpay_Block_Catalog_Product_Boltpay $this */
 ?>
 <?php if ($this->isEnabledProductPageCheckout() && $this->isSupportedProductType()): ?>
 <script type="text/javascript">
 var productPageCheckoutSelector = '<?php $this->escapeHtml($this->getProductPageCheckoutSelector()) ?>';
 var order_completed = false;
 var do_checks = 1;
+var max_qty = <?php echo $this->getProductMaxQty(); ?>;
 <?php $productTierPrice = $this->getProductTierPrice(); ?>
 var boltConfigPDP = {
     _jsonProductCart: <?php echo $this->getCartDataJsForProductPage(); ?>,

--- a/app/design/frontend/base/default/template/boltpay/popup.phtml
+++ b/app/design/frontend/base/default/template/boltpay/popup.phtml
@@ -159,5 +159,6 @@
     }
     .bolt-popup .popup-wrapper .popup-content {
         margin: 10px 0;
+        text-align: center;
     }
 </style>


### PR DESCRIPTION
# Description
Bolt server-side currently is not handling Product Page checkout out of stock errors.  A non-informative error is displayed that confuses users.  This adds a frontend quantity check to and displays a suitable error to the user if they attempt to order more than what is in stock.  If the order becomes out of stock while the user is browsing the product page, refreshing the browser will now solve the problem, consistent with the error message which Bolt currently displays.

Fixes: https://app.asana.com/0/544708310157130/1157626513145145

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
