### PR TITLE
PPC Validate Items by Product ID

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -694,7 +694,9 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
 
         foreach ($transaction->order->cart->items as $boltCartItem) {
 
-            $cartItem = $immutableQuote->getItemById($boltCartItem->reference);
+            $cartItem = $immutableQuote->getData('is_bolt_pdp')
+                ? $immutableQuote->getItemsCollection()->getItemByColumnValue('product_id', $boltCartItem->reference)
+                : $immutableQuote->getItemById($boltCartItem->reference);
             if ( !($cartItem instanceof Mage_Sales_Model_Quote_Item) ) { continue; }
 
             $cartItem->shouldNotBeValidated = false;


### PR DESCRIPTION
# Description
Currently, we use the product ID instead of cart ID for the reference that is passed to Bolt and then rely on the product not being able to be found by ID. While most of the time this is ok, there exists a remote opportunity for the product ID to match the cart item ID and validation to fail.

Instead, we wish to use the product ID matched against the cart item to validate the cart item price

Fixes: https://app.asana.com/0/941895179897714/1165040796588172

#changelog PPC Item Validation by Product ID

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
