### PR TITLE
Product Page - Remove backend validation of available stock and defer it to pre-auth

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Productpage/Cart.php
+++ b/app/code/community/Bolt/Boltpay/Model/Productpage/Cart.php
@@ -70,6 +70,8 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
      *
      * @return bool
      * @throws \Exception
+     *
+     * @todo re-enable stock validation when Bolt server-side code supports the error type
      */
     protected function validateCartRequest()
     {
@@ -77,7 +79,8 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
         $this->validateEmptyCart();
         $this->validateProductsExist();
         $this->validateProductsQty();
-        $this->validateProductsStock();
+        // $this->validateProductsStock();  # we will temporarily disable stock checks as sending this error
+                                            # is currently not supported on Bolt server-side
 
         return true;
     }
@@ -202,6 +205,13 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
             $productId = @$cartItem->reference;
 
             $product = $this->getProductById($productId);
+
+            /** @var Mage_CatalogInventory_Model_Stock_Item $stockItem */
+            $stockItem = $product->getStockItem();
+
+            //defer stock validation to order creation
+            $stockItem->setManageStock(0);
+            $stockItem->setUseConfigManageStock(0);
 
             $param = array(
                 'product' => $productId,

--- a/app/code/community/Bolt/Boltpay/Model/Productpage/Cart.php
+++ b/app/code/community/Bolt/Boltpay/Model/Productpage/Cart.php
@@ -68,8 +68,7 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
     /**
      * Validate cart request data
      *
-     * @return bool
-     * @throws \Exception
+     * @throws \Exception upon any error in validation
      *
      * @todo re-enable stock validation when Bolt server-side code supports the error type
      */
@@ -81,8 +80,6 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
         $this->validateProductsQty();
         // $this->validateProductsStock();  # we will temporarily disable stock checks as sending this error
                                             # is currently not supported on Bolt server-side
-
-        return true;
     }
 
     /**
@@ -193,8 +190,15 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
     }
 
     /**
+     * Creates a cart that contains the exact contents of the request sent from Bolt
+     * This operates in a context outside of the true client session, so it is never reflected
+     * in the Magento frontend.
      *
-     * @return Mage_Checkout_Model_Cart
+     * @return Mage_Checkout_Model_Cart  Magento cart containing the quote which is used for Bolt
+     *                                   order JSON
+     *
+     * @todo remove disabling of stock management once Bolt server-side adds support
+     *       for out of stock error codes
      */
     protected function createCart()
     {
@@ -209,9 +213,16 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
             /** @var Mage_CatalogInventory_Model_Stock_Item $stockItem */
             $stockItem = $product->getStockItem();
 
-            //defer stock validation to order creation
+            ///////////////////////////////////////////////
+            // Remove stock validation as a temporary 
+            // solution for the Bolt backend unable to 
+            // handle stock error codes
+            // TODO: remove this once Bolt adds PPC
+            //       out-of-stock error code support
+            ///////////////////////////////////////////////
             $stockItem->setManageStock(0);
             $stockItem->setUseConfigManageStock(0);
+            ///////////////////////////////////////////////
 
             $param = array(
                 'product' => $productId,


### PR DESCRIPTION
# Description
In addition to frontend check, it is always possible that inventory may not be available in the middle of a product page checkout experience do to concurrent users ordering the same products.  Currently, the Bolt Server-side error message is does not support out of stock errors.  As a workaround solution, we disable the stock quantity backend checks during the create.order call, and instead defer this to pre-auth where out of stock messaging is supported

Fixes: https://app.asana.com/0/544708310157130/1157626513145145

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
