### PR TITLE
Add pending status to the default reception statuses

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
@@ -344,7 +344,7 @@ JS;
 
     /**
      * Formats the result as an array statuses while defining the default value as a single element array
-     * containing {@see Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING}
+     * containing {@see Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, Bolt_Boltpay_Model_Payment::TRANSACTION_PENDING}
      *
      * @param int|string $rawConfigValue    The config value pre-filter. Will be comma delimited string
      * @param array      $additionalParams  unused for this filter
@@ -354,7 +354,7 @@ JS;
     public function filterAllowedReceptionStatuses($rawConfigValue, $additionalParams = array() ) {
         return !empty($rawConfigValue)
             ? array_map('trim', explode(',', $rawConfigValue))
-            : array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING)
+            : array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, Bolt_Boltpay_Model_Payment::TRANSACTION_PENDING)
         ;
     }
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/Admin/ExtraConfigTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/Admin/ExtraConfigTest.php
@@ -353,12 +353,12 @@ class Bolt_Boltpay_Model_Admin_ExtraConfigTest extends PHPUnit_Framework_TestCas
                     'expectedResult'   => false
                 )
             ,
-            'Allow reception statuses, if not configured, will return Bolt pending payment' =>
+            'Allow reception statuses, if not configured, will return Bolt pending payment and pending' =>
                 array(
                     'configName'       => 'allowedReceptionStatuses',
                     'jsonFromDb'       => '',
                     'filterParameters' => array(),
-                    'expectedResult'   => array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING)
+                    'expectedResult'   => array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, Bolt_Boltpay_Model_Payment::TRANSACTION_PENDING)
                 )
             ,
             'Allow reception statuses, when configured, will return array of configured strings' =>


### PR DESCRIPTION
# Description
Currently, the back-office order status is "pending" and the default reception status configuration is "pending_bolt". So it throws an exception “Invalid webhook transition from pending to pending_bolt“ when the payment hook is sent to Magento to create an invoice for the back-office order.
This PR resolves that issue by adding "pending" status to the default reception statuses

Fixes: https://app.asana.com/0/564264490825835/1162923722970065



# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
