### PR TITLE
Update codeowners - removing Ryan

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Automatically request reviews from M1 code-owners
-* @matt-thomason @ryan-timothy-albert @Jiyuan-Bolt @adentong @mccottry @johnmccombs1
+* @matt-thomason @Jiyuan-Bolt @adentong @mccottry @johnmccombs1


### PR DESCRIPTION
# Description
Removing @ryan-timothy-albert from codeowners

#changelog Removing @ryan-timothy-albert from codeowners
