### PR TITLE
Validate Bolt order creation origin

### DIFF
--- a/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
+++ b/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
@@ -46,6 +46,10 @@ trait Bolt_Boltpay_Controller_Traits_WebHookTrait {
      */
     public function preDispatch()
     {
+        # Allows actions to be used even if the Bolt plugin is disabled.
+        # This accounts for orders that have already been processed by Bolt
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
+
         # disables web server compression if enabled
         @ini_set("zlib.output_compression", 0);
 

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -437,7 +437,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
      *                                        -  object (bolt) transaction (ONLY pre-auth; will be empty for admin)
      *
      *
-     * @throws Exception    if an unknown error occurs
+     * @throws Exception    if order is empty or order creation is not allowed
      * @throws Bolt_Boltpay_OrderCreationException if the bottom line price total differs by allowed tolerance
      *
      */
@@ -461,13 +461,30 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
         }
         /////////////////////////////////////////////////////////////
 
-        $payment = $order->getPayment();
-
         /** @var Mage_Sales_Model_Quote $quote */
         $immutableQuote = $order->getQuote();
         $boltTransaction = $immutableQuote->getTransaction();
 
-        if ( (strtolower($payment->getMethod()) !== Bolt_Boltpay_Model_Payment::METHOD_CODE) || empty($boltTransaction) ) {
+        // Do not validate non-Bolt orders
+        if ( !$this->isBoltOrder($order) ) {
+            return;
+        }
+
+        /////////////////////////////////////////////////////////////
+        /// Refuse Bolt order creation for orders triggered
+        /// outside of official Bolt Paths
+        /////////////////////////////////////////////////////////////
+        if (
+            !Bolt_Boltpay_Helper_Data::$fromHooks
+            && !Mage::app()->getStore()->isAdmin()
+        ) {
+            throw new Exception('Order creation with Boltpay not allowed for this path');
+        }
+        /////////////////////////////////////////////////////////////
+
+        // Bolt order pre-commit validation can be canceled by removing the Bolt transaction
+        // from the order's quote in the bolt_boltpay_validation_pre_order_commit_before event
+        if( empty($boltTransaction) ) {
             return;
         }
 

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -35,9 +35,6 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
 
             $requestData = $this->getRequestData();
 
-            /* Allows this method to be used even if the Bolt plugin is disabled.  This accounts for orders that have already been processed by Bolt */
-            Bolt_Boltpay_Helper_Data::$fromHooks = true;
-
             $reference = $requestData->reference;
             $transactionId = @$requestData->transaction_id ?: $requestData->id;
             $hookType = @$requestData->notification_type ?: $requestData->type;

--- a/tests/unit/testsuite/Bolt/Boltpay/Controller/Traits/WebHookTraitTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Controller/Traits/WebHookTraitTest.php
@@ -120,6 +120,7 @@ class Bolt_Boltpay_Controller_Traits_WebHookTraitTest extends PHPUnit_Framework_
         self::$_fastcgiFinishRequestCalled = false;
         unset($_SERVER['HTTP_X_BOLT_HMAC_SHA256']);
         Bolt_Boltpay_StreamHelper::restore();
+        Bolt_Boltpay_Helper_Data::$fromHooks = false;
     }
 
     /**
@@ -152,6 +153,7 @@ class Bolt_Boltpay_Controller_Traits_WebHookTraitTest extends PHPUnit_Framework_
         }
 
         $this->currentMock->preDispatch();
+        $this->assertTrue(Bolt_Boltpay_Helper_Data::$fromHooks);
     }
 
     /**
@@ -194,6 +196,7 @@ class Bolt_Boltpay_Controller_Traits_WebHookTraitTest extends PHPUnit_Framework_
 
         Bolt_Boltpay_StreamHelper::register();
         $this->currentMock->preDispatch();
+        $this->assertTrue(Bolt_Boltpay_Helper_Data::$fromHooks);
     }
 
     /**

--- a/tests/unit/testsuite/Bolt/Boltpay/OrderHelper.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/OrderHelper.php
@@ -80,12 +80,13 @@ class Bolt_Boltpay_OrderHelper
     /**
      * Creates dummy order
      *
-     * @param $productId
+     * @param int $productId to be used for order creation
+     * @param int $qty of the product provided
+     * @param string $paymentMethod code used for order creation
      *
-     * @param int $qty
-     * @param string $paymentMethod
-     * @return Mage_Sales_Model_Order
-     * @throws Mage_Core_Exception
+     * @return Mage_Sales_Model_Order dummy order
+     *
+     * @throws Mage_Core_Exception if provided payment method is not available
      */
     public static function createDummyOrder($productId, $qty = 2, $paymentMethod = 'boltpay')
     {
@@ -109,7 +110,18 @@ class Bolt_Boltpay_OrderHelper
         // Set payment method for the quote
         $quote->getPayment()->importData(array('method' => $paymentMethod));
         $service = Mage::getModel('sales/service_quote', $quote);
+
+        if ($paymentMethod == Bolt_Boltpay_Model_Payment::METHOD_CODE) {
+            $previousHookValue = Bolt_Boltpay_Helper_Data::$fromHooks;
+            //temporarily set flag to true in order to pass order validation
+            Bolt_Boltpay_Helper_Data::$fromHooks = true;
+        }
+
         $service->submitAll();
+        if ($paymentMethod == Bolt_Boltpay_Model_Payment::METHOD_CODE) {
+            Bolt_Boltpay_Helper_Data::$fromHooks = $previousHookValue;
+        }
+
         /** @var Mage_Sales_Model_Order $order */
         $order = $service->getOrder();
 


### PR DESCRIPTION
# Description
Context:
There have been third party plugins creating orders that say payment method: Boltpay, but were not created by Bolt.  

Goal:
We want to prevent an order from being created with the the payment method boltpay if the submit isn't coming via webhooks, admin, or bolt product page flows.

Fixes: https://app.asana.com/0/544708310157130/1146170148693767

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
