### PR TITLE
PPC Refactor: Utilize Bolt_Boltpay_Model_BoltOrder and Bolt_Boltpay_Block_Checkout_Boltpay

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
@@ -26,13 +26,14 @@
  * create the order on Bolt side through the javascript BoltCheckout.configureProductCheckout process.
  *
  */
-class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Template
+class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Bolt_Boltpay_Block_Checkout_Boltpay
 {
     use Bolt_Boltpay_BoltGlobalTrait;
 
     /**
      * Get Product Tier Price
      * @return mixed
+     * @deprecated
      */
     public function getProductTierPrice()
     {
@@ -40,9 +41,10 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
     }
 
     /**
-     * Initiates sets up BoltCheckout config.
+     * Generates BoltCheckout cart configuration for product page checkout
      *
-     * @return string
+     * @return string JSON encoded Bolt cart data containing current product
+     * @deprecated
      */
     public function getCartDataJsForProductPage()
     {
@@ -50,7 +52,6 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
             $currency = Mage::app()->getStore()->getCurrentCurrencyCode();
 
             $productCheckoutCartItem = [];
-            $totalAmount = (float) 0;
 
             /** @var Mage_Catalog_Model_Product $_product */
             $_product = Mage::registry('current_product');
@@ -94,6 +95,7 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
      * @param bool   $isVirtualQuote
      *
      * @return string
+     * @deprecated
      */
     public function getBoltCallbacks($checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_PRODUCT_PAGE, $isVirtualQuote = false )
     {
@@ -101,8 +103,15 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
     }
 
     /**
-     * @param string $successCustom
-     * @return string
+     * Generates on success callback for product page checkout
+     *
+     * @param string $successCustom javascript callback to be included in AJAX success callback
+     *
+     * @return string on success javascript callback
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to get save order URL
+     *
+     * @deprecated
      */
     public function buildOnSuccessCallback($successCustom = '')
     {
@@ -126,8 +135,15 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
     }
 
     /**
-     * @param $closeCustom
-     * @return string
+     * Generates on close callback for product page checkout
+     *
+     * @param string $closeCustom callback to be included in returned javascript
+     *
+     * @return string on close javascript callback
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to get success URL
+     *
+     * @deprecated
      */
     public function buildOnCloseCallback($closeCustom = '')
     {
@@ -139,15 +155,6 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
                 location.href = '$successUrl';
             }
             ";
-    }
-
-    /**
-     * Returns the Enabled Bolt configuration option value.
-     * @return bool
-     */
-    public function isBoltActive()
-    {
-        return $this->boltHelper()->isBoltPayActive();
     }
 
     /**
@@ -193,6 +200,8 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
      * @return int -1 Ignore product quantity levels
      *              0 if product is out of stock
      *              positive value otherwise
+     *
+     * @deprecated
      */
     public function getProductMaxQty()
     {
@@ -206,5 +215,24 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Mage_Core_Block_Templat
         } else {
             return $stockItem->getQty();
         }
+    }
+
+    /**
+     * Returns product data needed for price calculation in JSON format
+     *
+     * @return string
+     */
+    public function getProductJSON()
+    {
+        /** @var Mage_Catalog_Model_Product $product */
+        $product = Mage::registry('current_product');
+        return Mage::helper('core')->jsonEncode(
+            array(
+                'id'         => $product->getId(),
+                'name'       => $product->getName(),
+                'price'      => $product->getFinalPrice(),
+                'tier_prices' => $product->getTierPrice()
+            )
+        );
     }
 }

--- a/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
@@ -67,18 +67,18 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Bolt_Boltpay_Block_Chec
 
             $productCheckoutCartItem[] = [
                 'reference' => $_product->getId(),
-                'price' => $_product->getFinalPrice(),
-                'quantity' => 1,
-                'image' => $_product->getImageUrl(),
-                'name' => $_product->getName(),
+                'price'     => $_product->getFinalPrice(),
+                'quantity'  => 1,
+                'image'     => $_product->getImageUrl(),
+                'name'      => $_product->getName(),
             ];
             $totalAmount = $_product->getFinalPrice();
 
 
             $productCheckoutCart = [
                 'currency' => $currency,
-                'items' => $productCheckoutCartItem,
-                'total' => $totalAmount,
+                'items'    => $productCheckoutCartItem,
+                'total'    => $totalAmount,
             ];
 
              return json_encode($productCheckoutCart);
