### PR TITLE
Do not make a call to Bolt if online refund amount is less than 0.01

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -344,6 +344,16 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
     public function refund(Varien_Object $payment, $amount)
     {
         try {
+            if ($amount < 0.01) {
+                ////////////////////////////////////////////////////////////////////////////////
+                // In certain circumstances, an amount's value of zero can be sent, for
+                // example if the complete invoice has already been refunded using
+                // store credit. This will then result in an exception by the Bolt API.  In
+                // these instances, there is no need to call the Bolt API, so we simply return
+                ////////////////////////////////////////////////////////////////////////////////
+                return $this;
+            }
+
             $boltTransactionWasRefundedByWebhook = $payment->getAdditionalInformation('bolt_transaction_was_refunded_by_webhook');
             if(!empty($boltTransactionWasRefundedByWebhook)){
                 return $this;

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
@@ -38,6 +38,16 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
     private $boltHelperMock;
 
     /**
+     * @var MockObject|Bolt_Boltpay_Model_Payment mocked instance of Bolt payment model
+     */
+    private $paymentMock;
+
+    /**
+     * @var MockObject|Mage_Sales_Model_Order mocked instance of order model
+     */
+    private $orderMock;
+
+    /**
      * Setup test dependencies, called before each test
      *
      * @throws Exception if test class name is not defined
@@ -50,6 +60,10 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
         $this->boltHelperMock = $this->getClassPrototype('Bolt_Boltpay_Helper_Data')
             ->setMethods(array('transmit', 'canUseBolt', 'notifyException', 'logWarning', 'fetchTransaction'))
             ->getMock();
+        $this->paymentMock = $this->getTestClassPrototype()->setMethods(array('getAdditionalInformation', 'getOrder'))
+            ->getMock();
+        $this->orderMock = $this->getClassPrototype('Mage_Sales_Model_Order')
+            ->setMethods(array())->getMock();
         $this->currentMock->method('boltHelper')->willReturn($this->boltHelperMock);
     }
 
@@ -750,6 +764,7 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
      * @expectedExceptionMessage Waiting for a transaction update from Bolt. Please retry after 60 seconds.
      *
      * @throws Exception from tested method
+     * @throws \GuzzleHttp\Exception\GuzzleException from tested method
      */
     public function refund_withoutTransactionId_throwsException()
     {
@@ -764,7 +779,7 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
             )
         );
         $this->currentMock->expects($this->once())->method('getInfoInstance')->willReturn($payment);
-        $this->currentMock->refund($payment, 0);
+        $this->currentMock->refund($payment, 100);
     }
 
     /**
@@ -3464,6 +3479,66 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
                 Mage::getModel('payment/info', array('order' => $orderMock)),
                 Bolt_Boltpay_Model_Payment::DECISION_REJECT
             )
+        );
+    }
+
+    /**
+     * Setup method for tests covering {@see Bolt_Boltpay_Model_Payment::refund}
+     *
+     * @return MockObject|Bolt_Boltpay_Model_Payment
+     * @throws Exception if test class name is not defined
+     */
+    private function refundSetUp()
+    {
+        /** @var MockObject|Bolt_Boltpay_Model_Payment $currentMock */
+        $currentMock = $this->getTestClassPrototype()->setMethods(array('boltHelper', 'getInfoInstance'))->getMock();
+        $currentMock->method('boltHelper')->willReturn($this->boltHelperMock);
+        $currentMock->method('getInfoInstance')->willReturn($this->paymentMock);
+        $this->paymentMock->method('getAdditionalInformation')->willReturnMap(
+            array(
+                array('bolt_merchant_transaction_id', self::BOLT_MERCHANT_TRANSACTION_ID)
+            )
+        );
+        $this->paymentMock->method('getOrder')->willReturn($this->orderMock);
+        return $currentMock;
+    }
+
+    /**
+     * @test
+     * that refund avoids calling Bolt refund API for amounts lower than 1 cent
+     *
+     * @covers ::refund
+     *
+     * @dataProvider refund_withAmountsLessThanOneCent_refundsWithoutCallingTheBoltApiProvider
+     *
+     * @param float $amount to be refunded
+     *
+     * @throws Exception from setup if test class name is not defined
+     */
+    public function refund_withAmountsLessThanOneCent_refundsWithoutCallingTheBoltApi($amount)
+    {
+        $currentMock = $this->refundSetUp();
+
+        $this->boltHelperMock->expects($this->never())->method('transmit');
+
+        $this->assertSame($currentMock, $currentMock->refund($this->paymentMock, $amount));
+    }
+
+    /**
+     * Data provider for {@see refund_withAmountsLessThanOneCent_refundsWithoutCallingTheBoltApi}
+     *
+     * @return array containing zero or negative values for which to avoid calling Bolt API refund
+     */
+    public function refund_withAmountsLessThanOneCent_refundsWithoutCallingTheBoltApiProvider()
+    {
+        return array(
+            array('amount' => 0),
+            array('amount' => null),
+            array('amount' => 0.001),
+            array('amount' => 0.009),
+            array('amount' => -1),
+            array('amount' => PHP_INT_MIN),
+            array('amount' => PHP_FLOAT_MIN),
         );
     }
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
@@ -751,7 +751,7 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
         $currentMock->expects($this->never())->method('getInfoInstance');
         $currentMock->expects($this->never())->method('boltHelper');
         $currentMock->expects($this->never())->method('setRefundPaymentInfo');
-        $this->assertEquals($currentMock, $currentMock->refund($payment, 0));
+        $this->assertEquals($currentMock, $currentMock->refund($payment, 12.50));
     }
 
     /**


### PR DESCRIPTION
# Description
In certain circumstances, an amount's value of zero can be sent, for example, if the complete invoice has already been refunded using store credit. This will then result in an exception by the Bolt API. Instead, do not send a refund request to Bolt of this nature.

Fixes: https://app.asana.com/0/941895179897714/1167296894232481

#changelog Bugfix: Online refund less than 0.01 will be ignored by Bolt

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
