### PR TITLE
PPC Refactor: Remove use of quote cloning

### DIFF
--- a/tests/unit/testsuite/Bolt/Boltpay/Model/Productpage/CartTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/Productpage/CartTest.php
@@ -96,7 +96,6 @@ class Bolt_Boltpay_Model_Productpage_CartTest extends PHPUnit_Framework_TestCase
      * @covers ::init
      * @covers ::validateCartRequest
      * @covers ::createCart
-     * @covers ::createImmutableQuote
      * @covers ::setCartResponse
      *
      * @throws ReflectionException if class tested doesn't have cartRequest property
@@ -135,7 +134,6 @@ class Bolt_Boltpay_Model_Productpage_CartTest extends PHPUnit_Framework_TestCase
      * @covers ::validateProductsQty
      * @covers ::validateProductsStock
      * @covers ::createCart
-     * @covers ::createImmutableQuote
      * @covers ::setCartResponse
      * @depends init_withValidCartRequest_setsInternalCartRequestProperty
      *
@@ -210,24 +208,17 @@ class Bolt_Boltpay_Model_Productpage_CartTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * that generate data returns false and logs exception thrown from {@see Bolt_Boltpay_Model_BoltOrder::cloneQuote}
+     * that generate data returns false and logs exception if thrown from {@see Bolt_Boltpay_Model_Productpage_Cart::createCart}
      *
      * @covers ::generateData
-     * @covers ::createImmutableQuote
      * @covers ::getProductById
-     * @depends init_withValidCartRequest_setsInternalCartRequestProperty
-     *
-     * @param MockObject|Bolt_Boltpay_Model_Productpage_Cart $currentMock tested class instance from previous test
-     * @throws ReflectionException if unable to stub boltOrder model
      */
-    public function generateData_whenQuoteCloningThrowsException_returnsFalseAndLogsException($currentMock)
+    public function generateData_whenQuoteCloningThrowsException_returnsFalseAndLogsException()
     {
-        $boltOrderMock = $this->getClassPrototype('Bolt_Boltpay_Model_BoltOrder')
-            ->setMethods(array('cloneQuote'))
-            ->getMock();
-        Bolt_Boltpay_TestHelper::stubModel('boltpay/boltOrder', $boltOrderMock);
-        $exception = new Exception('Unable to clone quote');
-        $boltOrderMock->expects($this->once())->method('cloneQuote')->willThrowException($exception);
+        $currentMock = $this->getTestClassPrototype()->setMethods(array('validateCartRequest', 'createCart'))->getMock();
+        $exception = new Exception('Unable to create cart');
+        $currentMock->expects($this->once())->method('validateCartRequest');
+        $currentMock->expects($this->once())->method('createCart')->willThrowException($exception);
 
         $this->boltHelperMock->expects($this->once())->method('notifyException')->with($exception);
         $this->boltHelperMock->expects($this->once())->method('logException')->with($exception);


### PR DESCRIPTION
# Description
PPC does not happen in the context of a user accessible session and therefore there is no need for any immutable quote cloning.

Fixes: https://app.asana.com/0/544708310157130/1161793187073236

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test
- [x] Refactor

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