@@ -228,9 +228,9 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Bolt_Boltpay_Block_Chec
         $product = Mage::registry('current_product');
         return Mage::helper('core')->jsonEncode(
             array(
-                'id'         => $product->getId(),
-                'name'       => $product->getName(),
-                'price'      => $product->getFinalPrice(),
+                'id'          => $product->getId(),
+                'name'        => $product->getName(),
+                'price'       => $product->getFinalPrice(),
                 'tier_prices' => $product->getTierPrice()
             )
         );

--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -170,9 +170,9 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
         $jsonCart = (is_string($cartData)) ? $cartData : json_encode($cartData);
         $jsonHints = json_encode($hintData, JSON_FORCE_OBJECT);
 
-        $callbacks = $this->boltHelper()->getBoltCallbacks($checkoutType, $quote);
+        $callbacks = $this->boltHelper()->getBoltCallbacks($checkoutType, $quote->isVirtual());
         $checkCustom = $this->boltHelper()->getPaymentBoltpayConfig('check', $checkoutType);
-        $onCheckCallback = $this->boltHelper()->buildOnCheckCallback($checkoutType, $quote);
+        $onCheckCallback = $this->boltHelper()->buildOnCheckCallback($checkoutType, $quote->isVirtual());
 
         $hintsTransformFunction = $this->boltHelper()->getExtraConfig('hintsTransform');
         $shouldCloneImmediately = !$this->boltHelper()->getExtraConfig( 'cloneOnClick' );
@@ -216,6 +216,19 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
                         }
                     ); 
                 ";
+                break;
+            case self::CHECKOUT_TYPE_PRODUCT_PAGE:
+                $jsonCart = /** @lang JavaScript */ 'boltConfigPDP.getCartData();';
+
+                $boltConfigureCall = <<<JS
+BoltCheckout.configureProductCheckout(
+    get_json_cart(),
+    json_hints,
+    {$callbacks},
+    { checkoutButtonClassName: 'bolt-product-checkout-button' }
+);
+JS;
+                break;
         }
 
         if (!isset($doChecks)) $doChecks = 'var do_checks = 1;';

--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -134,8 +134,16 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
                     if (!checkout.validate()) return false;
                     ";
             case Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_PRODUCT_PAGE:
