### PR TITLE
Remove payment method for failed preauth order quotes

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -1027,6 +1027,7 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
         if ($this->isBoltOrder($order)) {
 
             $parentQuote = $this->getParentQuoteFromOrder($order);
+            $immutableQuote = $this->getQuoteFromOrder($order);
 
             ##############################################################
             # Cancel order for restocking inventory and triggering events
@@ -1056,6 +1057,12 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             Mage::dispatchEvent('bolt_boltpay_failed_order_removed_after', array('order' => $order));
             $this->reactivateUsedPromotion($order);
             Mage::app()->setCurrentStore($previousStoreId);
+            ###########################################################
+
+            ##########################################################
+            # Remove payment method
+            ##########################################################
+            $immutableQuote->getPayment()->setMethod(null)->save();
             ###########################################################
 
             ##########################################################

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
@@ -181,6 +181,7 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
             'setTotalsCollectedFlag',
             'prepareRecurringPaymentProfiles',
             'setInventoryProcessed',
+            'getPayment'
         );
         $this->immutableQuoteMock = $this->getClassPrototype('Mage_Sales_Model_Quote')
             ->setMethods($quoteMockMethods)->getMock();
@@ -1861,6 +1862,13 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
         $this->orderMock->expects($this->once())->method('cancel')->willReturnSelf();
         $this->orderMock->expects($this->once())->method('setStatus')->with('canceled_bolt')->willReturnSelf();
 
+        $paymentMock = $this->getClassPrototype('Mage_Sales_Model_Quote_Payment')
+            ->setMethods(array('setMethod', 'save'))
+            ->getMock();
+        $paymentMock->expects($this->once())->method('setMethod')->with(null)->willReturnSelf();
+        $paymentMock->expects($this->once())->method('save')->willReturnSelf();
+        $this->immutableQuoteMock->expects($this->once())->method('getPayment')->willReturn($paymentMock);
+
         $currentMock->removePreAuthOrder($this->orderMock);
     }
 
@@ -1881,6 +1889,7 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
         $this->orderMock->expects($this->never())->method('save');
         $this->orderMock->expects($this->never())->method('cancel')->willReturnSelf();
         $this->orderMock->expects($this->never())->method('setStatus')->with('canceled_bolt')->willReturnSelf();
+        $this->immutableQuoteMock->expects($this->never())->method('getPayment');
 
         $currentMock->removePreAuthOrder($this->orderMock);
     }


### PR DESCRIPTION
# Description
Remove Boltpay from failed preauth order quotes in order to prevent third party modules from placing Bolt orders

Fixes: https://app.asana.com/0/inbox/544708310157128/1161099143858659/1164932369617130

#changelog Remove payment method for failed preauth order quotes

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
