### PR TITLE
HOT FIX: Deserialize to expected array instead of object

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -689,7 +689,7 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
             && (($cachedCartDataJS['creation_time'] + self::$cached_token_expiration_time) > time())
             && ($cachedCartDataJS['key'] === $this->calculateCartCacheKey($quote, $checkoutType))
         ) {
-            return json_decode($cachedCartDataJS["cart_data"]);
+            return json_decode($cachedCartDataJS["cart_data"], true);
         }
 
         Mage::getSingleton('core/session')->unsCachedCartData();

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/BoltOrderTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/BoltOrderTest.php
@@ -1673,7 +1673,7 @@ class Bolt_Boltpay_Model_BoltOrderTest extends PHPUnit_Framework_TestCase
 		$sessionMock->expects($this->never())->method('unsCachedCartData');
 		$currentMock->method('calculateCartCacheKey')->willReturn($cachedCartDataJS['key']);
 		$this->assertEquals(
-			json_decode($cachedCartDataJS['cart_data']),
+			json_decode($cachedCartDataJS['cart_data'], true),
 			$currentMock->getCachedCartData(
 				$quote,
 				$checkoutType


### PR DESCRIPTION
# Description
Upon changing unserialize to json_decode, the conversion from serialized string to array was changed to serialized string to object.  This fixes the issue by returning the expected array

Fixes: https://app.asana.com/0/inbox/544708310157128/1167010772454833/1167039107816210
https://boltpay.slack.com/archives/CKBBANKD2/p1584483491048700?thread_ts=1584483356.047600&cid=CKBBANKD2

#changelog HOT FIX: Deserialize to expected array instead of object

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
