### PR TITLE
Correct the total validation logic when the create_order hook is sent to Magento 

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -711,7 +711,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 
             $boltPrice = (int)$boltCartItem->total_amount->amount;
             $magentoRowPrice = (int) ( $cartItem->getRowTotalWithDiscount() * 100 );
-            $magentoCalculatedPrice = (int) round($cartItem->getCalculationPrice() * 100 * $cartItem->getQty());
+            $magentoCalculatedPrice = (int) round($cartItem->getCalculationPrice() * 100) * $cartItem->getQty();
 
             if ( !in_array($boltPrice, [$magentoRowPrice, $magentoCalculatedPrice]) ) {
                 throw new Bolt_Boltpay_OrderCreationException(

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
@@ -542,6 +542,44 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     *
+     * @covers ::validateTotals
+     *
+     * @throws ReflectionException if validateTotals method doesn't exist
+     */
+    public function validateTotals_ifItemProductPriceDoesNotChange_notThrowsException()
+    {
+        $transaction = new stdClass();
+        $transaction->order->cart->items = array(
+            (object)array('reference' => 1, 'unit_price' => 460, 'total_amount' => (object)array('amount' => 2300))
+        );
+
+        $this->immutableQuoteMock->expects($this->once())->method('getTotals')
+            ->willReturnCallback(
+                function () use ($transaction) {
+                    //disable validations we are not interested in this test
+                    $transaction->shouldDoTaxTotalValidation = false;
+                    $transaction->shouldSkipDiscountAndShippingTotalValidation = true;
+                }
+            );
+
+        $this->immutableQuoteMock->expects($this->once())->method('getItemById')->with(1)
+            ->willReturn(
+                Mage::getModel(
+                    'sales/quote_item',
+                    array('row_total_with_discount' => 0, 'calculation_price' => 4.6035, 'qty' => 5, 'product_id' => 1001)
+                )
+            );
+
+        TestHelper::callNonPublicFunction(
+            $this->currentMock,
+            'validateTotals',
+            array($this->immutableQuoteMock, $transaction)
+        );
+    }
+
+    /**
+     * @test
      * that when the tax total amount is different at Bolt than Magento BEYOND the price fault tolerance
      * a mismatch exception is thrown that includes the mismatch reason, Bolt tax amount and Magento tax amount
      *


### PR DESCRIPTION

# Description
We used the following logic to send the total amount to Bolt:
**round($item->getCalculationPrice() * 100) * $item->getQty()**
See here: https://www.screencast.com/t/D9HFAy63x
So when the create_order hook is sent to Magento to create the order, we must use the same logic to validate it.

Fixes: 
https://app.asana.com/0/564264490825835/1163958531351617
https://app.asana.com/0/564264490825835/1163433085577459

(Optional: Add a changelog by writing a comment after "#changelog" on the next line)

\#changelog Correct the total validation logic when the create_order hook is sent to Magento 

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
