### PR TITLE
[M1P-20] Make tests run faster by disabling coverage for 5.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           command: |
             mkdir ./artifacts
             export TEST_ENV=php56-mage18
-            PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar MAGENTO_VERSION=magento-mirror-1.8.1.0 tests/scripts/ci.sh
+            PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar MAGENTO_VERSION=magento-mirror-1.8.1.0 tests/scripts/ci.sh withcov
       - store_artifacts:
           path: ./artifacts
       - notify-buildcop
@@ -72,7 +72,7 @@ jobs:
           command: |
             mkdir ./artifacts
             export TEST_ENV=php56-mage19
-            PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar MAGENTO_VERSION=magento-mirror-1.9.3.6 tests/scripts/ci.sh
+            PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar MAGENTO_VERSION=magento-mirror-1.9.3.6 tests/scripts/ci.sh withcov
       - store_artifacts:
           path: ./artifacts
       - notify-buildcop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             mkdir ./artifacts
             export TEST_ENV=php55-mage18
-            PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar MAGENTO_VERSION=magento-mirror-1.8.1.0 tests/scripts/ci.sh
+            PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar MAGENTO_VERSION=magento-mirror-1.8.1.0 tests/scripts/ci.sh nocov
       - store_artifacts:
           path: ./artifacts
       - notify-buildcop
@@ -40,7 +40,7 @@ jobs:
           command: |
             mkdir ./artifacts
             export TEST_ENV=php55-mage19
-            PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar MAGENTO_VERSION=magento-mirror-1.9.3.6 tests/scripts/ci.sh
+            PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar MAGENTO_VERSION=magento-mirror-1.9.3.6 tests/scripts/ci.sh nocov
       - store_artifacts:
           path: ./artifacts
       - notify-buildcop

--- a/tests/scripts/ci.sh
+++ b/tests/scripts/ci.sh
@@ -4,5 +4,5 @@ set -e
 set -u
 set -x
 
-tests/scripts/magento_install.sh
-tests/scripts/run_phpunit_tests.sh
+tests/scripts/magento_install.sh "$@"
+tests/scripts/run_phpunit_tests.sh "$@"

--- a/tests/scripts/magento_install.sh
+++ b/tests/scripts/magento_install.sh
@@ -10,7 +10,11 @@ echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backpor
 sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 # Since Jessie is no longer the most recent stable release for Debian, we have to set Acquire::Check-Valid-Until=false
 apt-get -o Acquire::Check-Valid-Until=false update
-apt-get -y install curl php5-curl mysql-client php5-mcrypt php5-xdebug
+if [ "$1" == "nocov" ]; then
+  apt-get -y install curl php5-curl mysql-client php5-mcrypt
+else
+  apt-get -y install curl php5-curl mysql-client php5-mcrypt php5-xdebug
+fi
 php5enmod mcrypt
 
 curl -O https://files.magerun.net/n98-magerun.phar

--- a/tests/scripts/run_phpunit_tests.sh
+++ b/tests/scripts/run_phpunit_tests.sh
@@ -7,5 +7,9 @@ set -x
 export TEST_ENV=local
 export PHPUNIT_ENVIRONMENT=true
 
-php ${PHPUNIT_PHAR} --verbose --stderr --report-useless-tests -c tests/unit/phpunit.xml --coverage-clover=./artifacts/coverage.xml
-bash <(curl -s https://bolt-devops.s3-us-west-2.amazonaws.com/testing/codecov_uploader) -f ./artifacts/coverage.xml -F $TEST_ENV
+if [ "$1" == "nocov" ]; then
+  php ${PHPUNIT_PHAR} --verbose --stderr --report-useless-tests -c tests/unit/phpunit.xml
+else
+  php ${PHPUNIT_PHAR} --verbose --stderr --report-useless-tests -c tests/unit/phpunit.xml --coverage-clover=./artifacts/coverage.xml
+  bash <(curl -s https://bolt-devops.s3-us-west-2.amazonaws.com/testing/codecov_uploader) -f ./artifacts/coverage.xml -F $TEST_ENV
+fi


### PR DESCRIPTION
We already have coverage with the 5.6 tests, so it's kinda redundant. Now everything completes in like 3 minutes, as opposed to 20+ minutes before.

#changelog Make tests run faster by disabling coverage for 5.5

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
