### PR TITLE
Remove BoltCheckout.configure from check callback in Admin and Firecheckout

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -194,27 +194,22 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
             case self::CHECKOUT_TYPE_ONE_PAGE:
                 if ($shouldCloneImmediately) break;
             case self::CHECKOUT_TYPE_ADMIN:
+                $checkoutTokenUrl = $this->boltHelper()->getMagentoUrl("adminhtml/sales_order_create/create/checkoutType/$checkoutType", array(), true);
             case self::CHECKOUT_TYPE_FIRECHECKOUT:
-                // We postpone calling configure until Bolt button clicked and form is ready
-                // This also allows us to save in cost of unnecessary quote creation
+                $checkoutTokenUrl = $this->boltHelper()->getMagentoUrl("boltpay/order/create/checkoutType/$checkoutType");
+                $parameters = "''";
                 $doChecks = 'var do_checks = 0;';
                 $boltConfigureCall = "
                     BoltCheckout.configure(
                         new Promise( 
-                            function (resolve, reject) {
-                                // Store state must be validated prior to open                          
+                            (resolve, reject) => {
+                                resolvePromise = resolve; 
+                                rejectPromise = reject;                          
                             }
                         ),
                         json_hints,
-                        {
-                            check: function() {
-                                $checkCustom
-                                $onCheckCallback
-                                $boltConfigureCall
-                                return true;
-                            }
-                        }
-                    ); 
+                        $callbacks
+                    );
                 ";
                 break;
             case self::CHECKOUT_TYPE_PRODUCT_PAGE:
@@ -231,16 +226,15 @@ JS;
                 break;
         }
 
-        if (!isset($doChecks)) $doChecks = 'var do_checks = 1;';
-
         $boltCheckoutJavascript = "
             var \$hints_transform = $hintsTransformFunction;
             
+            var resolvePromise;
+            var rejectPromise;
             var get_json_cart = function() { return $jsonCart };
             var json_hints = \$hints_transform($jsonHints);
             var quote_id = '{$quote->getId()}';
             var order_completed = false;
-            $doChecks
                 
             window.BoltModal = $boltConfigureCall   
         ";

--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -194,11 +194,7 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
             case self::CHECKOUT_TYPE_ONE_PAGE:
                 if ($shouldCloneImmediately) break;
             case self::CHECKOUT_TYPE_ADMIN:
-                $checkoutTokenUrl = $this->boltHelper()->getMagentoUrl("adminhtml/sales_order_create/create/checkoutType/$checkoutType", array(), true);
             case self::CHECKOUT_TYPE_FIRECHECKOUT:
-                $checkoutTokenUrl = $this->boltHelper()->getMagentoUrl("boltpay/order/create/checkoutType/$checkoutType");
-                $parameters = "''";
-                $doChecks = 'var do_checks = 0;';
                 $boltConfigureCall = "
                     BoltCheckout.configure(
                         new Promise( 

--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -96,10 +96,12 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
     }
 
     /**
-     * @param      $checkoutType
+     * @param string $checkoutType
      * @param bool $isVirtualQuote
      *
      * @return string
+     *
+     * @throws Mage_Core_Model_Store_Exception
      */
     public function buildOnCheckCallback($checkoutType, $isVirtualQuote = false)
     {
@@ -124,7 +126,7 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
                         resolvePromise(response.responseJSON.cart_data);
                     }                   
                 },
