### PR TITLE
Supply default value for optional parameter for Bolt_Boltpay_Model_BoltOrder::addShippingForAdmin

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -413,11 +413,11 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
      * @param array                                 $cartSubmissionData data to be sent to Bolt
      * @param Mage_Sales_Model_Quote_Address_Rate   $shippingRate       shipping rate meta data
      * @param array                                 $boltFormatAddress  shipping address in Bolt format
-     * @param Mage_Sales_Model_Quote                $quote              the quote associated with the order
+     * @param Mage_Sales_Model_Quote|null           $quote              the quote associated with the order
      *
      * @return int    The total shipping in cents
      */
-    protected function addShippingForAdmin($totalsBlock, &$cartSubmissionData, $shippingRate, $boltFormatAddress, $quote ) {
+    protected function addShippingForAdmin($totalsBlock, &$cartSubmissionData, $shippingRate, $boltFormatAddress, $quote = null) {
         $totalShipping = 0;
         if ($shippingRate){
             /* @var Mage_Sales_Model_Quote_Address_Total $addressShippingTotal */


### PR DESCRIPTION
# Description
quote parameter is not used inside the method. What may ultimately be more important is that it wasn't being provided in the call which usually only results in warning logged but in developer mode or PHP>=7.1 will throw an exception
https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.too-few-arguments-exception

https://github.com/GuaranteedNetwork/bolt-magento1/blob/6c3d8da28ffe482d9ff9b8ad036dcb3ac1768403/app/code/community/Bolt/Boltpay/Model/BoltOrder.php#L287

Fixes: https://app.asana.com/0/941895179897714/1163884592458094

#changelog Bugfix: Provide missing default parameter for Bolt_Boltpay_Model_BoltOrder::addShippingForAdmin

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
