### PR TITLE
PPC - Additional attribute price is not counted up in Bolt

### DIFF
--- a/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
@@ -221,6 +221,7 @@ document.addEventListener("DOMContentLoaded", function() {
     if (typeof bundle !== 'undefined') {
         bundle.reloadPrice = function () {
             Product.Bundle.prototype.reloadPrice.apply(bundle);
+            boltConfigPDP.init();
         };
     }
 });


### PR DESCRIPTION
# Description
PPC - Add missing init call for additional attribute prices

Fixes: https://app.asana.com/0/inbox/544708310157128/1166389723391913/1166448806825648

#changelog PPC - Additional attribute price is not counted up in Bolt

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