-                 onFailure: function(error) { rejectPromise(error); }
+                onFailure: function(error) { rejectPromise(error); }
             }); 
         ";
         switch ($checkoutType) {

--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -62,10 +62,8 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
 
         return "{
                   check: function() {
-                    if (do_checks++) {
-                        $checkCustom
-                        $onCheckCallback
-                    }
+                    $checkCustom
+                    $onCheckCallback
                     return true;
                   },
                   onCheckoutStart: function() {
@@ -105,6 +103,30 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function buildOnCheckCallback($checkoutType, $isVirtualQuote = false)
     {
+        if ( $checkoutType === Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ADMIN ) {
+            $checkoutTokenUrl = $this->getMagentoUrl("adminhtml/sales_order_create/create/checkoutType/$checkoutType", array(), true);
+        } else {
+            $checkoutTokenUrl = $this->getMagentoUrl("boltpay/order/create/checkoutType/$checkoutType");
+        }
+
+        $ajaxCall = "
+            new Ajax.Request('$checkoutTokenUrl', {
+                method:'post',
+                parameters: '',
+                onSuccess: function(response) {
+                    if(response.responseJSON.error) {                                                        
+                        rejectPromise(response.responseJSON.error_messages);
+                        
+                        // BoltCheckout is currently not doing anything reasonable to alert the user of a problem, so we will do something as a backup
+                        alert(response.responseJSON.error_messages);
+                        location.reload();
+                    } else {                                     
+                        resolvePromise(response.responseJSON.cart_data);
+                    }                   
+                },
+                 onFailure: function(error) { rejectPromise(error); }
+            }); 
+        ";
         switch ($checkoutType) {
             case Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ADMIN:
                 return
@@ -126,12 +148,14 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
                         } "). "
         
                         bolt_hidden.classList.add('required-entry');
+                        $ajaxCall
                     }
                     ";
             case Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_FIRECHECKOUT:
                 return
                     "
                     if (!checkout.validate()) return false;
+                    $ajaxCall
                     ";
             case Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_PRODUCT_PAGE:
                 return /** @lang JavaScript */ 'if (!boltConfigPDP.validate()) return false;';

--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -116,11 +116,9 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
                 method:'post',
                 parameters: '',
                 onSuccess: function(response) {
-                    if(response.responseJSON.error) {                                                        
+                    if(response.responseJSON.error) {
+                        // TODO: Consider informing the user of the error.  This could be handled Bolt-server-side
                         rejectPromise(response.responseJSON.error_messages);
-                        
-                        // BoltCheckout is currently not doing anything reasonable to alert the user of a problem, so we will do something as a backup
-                        alert(response.responseJSON.error_messages);
                         location.reload();
                     } else {                                     
                         resolvePromise(response.responseJSON.cart_data);

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
@@ -65,7 +65,7 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
                 } ") . "
 
                 bolt_hidden.classList.add('required-entry');
-                newAjax.Request('
+                new Ajax.Request('
         ";
         $result = $this->currentMock->buildOnCheckCallback($checkoutType, $isVirtualQuote);
         $this->assertContains(

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
@@ -65,10 +65,10 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
                 } ") . "
 
                 bolt_hidden.classList.add('required-entry');
-            }
+                newAjax.Request('
         ";
         $result = $this->currentMock->buildOnCheckCallback($checkoutType, $isVirtualQuote);
-        $this->assertEquals(
+        $this->assertContains(
             preg_replace('/\s/', '', $checkCallback),
             preg_replace('/\s/', '', $result)
         );
@@ -95,7 +95,7 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
      */
     public function buildOnCheckCallback_whenCheckoutTypeIsFireCheckout_returnsCorrectJs()
     {
-        $expected = 'if (!checkout.validate()) return false;';
+        $expected = 'if (!checkout.validate()) return false; new Ajax.Request(\'';
         $trueResult = $this->currentMock->buildOnCheckCallback(
             Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_FIRECHECKOUT,
             true
@@ -104,11 +104,11 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
             Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_FIRECHECKOUT,
             false
         );
-        $this->assertEquals(
+        $this->assertContains(
             preg_replace('/\s+/', '', $expected),
             preg_replace('/\s+/', '', $trueResult)
         );
-        $this->assertEquals(
+        $this->assertContains(
             preg_replace('/\s+/', '', $expected),
             preg_replace('/\s+/', '', $falseResult)
         );
@@ -330,9 +330,7 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
 
         $expected = "{
           check: function() {
-            if (do_checks++) {
-                if (!boltConfigPDP.validate()) return false;
-            }
+            if (!boltConfigPDP.validate()) return false;
             return true;
           },
           onCheckoutStart: function() {


### PR DESCRIPTION
# Description
Recently, changes were made to BoltCheckout.configure which breaks the use of calling this method from the check callback.  We therefore take an alternative approach to deferred configuration for Admin and Firecheckout where we must first validate the forms before BoltCheckout.configure can can be provided with proper data.

Note: This is a functional implementation of the request to be available at the soonest release and it is not for style points.  This code will be refactored in the future to simplify it's understanding.

Fixes: https://app.asana.com/0/544708310157130/1164240591833289

#changelog Remove BoltCheckout.configure from check callback in Admin and Firecheckout

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test
- [x] Refactor

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
