### PR TITLE
Refactor ProductPageController to use WebhookTrait

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ProductpageController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ProductpageController.php
@@ -21,22 +21,12 @@
 class Bolt_Boltpay_ProductpageController
     extends Mage_Core_Controller_Front_Action implements Bolt_Boltpay_Controller_Interface
 {
-    use Bolt_Boltpay_BoltGlobalTrait;
+    use Bolt_Boltpay_Controller_Traits_WebHookTrait;
 
     public function createCartAction()
     {
         try {
-            $hmacHeader = $_SERVER['HTTP_X_BOLT_HMAC_SHA256'];
-
-            $requestJson = file_get_contents('php://input');
-
-            if (!$this->boltHelper()->verify_hook($requestJson, $hmacHeader)) {
-                $exception = new Exception($this->boltHelper()->__("Failed HMAC Authentication"));
-                $this->boltHelper()->logWarning($exception->getMessage());
-                throw $exception;
-            }
-
-            $request = json_decode($requestJson);
+            $request = $this->getRequestData();
 
             /** @var Bolt_Boltpay_Model_Productpage_Cart $productCartModel */
             $productCartModel = Mage::getModel('boltpay/productpage_cart');
@@ -58,19 +48,5 @@ class Bolt_Boltpay_ProductpageController
                     )
             ));
         }
-    }
-
-    /**
-     * @param int   $httpCode
-     * @param array $data
-     *
-     * @throws \Zend_Controller_Response_Exception
-     */
-    protected function sendResponse($httpCode, $data = array())
-    {
-        $this->boltHelper()->setResponseContextHeaders();
-        $this->getResponse()->setHeader('Content-type', 'application/json');
-        $this->getResponse()->setHttpResponseCode($httpCode);
-        $this->getResponse()->setBody(json_encode($data));
     }
 }


### PR DESCRIPTION
# Description
We want to use a common method for hook verification, extraction of request body and sending of responses including identifying PPC as a webhook request.  This is all handled in WebhookTrait and ProductPageController should be using this.

Fixes: https://app.asana.com/0/941895179897714/1161793187073238

#changelog  Product Page integration into core system

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test
- [x] Refactor

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