-                return <<<JS
-if(max_qty !== -1 && boltConfigPDP._jsonProductCart.items[0].quantity > max_qty) {
+                /** @var Mage_Catalog_Model_Product $product */
+                $product = Mage::registry('current_product');
+                if (!$product || !$product->getStockItem() || !$product->getStockItem()->getIsInStock()) {
+                    return 'return false;';
+                }
+
+                /** @var Mage_CatalogInventory_Model_Stock_Item $stockItem */
+                $stockItem = $product->getStockItem();
+                return /** @lang JavaScript */ <<<JS
+if(boltConfigPDP.getQty() > Number({$stockItem->getQty()})) {
     if ((typeof BoltPopup !== 'undefined')) {
         BoltPopup.setMessage('{$this->__("The requested quantity is not available.")}');
         BoltPopup.show();

--- a/app/code/community/Bolt/Boltpay/Model/Productpage/Cart.php
+++ b/app/code/community/Bolt/Boltpay/Model/Productpage/Cart.php
@@ -249,14 +249,17 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
      * @param Mage_Sales_Model_Quote $quote
      *
      * @return array configured cart response
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to build Bolt order data
      */
     protected function setCartResponse($quote)
     {
+        $boltOrderData = Mage::getModel('boltpay/boltOrder')->buildOrder($quote, true);
         $this->cartResponse = array(
-            'order_reference' => $quote->getId(),
-            'currency'        => $quote->getQuoteCurrencyCode(),
-            'items'           => $this->getGeneratedItems($quote),
-            'total_amount'    => $this->getGeneratedTotal()
+            'order_reference' => $boltOrderData['cart']['order_reference'],
+            'currency'        => $boltOrderData['cart']['currency'],
+            'items'           => $boltOrderData['cart']['items'],
+            'total_amount'    => $boltOrderData['cart']['total_amount']
         );
         $this->httpCode = 200;
 
@@ -279,6 +282,8 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
     /**
      *
      * @return array
+     *
+     * @deprecated
      */
     protected function getGeneratedItems($quote)
     {
@@ -313,6 +318,8 @@ class Bolt_Boltpay_Model_Productpage_Cart extends Bolt_Boltpay_Model_Abstract
     /**
      *
      * @return string
+     *
+     * @deprecated
      */
     protected function getGeneratedTotal()
     {

--- a/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
@@ -19,53 +19,34 @@
 ?>
 <?php if ($this->isEnabledProductPageCheckout() && $this->isSupportedProductType()): ?>
 <script type="text/javascript">
-var productPageCheckoutSelector = '<?php $this->escapeHtml($this->getProductPageCheckoutSelector()) ?>';
-var order_completed = false;
-var do_checks = 1;
-var max_qty = <?php echo $this->getProductMaxQty(); ?>;
-<?php $productTierPrice = $this->getProductTierPrice(); ?>
 var boltConfigPDP = {
-    _jsonProductCart: <?php echo $this->getCartDataJsForProductPage(); ?>,
-    _tierPrices : <?php echo json_encode($productTierPrice) ?>,
-    getPrice : function (qty) {
-        qty = Number(qty);
-        var i;
-        for (i = this._tierPrices.length; i > 0; --i) {
-            if (qty >= this._tierPrices[i-1]['price_qty']){
-                return this._tierPrices[i-1]['price'];
+    product: <?php echo $this->getProductJSON(); ?>,
+    init: function () {
+        <?php echo $this->getCartDataJs(Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_PRODUCT_PAGE); ?>
+    },
+    getQty: function () {
+        return Number(document.getElementById('qty').value);
+    },
+    getCartData: function () {
+        var qty = this.getQty();
+        var price = this.product.price;
+        for (var i = 0; i < this.product.tier_prices.length; i++) {
+            if (qty >= Number(this.product.tier_prices[i]['price_qty'])) {
+                price = this.product.tier_prices[i]['price'];
             }
         }
-
-        return this._jsonProductCart.items[0].price;
+        return {
+            items: qty > 0 ? [
+                {
+                    reference: this.product.id,
+                    name: this.product.name,
+                    price: price,
+                    quantity: qty,
+                },
+            ] : [],
+            total: qty * price,
+        };
     },
-
-    increaseQty: function(number) {
-        if (this._jsonProductCart) {
-            this._jsonProductCart.items[0].quantity = parseInt(number);
-            if(this._tierPrices){
-                this._jsonProductCart.items[0].price = this.getPrice(number);
-            }
-            this._jsonProductCart.total = parseFloat(this._jsonProductCart.items[0].price) * number;
-        } else {
-            console.log('There is no json product data');
-        }
-    },
-    init: function(removeItems) {
-        // copy object that we always have correct product data.
-        var jsonProductCart = Object.assign({}, this._jsonProductCart),
-            boltJsonProductHints = null;
-
-        if (removeItems === true) {
-            jsonProductCart.items = [];
-        }
-
-        window.BoltModal = BoltCheckout.configureProductCheckout(
-            jsonProductCart,
-            boltJsonProductHints,
-            <?php echo $this->getBoltCallbacks(); ?>,
-            { checkoutButtonClassName: 'bolt-product-checkout-button' }
-        );
-    }
 };
 
 document.addEventListener("DOMContentLoaded", function() {
@@ -79,14 +60,7 @@ document.addEventListener("DOMContentLoaded", function() {
             processIntervalCounter++;
             if (typeof BoltCheckout !== "undefined") {
                 clearInterval(processIntervalProd);
-                var qtyValue = parseInt(document.getElementById('qty').value);
-
-                if (qtyValue > 0 && !isNaN(qtyValue)) {
-                    boltConfigPDP.increaseQty(qtyValue);
-                    boltConfigPDP.init();
-                } else {
-                    boltConfigPDP.init(true);
-                }
+                boltConfigPDP.init();
             }
 
             if (processIntervalCounter > 50) {
@@ -95,16 +69,7 @@ document.addEventListener("DOMContentLoaded", function() {
         }, 50
     );
 
-    document.getElementById('qty').addEventListener('input', function() {
-        var qtyValue = parseInt(this.value);
-
-        if (qtyValue > 0 && !isNaN(qtyValue)) {
-            boltConfigPDP.increaseQty(qtyValue);
-            boltConfigPDP.init();
-        } else {
-            boltConfigPDP.init(true);
-        }
-    });
+    document.getElementById('qty').addEventListener('input', boltConfigPDP.init.bind(boltConfigPDP));
 });
 
 </script>

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Catalog/Product/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Catalog/Product/BoltpayTest.php
@@ -378,62 +378,66 @@ class Bolt_Boltpay_Block_Catalog_Product_BoltpayTest extends PHPUnit_Framework_T
 
     /**
      * @test
-     * that getProductMaxQty returns -1 when stock is not managed for current product
+     * that getProductJSON returns required product data in JSON format
      *
-     * @covers ::getProductMaxQty
+     * @covers ::getProductJSON
      *
-     * @throws Mage_Core_Exception if unable to register current product
+     * @throws Mage_Core_Exception if unable to stub current product
      */
-    public function getProductMaxQty_ifStockIsNotManaged_returnsNegativeOne()
+    public function getProductJSON_always_returnsProductDataInJSON()
     {
-        $stockItem = $this->getMockBuilder('Mage_CatalogInventory_Model_Stock_Item')
-            ->setMethods(array('getManageStock', 'getIsInStock', 'getQty'))
-            ->getMock();
-        $stockItem->expects($this->once())->method('getManageStock')->willReturn(false);
-        $product = Mage::getModel('catalog/product', array('stock_item' => $stockItem));
-        Mage::register('current_product', $product);
-        $this->assertEquals(-1, $this->currentMock->getProductMaxQty());
-    }
-
-    /**
-     * @test
-     * that getProductMaxQty returns 0 if current product is out of stock
-     *
-     * @covers ::getProductMaxQty
-     *
-     * @throws Mage_Core_Exception if unable to register current product
-     */
-    public function getProductMaxQty_ifProductIsOutOfStock_returnsNegativeOne()
-    {
-        $stockItem = $this->getMockBuilder('Mage_CatalogInventory_Model_Stock_Item')
-            ->setMethods(array('getManageStock', 'getIsInStock', 'getQty'))
-            ->getMock();
-        $stockItem->expects($this->once())->method('getManageStock')->willReturn(true);
-        $stockItem->expects($this->once())->method('getIsInStock')->willReturn(false);
-        $product = Mage::getModel('catalog/product', array('stock_item' => $stockItem));
-        Mage::register('current_product', $product);
-        $this->assertEquals(0, $this->currentMock->getProductMaxQty());
-    }
-
-    /**
-     * @test
-     * that getProductMaxQty returns stock quantity if stock is managed and current product is in stock
-     *
-     * @covers ::getProductMaxQty
-     *
-     * @throws Mage_Core_Exception if unable to register current product
-     */
-    public function getProductMaxQty_ifQtyIsManagedAndProductIsInStock_returnsStockQuantity()
-    {
-        $qty = mt_rand(1, 10000);
-        $stockItem = $this->getMockBuilder('Mage_CatalogInventory_Model_Stock_Item')
-            ->setMethods(array('getManageStock', 'getIsInStock', 'getQty'))
-            ->getMock();
-        $stockItem->expects($this->once())->method('getManageStock')->willReturn(true);
-        $stockItem->expects($this->once())->method('getIsInStock')->willReturn(true);
-        $stockItem->expects($this->once())->method('getQty')->willReturn($qty);
-        $product = Mage::getModel('catalog/product', array('stock_item' => $stockItem));
-        Mage::register('current_product', $product);
-        $this->assertEquals($qty, $this->currentMock->getProductMaxQty());
+        $productMock = $this->getMockBuilder('Mage_Catalog_Model_Product')
+            ->setMethods(
+                array(
+                    'getId',
+                    'getName',
+                    'getFinalPrice',
+                    'getTierPrice',
+                )
+            )->getMock();
+        $dummyTierPrices = array(
+            array(
+                'price_id'      => '45',
+                'website_id'    => '0',
+                'all_groups'    => '1',
+                'cust_group'    => 32000,
+                'price'         => '70.0000',
+                'price_qty'     => '2.0000',
+                'website_price' => '70.0000',
+                'is_percent'    => 0,
+            ),
+            array(
+                'price_id'      => '46',
+                'website_id'    => '0',
+                'all_groups'    => '1',
+                'cust_group'    => 32000,
+                'price'         => '65.0000',
+                'price_qty'     => '3.0000',
+                'website_price' => '65.0000',
+                'is_percent'    => 0,
+            ),
+            array(
+                'price_id'      => '49',
+                'website_id'    => '0',
+                'all_groups'    => '1',
+                'cust_group'    => 32000,
+                'price'         => '55.0000',
+                'price_qty'     => '4.0000',
+                'website_price' => '55.0000',
+                'is_percent'    => 0,
+            ),
+        );
+        $productMock->expects($this->once())->method('getId')->willReturn(123);
+        $productMock->expects($this->once())->method('getName')->willReturn('Test Product Name');
+        $productMock->expects($this->once())->method('getFinalPrice')->willReturn(456.78);
+        $productMock->expects($this->once())->method('getTierPrice')->willReturn($dummyTierPrices);
+        TestHelper::stubRegistryValue('current_product', $productMock);
+        $productJson = $this->currentMock->getProductJSON();
+        $this->assertJson($productJson);
+        $productData = json_decode($productJson, true);
+        $this->assertEquals(123, $productData['id']);
+        $this->assertEquals('Test Product Name', $productData['name']);
+        $this->assertEquals(456.78, $productData['price']);
+        $this->assertEquals($dummyTierPrices, $productData['tier_prices']);
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
@@ -283,24 +283,65 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * that buildOnCheckCallback returns quantity check for product page checkout regardless if quote is virtual or not
+     * if product is in stock
      *
      * @covers ::buildOnCheckCallback
      *
      * @dataProvider buildOnCheckCallback_whenCheckoutTypeIsProductPageProvider
      *
      * @param bool $isVirtualQuote flag designating whether quote is virtual or not
+     *
+     * @throws Mage_Core_Exception if unable to stub current product
      */
-    public function buildOnCheckCallback_whenCheckoutTypeIsProductPage_returnsQuantityCheck($isVirtualQuote)
+    public function buildOnCheckCallback_whenCheckoutTypeIsProductPageAndProductInStock_returnsQuantityCheck($isVirtualQuote)
     {
+        $stockItem = Mage::getModel('cataloginventory/stock_item', array('qty' => mt_rand(), 'is_in_stock' => true));
+        $product = Mage::getModel('catalog/product', array('stock_item' => $stockItem));
+
+        Bolt_Boltpay_TestHelper::stubRegistryValue('current_product', $product);
         $expected = <<<JS
-if(max_qty !== -1 && boltConfigPDP._jsonProductCart.items[0].quantity > max_qty) {
+if(boltConfigPDP.getQty() > Number({$stockItem->getQty()})) {
     if ((typeof BoltPopup !== 'undefined')) {
-        BoltPopup.setMessage('The requested quantity is not available.');
+        BoltPopup.setMessage('{$this->currentMock->__("The requested quantity is not available.")}');
         BoltPopup.show();
     }
     return false;
 }
 JS;
+        $result = $this->currentMock->buildOnCheckCallback(
+            Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_PRODUCT_PAGE,
+            $isVirtualQuote
+        );
+        $this->assertEquals(preg_replace('/\s+/', '', $expected), preg_replace('/\s+/', '', $result));
+    }
+
+    /**
+     * @test
+     * that buildOnCheckCallback returns quantity check for product page checkout regardless if quote is virtual or not
+     * if product is not in stock that always fails
+     *
+     * @covers ::buildOnCheckCallback
+     *
+     * @dataProvider buildOnCheckCallback_whenCheckoutTypeIsProductPageProvider
+     *
+     * @param bool $isVirtualQuote flag designating whether quote is virtual or not
+     *
+     * @throws Mage_Core_Exception if unable to stub current product
+     */
+    public function buildOnCheckCallback_whenCheckoutTypeIsProductPageAndProductIsOutOfStock_returnsCheckThatFails($isVirtualQuote)
+    {
+        $stockItem = Mage::getModel(
+            'cataloginventory/stock_item',
+            array('qty'                     => mt_rand(),
+                  'is_in_stock'             => false,
+                  'manage_stock'            => true,
+                  'use_config_manage_stock' => false
+            )
+        );
+        $product = Mage::getModel('catalog/product', array('stock_item' => $stockItem));
+
+        Bolt_Boltpay_TestHelper::stubRegistryValue('current_product', $product);
+        $expected = 'return false;';
         $result = $this->currentMock->buildOnCheckCallback(
             Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_PRODUCT_PAGE,
             $isVirtualQuote

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/GeneralTraitTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/GeneralTraitTest.php
@@ -363,12 +363,13 @@ class Bolt_Boltpay_Helper_GeneralTraitTest extends PHPUnit_Framework_TestCase
      * @covers       Bolt_Boltpay_Helper_GeneralTrait::getCartDataJs
      *
      * @param string $checkoutType Bolt parameter
+     * @param string $configureCall expected Bolt configure call
      */
-    public function getCartDataJs_withVariousCheckoutTypes_returnsCartData($checkoutType)
+    public function getCartDataJs_withVariousCheckoutTypes_returnsCartData($checkoutType, $configureCall)
     {
         $cartDataJs = $this->currentMock->getCartDataJs($checkoutType);
         $this->assertContains('window.BoltModal', $cartDataJs);
-        $this->assertContains('BoltCheckout.configure(', $cartDataJs);
+        $this->assertContains($configureCall, $cartDataJs);
     }
 
     /**
@@ -379,11 +380,26 @@ class Bolt_Boltpay_Helper_GeneralTraitTest extends PHPUnit_Framework_TestCase
     public function getCartDataJs_withVariousCheckoutTypes_returnsCartDataProvider()
     {
         return array(
-            'Admin checkout type'        => array('checkoutType' => 'admin'),
-            'Multi-page checkout type'   => array('checkoutType' => 'multi-page'),
-            'One-page checkout type'     => array('checkoutType' => 'one-page'),
-            'Firecheckout type'          => array('checkoutType' => 'firecheckout'),
-            'Product page checkout type' => array('checkoutType' => 'product-page'),
+            'Admin checkout type'        => array(
+                'checkoutType'  => 'admin',
+                'configureCall' => 'BoltCheckout.configure'
+            ),
+            'Multi-page checkout type'   => array(
+                'checkoutType'  => 'multi-page',
+                'configureCall' => 'BoltCheckout.configure'
+            ),
+            'One-page checkout type'     => array(
+                'checkoutType'  => 'one-page',
+                'configureCall' => 'BoltCheckout.configure'
+            ),
+            'Firecheckout type'          => array(
+                'checkoutType'  => 'firecheckout',
+                'configureCall' => 'BoltCheckout.configure'
+            ),
+            'Product page checkout type' => array(
+                'checkoutType'  => 'product-page',
+                'configureCall' => 'BoltCheckout.configureProductCheckout'
+            ),
         );
     }
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
@@ -80,9 +80,13 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
 
     /**
      * Initialize benchmarking and remove events
+     *
+     * @throws ReflectionException if unable to remove events
+     * @throws Mage_Core_Exception if unable to clean registry
      */
     public static function setUpBeforeClass()
     {
+        TestHelper::clearRegistry();
         Mage::getModel('boltpay/observer')->initializeBenchmarkProfiler();
 
         $events = TestHelper::getNonPublicProperty(Mage::app(), '_events');

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/Productpage/CartTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/Productpage/CartTest.php
@@ -96,7 +96,6 @@ class Bolt_Boltpay_Model_Productpage_CartTest extends PHPUnit_Framework_TestCase
      * @covers ::init
      * @covers ::validateCartRequest
      * @covers ::createCart
-     * @covers ::setCartResponse
      *
      * @throws ReflectionException if class tested doesn't have cartRequest property
      * @throws Exception if the variable $testClassName is not specified in the class


### PR DESCRIPTION
# Description
PPC currently exist in its own island doing a lot of repeat code.  This is not desirable.  Instead of repeating code, we send PPC Bolt Order creation down the same path as all other order creation.

Fixes: https://app.asana.com/0/941895179897714/1161793187073237

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test
- [x] Refactor

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
