### PR TITLE
PPC Downloadable Product w/ login required support

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
@@ -193,6 +193,7 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Bolt_Boltpay_Block_Chec
             Mage_Catalog_Model_Product_Type::TYPE_SIMPLE,
             Mage_Catalog_Model_Product_Type::TYPE_VIRTUAL,
             Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE,
+            Mage_Downloadable_Model_Product_Type::TYPE_DOWNLOADABLE,
         ];
     }
 
@@ -220,12 +221,44 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Bolt_Boltpay_Block_Chec
                         $product->getTypeId(),
                         array(
                             Mage_Catalog_Model_Product_Type::TYPE_SIMPLE,
-                            Mage_Catalog_Model_Product_Type::TYPE_VIRTUAL
+                            Mage_Catalog_Model_Product_Type::TYPE_VIRTUAL,
+                            Mage_Downloadable_Model_Product_Type::TYPE_DOWNLOADABLE,
                         )
                     ) ? $stockItem->getManageStock() : false,
                     'status' => $stockItem->getIsInStock(),
                     'qty'    => (float) $stockItem->getQty(),
                 ),
+            )
+        );
+    }
+
+    /**
+     * Returns customer data in JSON format
+     *
+     * @return string
+     */
+    public function getCustomerJSON()
+    {
+        return Mage::helper('core')->jsonEncode(
+            array(
+                'is_logged_in' => Mage::getSingleton('customer/session')->isLoggedIn()
+            )
+        );
+    }
+
+    /**
+     * Returns url to login page with current as referrer
+     *
+     * @return string
+     */
+    public function getCustomerLoginUrlWithReferrer()
+    {
+        return $this->getUrl(
+            'customer/account/login',
+            array(
+                Mage_Customer_Helper_Data::REFERER_QUERY_PARAM_NAME => Mage::helper('core')->urlEncode(
+                    $this->getUrl('*/*/*', array('_current' => true))
+                )
             )
         );
     }

--- a/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
@@ -21,6 +21,7 @@
 <script type="text/javascript">
 var boltConfigPDP = {
     product: <?php echo $this->getProductJSON(); ?>,
+    customer: <?php echo $this->getCustomerJSON(); ?>,
     /**
      * Initializes BoltCheckout
      */
@@ -61,6 +62,12 @@ var boltConfigPDP = {
                     price += Number(optionsPrice.optionPrices.config.price);
                 }
                 break;
+            case 'downloadable':
+                if (typeof optionsPrice.optionPrices.downloadable !== 'undefined') {
+                    //add downloadable options price
+                    price += Number(optionsPrice.optionPrices.downloadable);
+                }
+                break;
         }
         return price;
     },
@@ -71,6 +78,12 @@ var boltConfigPDP = {
     validate: function () {
         var formValidation = new Validation('product_addtocart_form');
         try {
+            if (this.product.type_id == 'downloadable' && !this.customer.is_logged_in) {
+                throw '<?php echo $this->__(
+                    'Please <a href="%s">login</a> in order to purchase this product',
+                    $this->getCustomerLoginUrlWithReferrer()
+                ); ?>';
+            }
             if (this.product.stock.manage && (!this.product.stock.status || this.product.stock.qty < this.getQty())) {
                 throw '<?php echo $this->__("The requested quantity is not available."); ?>';
             }
@@ -145,6 +158,12 @@ document.addEventListener("DOMContentLoaded", function() {
     if (typeof opConfig !== 'undefined') {
         opConfig.reloadPrice = function () {
             Product.Options.prototype.reloadPrice.apply(opConfig);
+            boltConfigPDP.init();
+        };
+    }
+    if (typeof dConfig !== 'undefined') {
+        dConfig.reloadPrice = function () {
+            Product.Downloadable.prototype.reloadPrice.apply(dConfig);
             boltConfigPDP.init();
         };
     }


### PR DESCRIPTION
# Description
Add support for downloadable products on PPC. During validation, if customer is not logged in and product is downloadable, ask the customer to login and redirect him back to product page after login if not disabled by 'Redirect Customer to Account Dashboard after Logging in' configuration.

Fixes: https://app.asana.com/0/941895179897714/1165040796588166

#changelog Product Page Checkout - Adds Downloadable Product support

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
