### PR TITLE
Fix variant image

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
@@ -97,15 +97,13 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
 
         /** @var Mage_Catalog_Model_Product $product */
         $product = Mage::getModel('catalog/product');
-
-        /** @var Mage_Catalog_Model_Product $_product */
-        $_product = $product->load($product->getIdBySku($item->getSku()));
+        $product->load($product->getIdBySku($item->getSku()));
 
         $image = '';
         try {
-            if ($_product->getThumbnail()) {
+            if ($product->getThumbnail()) {
                 /** @var Mage_Catalog_Helper_Image $image */
-                $image = $imageHelper->init($_product, 'thumbnail', $_product->getThumbnail());
+                $image = $imageHelper->init($product, 'thumbnail', $product->getThumbnail());
             }
         } catch (Exception $e) {
         }

--- a/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
@@ -86,7 +86,7 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
     }
 
     /**
-     * @param $item
+     * @param $item Mage_Sales_Model_Quote_Item
      *
      * @return string
      */
@@ -95,8 +95,11 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
         /** @var Mage_Catalog_Helper_Image $imageHelper */
         $imageHelper = Mage::helper('catalog/image');
 
+        /** @var Mage_Catalog_Model_Product $product */
+        $product = Mage::getModel('catalog/product');
+
         /** @var Mage_Catalog_Model_Product $_product */
-        $_product = $item->getProduct();
+        $_product = $product->load($product->getIdBySku($item->getSku()));
 
         $image = '';
         try {
@@ -104,9 +107,10 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
                 /** @var Mage_Catalog_Helper_Image $image */
                 $image = $imageHelper->init($_product, 'thumbnail', $_product->getThumbnail());
             }
-        } catch (Exception $e) {  }
+        } catch (Exception $e) {
+        }
 
-        return (string) $image;
+        return (string)$image;
     }
 
     /**

--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -136,7 +136,7 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
                 function ($item) use ($quote, &$calculatedTotal) {
                     /** @var Mage_Sales_Model_Quote_Item $item */
                     $imageUrl = $this->boltHelper()->getItemImageUrl($item);
-                    $product   = Mage::getModel('catalog/product')->load($item->getProductId());
+                    $product = Mage::getModel('catalog/product')->load($item->getProductId());
                     $type = $product->getTypeId() == 'virtual' ? self::ITEM_TYPE_DIGITAL : self::ITEM_TYPE_PHYSICAL;
                     $calculatedTotal += round($item->getPrice() * 100 * $item->getQty());
                     return array(


### PR DESCRIPTION
Fix images for products with variants are not populated correctly. Instead of getting product directly from quote item, we retrieve it using the sku, which is unique for variants.

Fixes: https://app.asana.com/0/1133951978134395/1155920207408049

#changelog Fix images for products with variants are not populated correctly

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
