### PR TITLE
Safeguards Bolt Orders from 3rd Party code

### DIFF
--- a/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/GeneralTrait.php
@@ -31,6 +31,16 @@ trait Bolt_Boltpay_Helper_GeneralTrait {
     public static $fromHooks = false;
 
     /**
+     * @var bool    a flag set to true if the an order was placed in this request, otherwise false
+     */
+    public static $boltOrderWasJustPlaced = false;
+
+    /**
+     * @var bool    a flag set to true if the class is instantiated from web hook call, otherwise false
+     */
+    public static $canChangePreAuthStatus = true;
+
+    /**
      * Determines if the Bolt payment method can be used to pay for the given quote using the quote's context
      *
      * @param Mage_Sales_Model_Quote $quote        The cart to be inspected as viable for Bolt payment

--- a/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
+++ b/app/code/community/Bolt/Boltpay/Model/Admin/ExtraConfig.php
@@ -343,22 +343,6 @@ JS;
     }
 
     /**
-     * Formats the result as an array statuses while defining the default value as a single element array
-     * containing {@see Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, Bolt_Boltpay_Model_Payment::TRANSACTION_PENDING}
-     *
-     * @param int|string $rawConfigValue    The config value pre-filter. Will be comma delimited string
-     * @param array      $additionalParams  unused for this filter
-     *
-     * @return array  an array of statuses accepted by the plugin to receive Bolt orders for hook processing
-     */
-    public function filterAllowedReceptionStatuses($rawConfigValue, $additionalParams = array() ) {
-        return !empty($rawConfigValue)
-            ? array_map('trim', explode(',', $rawConfigValue))
-            : array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, Bolt_Boltpay_Model_Payment::TRANSACTION_PENDING)
-        ;
-    }
-
-    /**
      * Normalizes JSON by stripping new lines from the given string and returning null
      * in the case of only white space.
      *

--- a/app/code/community/Bolt/Boltpay/controllers/ApiController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ApiController.php
@@ -71,11 +71,6 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
                 ///////////////////////////////////////
                 Mage::app()->setCurrentStore($order->getStore());
 
-                if (empty($transaction) && $hookType !== 'pending') {
-                    // further transaction details are required from the Bolt API to process hook
-                    $transaction = $this->boltHelper()->fetchTransaction($reference);
-                }
-
                 $orderPayment = $order->getPayment();
                 $paymentMethod = strtolower($orderPayment->getMethod());
                 if ($paymentMethod !== Bolt_Boltpay_Model_Payment::METHOD_CODE) {
@@ -84,6 +79,12 @@ class Bolt_Boltpay_ApiController extends Mage_Core_Controller_Front_Action imple
                         "Order #{$order->getIncrementId()} is not a Bolt order.  Order type: $paymentMethod"
                     );
                 }
+
+                if (empty($transaction) && $hookType !== 'pending') {
+                    // further transaction details are required from the Bolt API to process hook
+                    $transaction = $this->boltHelper()->fetchTransaction($reference);
+                }
+
                 if (!$orderPayment->getAdditionalInformation('bolt_reference')) {
                     if ($hookType === Bolt_Boltpay_Model_Payment::HOOK_TYPE_REJECTED_IRREVERSIBLE) {
                         // This is a special case of failed payment hook where Bolt immediately

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -125,6 +125,15 @@
           </bolt_boltpay_filter_preauth_orders>
         </observers>
       </sales_order_grid_collection_load_before>
+      <sales_order_place_after>
+        <observers>
+          <bolt_boltpay_mark_order_as_placed>
+            <type>singleton</type>
+            <class>Bolt_Boltpay_Model_Observer</class>
+            <method>markThatBoltOrderWasJustPlaced</method>
+          </bolt_boltpay_mark_order_as_placed>
+        </observers>
+      </sales_order_place_after>
       <sales_order_save_before>
         <observers>
           <bolt_boltpay_safeguard_preauth_status>

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/Admin/ExtraConfigTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/Admin/ExtraConfigTest.php
@@ -75,7 +75,6 @@ class Bolt_Boltpay_Model_Admin_ExtraConfigTest extends PHPUnit_Framework_TestCas
      * @covers ::filterKeepPreAuthOrderTimeStamps
      * @covers ::filterKeepPreAuthOrders
      * @covers ::filterEnableBenchmarkProfiling
-     * @covers ::filterAllowedReceptionStatuses
      *
      * @dataProvider getExtraConfig_throughVariousFilters_returnsExpectedResultProvider
      *
@@ -351,22 +350,6 @@ class Bolt_Boltpay_Model_Admin_ExtraConfigTest extends PHPUnit_Framework_TestCas
                     'jsonFromDb'       => '{"keepPreAuthOrders": "Y"}',
                     'filterParameters' => array(),
                     'expectedResult'   => false
-                )
-            ,
-            'Allow reception statuses, if not configured, will return Bolt pending payment and pending' =>
-                array(
-                    'configName'       => 'allowedReceptionStatuses',
-                    'jsonFromDb'       => '',
-                    'filterParameters' => array(),
-                    'expectedResult'   => array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, Bolt_Boltpay_Model_Payment::TRANSACTION_PENDING)
-                )
-            ,
-            'Allow reception statuses, when configured, will return array of configured strings' =>
-                array(
-                    'configName'       => 'allowedReceptionStatuses',
-                    'jsonFromDb'       => '{"keepPreAuthOrders": "Y", "allowedReceptionStatuses": "pending, pending_bolt   ,new"}',
-                    'filterParameters' => array(),
-                    'expectedResult'   => array('pending','pending_bolt','new')
                 )
             ,
         );

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/CronTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/CronTest.php
@@ -162,8 +162,9 @@ class Bolt_Boltpay_Model_CronTest extends PHPUnit_Framework_TestCase
      *
      * @throws Mage_Core_Exception on failure to create or delete a dummy order
      */
-    public function cleanupOrders_deletesOrdersOlderThan15Minutes()
+    public function cleanupOrders_always_deletesOrdersOlderThan15Minutes()
     {
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
         $pendingPaymentOrders = $paidOrders = $ordersPastExpiration = $activeOrders = [];
         $cleanupDate = gmdate(
             'Y-m-d H:i:s',

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/ObserverTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/ObserverTest.php
@@ -698,37 +698,215 @@ class Bolt_Boltpay_Model_ObserverTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * that safeguardPreAuthStatus overrides status with original status value if not hook request
-     * and original status is one of preauth statuses
+     * that the flag for Bolt order being placed is set to true for Bolt orders after the order is created
+     *
+     * @covers ::markThatBoltOrderWasJustPlaced
+     */
+    public function markThatBoltOrderWasJustPlaced_forBoltOrders_flagsOrderAsJustPlaced()
+    {
+        Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced = false;
+        $order = Bolt_Boltpay_OrderHelper::createDummyOrder(
+            self::$productId,
+            $qty = 2,
+            $paymentMethod = 'boltpay',
+            $overrideNormalOrderStateAndStatusSetByObservers = false
+        ); # triggers markThatBoltOrderWasJustPlaced
+        $this->assertTrue(Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced);
+        Bolt_Boltpay_OrderHelper::deleteDummyOrder($order);
+    }
+
+    /**
+     * @test
+     * that the flag for Bolt order being placed remains false for non-Bolt orders after the order is created
+     *
+     * @covers ::markThatBoltOrderWasJustPlaced
+     */
+    public function markThatBoltOrderWasJustPlaced_forNonBoltOrders_keepsOrderJustPlacedFlagAsFalse()
+    {
+        Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced = false;
+        $order = Bolt_Boltpay_OrderHelper::createDummyOrder(
+            self::$productId,
+            $qty = 2,
+            $paymentMethod = 'checkmo',
+            $overrideNormalOrderStateAndStatusSetByObservers = false
+        ); # triggers markThatBoltOrderWasJustPlaced
+
+        $this->assertFalse(Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced);
+        Bolt_Boltpay_OrderHelper::deleteDummyOrder($order);
+    }
+
+    /**
+     * @test
+     * that safeguardPreAuthStatus allows for state and status when directive comes from
+     * a hook request and the request in not after the order has just been place
+     *
+     * @covers ::safeguardPreAuthStatus
+     *
+     * @throws Mage_Core_Exception if unable to create dummy order
+     */
+    public function safeguardPreAuthStatus_whenFromHook_setsStatus()
+    {
+        $order = Bolt_Boltpay_OrderHelper::createDummyOrder(self::$productId);
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, $order->getState());
+        $this->assertEquals(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, $order->getStatus());
+        $this->assertFalse(Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced);
+        $this->assertTrue(Bolt_Boltpay_Helper_Data::$canChangePreAuthStatus);
+
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
+
+        $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, Mage_Sales_Model_Order::STATE_PROCESSING)
+            ->save();  # triggers event that invokes safeguardPreAuthStatus
+
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $order->getStatus());
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $order->getStatus());
+
+        Bolt_Boltpay_OrderHelper::deleteDummyOrder($order);
+    }
+
+    /**
+     * @test
+     * that safeguardPreAuthStatus overrides state and status with original values if the
+     * hook request has recently created the order.  This represents the case when third party plugins
+     * attempt to change our pre-auth status
+     *
+     * @covers ::safeguardPreAuthStatus
+     *
+     * @throws Mage_Core_Exception if unable to create dummy order
+     */
+    public function safeguardPreAuthStatus_whenFromHookAfterOrderJustPlaced_blocksStatusChange()
+    {
+        $order = Bolt_Boltpay_OrderHelper::createDummyOrder(
+            self::$productId,
+            $qty = 2,
+            $paymentMethod = 'boltpay',
+            $overrideNormalOrderStateAndStatusSetByObservers = false
+        );
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, $order->getState());
+        $this->assertEquals(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, $order->getStatus());
+        $this->assertTrue(Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced);
+        $this->assertFalse(Bolt_Boltpay_Helper_Data::$canChangePreAuthStatus);
+
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
+
+        $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, Mage_Sales_Model_Order::STATE_PROCESSING)
+            ->save();  # triggers safeguardPreAuthStatus
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, $order->getState());
+        $this->assertEquals(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING, $order->getStatus());
+
+        Bolt_Boltpay_OrderHelper::deleteDummyOrder($order);
+    }
+
+    /**
+     * @test
+     * that safeguardPreAuthStatus does not block status change if the
+     * directive comes outside of a hook request and original state and status are
+     * not Bolt preauth
+     *
+     * @covers ::safeguardPreAuthStatus
+     *
+     * @throws Mage_Core_Exception if unable to create dummy order
+     */
+    public function safeguardPreAuthStatus_whenNotFromHookAndStatusNotPreAuth_setsStatus()
+    {
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
+        $order = Bolt_Boltpay_OrderHelper::createDummyOrder(self::$productId);
+
+        $order->setState(
+            Mage_Sales_Model_Order::STATE_PROCESSING,
+            true
+        )->save();
+
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $order->getState());
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $order->getStatus());
+        $this->assertFalse(Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced);
+        $this->assertTrue(Bolt_Boltpay_Helper_Data::$canChangePreAuthStatus);
+
+        Bolt_Boltpay_Helper_Data::$fromHooks = false;
+        $order->setState(Mage_Sales_Model_Order::STATE_NEW, 'pending' )
+            ->save(); # triggers safeguardPreAuthStatus
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_NEW, $order->getState());
+        $this->assertEquals('pending', $order->getStatus());
+
+        $order->setState(Mage_Sales_Model_Order::STATE_CANCELED, true)
+            ->save(); # triggers safeguardPreAuthStatus
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_CANCELED, $order->getState());
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_CANCELED, $order->getStatus());
+
+        Bolt_Boltpay_OrderHelper::deleteDummyOrder($order);
+    }
+
+    /**
+     * @test
+     * that safeguardPreAuthStatus blocks state and status change if initiated from
+     * outside a hook request and the order is has preauth state and status
      *
      * @covers ::safeguardPreAuthStatus
      *
      * @dataProvider safeguardPreAuthStatus_whenNotFromHookAndStatusIsPreAuthProvider
      *
+     * @param string $preAuthState  original value of order state
      * @param string $preAuthStatus original value of order status
      *
      * @throws Mage_Core_Exception if unable to create dummy order
      */
-    public function safeguardPreAuthStatus_whenNotFromHookAndStatusIsPreAuth_overridesStatusToOriginalValue($preAuthStatus)
+    public function safeguardPreAuthStatus_whenNotFromHookAndStatusIsPreAuth_overridesStatusToOriginalValue(
+        $preAuthState,
+        $preAuthStatus
+    )
     {
-        Bolt_Boltpay_Helper_Data::$fromHooks = false;
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
         $order = Bolt_Boltpay_OrderHelper::createDummyOrder(self::$productId);
-        $order->setOrigData('status', $preAuthStatus);
-        Mage::dispatchEvent('sales_order_save_before', array('order' => $order));
-        $this->assertEquals($order->getStatus(), $preAuthStatus);
+
+        if ($preAuthStatus === Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_CANCELED) {
+                $order->setState(
+                    Mage_Sales_Model_Order::STATE_CANCELED,
+                    Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_CANCELED
+                )->save();
+        }
+
+        $this->assertFalse(Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced);
+        $this->assertTrue(Bolt_Boltpay_Helper_Data::$canChangePreAuthStatus);
+        $this->assertEquals($preAuthState, $order->getState());
+        $this->assertEquals($preAuthStatus, $order->getStatus());
+
+        /////////////////////////////////////////////////////////////////////////////////
+        /// We'll use verbose assertions to emphasize that the status is not
+        /// changing from preauth despite attempting to save a new status from a
+        ///  context outside of webhooks
+        /////////////////////////////////////////////////////////////////////////////////
+        Bolt_Boltpay_Helper_Data::$fromHooks = false;
+        $order->setState(Mage_Sales_Model_Order::STATE_NEW, 'pending' )->save();
+        $this->assertNotEquals(Mage_Sales_Model_Order::STATE_NEW, $order->getState());
+        $this->assertNotEquals('pending', $order->getStatus());
+        $this->assertEquals($preAuthState, $order->getState());
+        $this->assertEquals($preAuthStatus, $order->getStatus());
+
+        $order->setState(Mage_Sales_Model_Order::STATE_HOLDED, true)->save();
+        $this->assertNotEquals(Mage_Sales_Model_Order::STATE_HOLDED, $order->getState());
+        $this->assertNotEquals(Mage_Sales_Model_Order::STATE_HOLDED, $order->getStatus());
+        $this->assertEquals($preAuthState, $order->getState());
+        $this->assertEquals($preAuthStatus, $order->getStatus());
+        /////////////////////////////////////////////////////////////////////////////////
+
         Bolt_Boltpay_OrderHelper::deleteDummyOrder($order);
     }
 
     /**
      * Data provider for {@see safeguardPreAuthStatus_whenNotFromHookAndStatusIsPreAuth_overridesStatusToOriginalValue}
      *
-     * @return array containing preAuthStatus
+     * @return array containing [preAuthState, preAuthStatus]
      */
     public function safeguardPreAuthStatus_whenNotFromHookAndStatusIsPreAuthProvider()
     {
         return array(
-            array('preAuthStatus' => Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING),
-            array('preAuthStatus' => Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_CANCELED),
+            array(
+                'preAuthState' => Mage_Sales_Model_Order::STATE_PENDING_PAYMENT,
+                'preAuthStatus' => Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING
+            ),
+            array(
+                'preAuthState' => Mage_Sales_Model_Order::STATE_CANCELED,
+                'preAuthStatus' => Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_CANCELED
+            ),
         );
     }
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/OrderTest.php
@@ -2468,14 +2468,7 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
         $currentMock->method('getQuoteFromOrder')->with($this->orderMock)->willReturn($this->immutableQuoteMock);
         $currentMock->method('getParentQuoteFromOrder')->with($this->orderMock)->willReturn($this->parentQuoteMock);
         $currentMock->method('boltHelper')->willReturn($this->boltHelperMock);
-
-        $this->boltHelperMock
-            ->expects($this->once())->method('getExtraConfig')
-            ->with('allowedReceptionStatuses')
-            ->willReturn(array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING));
-
-        $this->orderMock->expects($this->once())->method('getStatus')
-            ->willReturn(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING);
+        
         $this->orderMock->expects($this->once())->method('getCreatedAt')->willReturn(null);
         $this->orderMock->expects($this->once())->method('setCreatedAt')->with($this->anything())->willReturnSelf();
         $this->orderMock->expects($this->once())->method('save')->willReturnSelf();
@@ -2490,91 +2483,6 @@ class Bolt_Boltpay_Model_OrderTest extends PHPUnit_Framework_TestCase
 
         $this->paymentMock->expects($this->once())->method('setAdditionalInformation')->willReturnSelf();
         $this->paymentMock->expects($this->once())->method('save')->willReturnSelf();
-        $currentMock->receiveOrder($this->orderMock, $payload);
-    }
-
-    /**
-     * @test
-     * that receiveOrder activates received order and sets Bolt user id with irregular statuses if
-     * that status is configured to be accepted
-     *
-     * @covers ::receiveOrder
-     * @covers ::activateOrder
-     *
-     * @throws Mage_Core_Exception from method tested if there is a problem retrieving the bolt transaction reference from the payload
-     * @throws Exception if test class name is not defined
-     */
-    public function receiveOrder_withAcceptedStatus_activatesOrderAndSetsBoltUserId()
-    {
-        $payload = new stdClass();
-        $payload->notification_type = Bolt_Boltpay_Model_Payment::HOOK_TYPE_PENDING;
-
-        /** @var MockObject|Bolt_Boltpay_Model_Order $currentMock */
-        $currentMock = $this->getTestClassPrototype()
-            ->setMethods(array('getQuoteFromOrder', 'getParentQuoteFromOrder', 'sendOrderEmail','boltHelper'))
-            ->getMock();
-        $currentMock->method('getQuoteFromOrder')->with($this->orderMock)->willReturn($this->immutableQuoteMock);
-        $currentMock->method('getParentQuoteFromOrder')->with($this->orderMock)->willReturn($this->parentQuoteMock);
-        $currentMock->method('boltHelper')->willReturn($this->boltHelperMock);
-
-        $this->boltHelperMock
-            ->expects($this->once())->method('getExtraConfig')
-            ->with('allowedReceptionStatuses')
-            ->willReturn(array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING,'status_configured_as_ok'));
-
-        $this->orderMock->expects($this->once())->method('getStatus')
-            ->willReturn('status_configured_as_ok');
-        $this->orderMock->expects($this->once())->method('getCreatedAt')->willReturn(null);
-        $this->orderMock->expects($this->once())->method('setCreatedAt')->with($this->anything())->willReturnSelf();
-        $this->orderMock->expects($this->once())->method('save')->willReturnSelf();
-
-        $this->parentQuoteMock->expects($this->once())->method('setIsActive')->with(false)->willReturnSelf();
-        $this->parentQuoteMock->expects($this->once())->method('save')->willReturnSelf();
-
-        $this->immutableQuoteMock->expects($this->once())->method('setTotalsCollectedFlag')->with(true)
-            ->willReturnSelf();
-        $this->immutableQuoteMock->expects($this->once())->method('prepareRecurringPaymentProfiles');
-        $this->immutableQuoteMock->expects($this->atLeastOnce())->method('setInventoryProcessed')->with(true);
-
-        $this->paymentMock->expects($this->once())->method('setAdditionalInformation')->willReturnSelf();
-        $this->paymentMock->expects($this->once())->method('save')->willReturnSelf();
-        $currentMock->receiveOrder($this->orderMock, $payload);
-    }
-
-    /**
-     * @test
-     * that receiveOrder throws an exception and does not activate an order for an irregular order status that
-     * is not configured to be accepted
-     *
-     * @covers ::receiveOrder
-     *
-     * @expectedException Bolt_Boltpay_InvalidTransitionException
-     * @expectedExceptionMessage Order has an unexpected status at order reception.  An order status of [unexpected_status] was found
-     *
-     * @throws Mage_Core_Exception from method tested if there is a problem retrieving the bolt transaction reference from the payload
-     * @throws Exception if test class name is not defined
-     */
-    public function receiveOrder_withUnexpectedStatus_throwExceptionWithoutActivatingOrder()
-    {
-        $payload = new stdClass();
-        $payload->notification_type = Bolt_Boltpay_Model_Payment::HOOK_TYPE_PENDING;
-
-        /** @var MockObject|Bolt_Boltpay_Model_Order $currentMock */
-        $currentMock = $this->getTestClassPrototype()
-            ->setMethods(array('boltHelper', 'activateOrder'))
-            ->getMock();
-        $currentMock->method('boltHelper')->willReturn($this->boltHelperMock);
-
-        $this->boltHelperMock
-            ->expects($this->once())->method('getExtraConfig')
-            ->with('allowedReceptionStatuses')
-            ->willReturn(array(Bolt_Boltpay_Model_Payment::TRANSACTION_PRE_AUTH_PENDING,'status_configured_as_ok'));
-
-        $this->orderMock->expects($this->once())->method('getStatus')
-            ->willReturn('unexpected_status');
-
-        $currentMock->expects($this->never())->method('activateOrder');
-
         $currentMock->receiveOrder($this->orderMock, $payload);
     }
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
@@ -1135,7 +1135,7 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
      */
     private function handleTransactionUpdateSetUp($product, $orderProductQty = 1)
     {
-
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
         $initialQty = (int)$product->getQty();
 
         // Assert initial product store stock is greater than what we will order
@@ -1875,7 +1875,7 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals($order->getGrandTotal(), $order->getTotalInvoiced());
         $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $order->getState());
-        $this->assertEquals('pending_bolt', $order->getStatus());
+        $this->assertEquals(Mage_Sales_Model_Order::STATE_PROCESSING, $order->getStatus());
         $this->assertEquals(1, $order->getInvoiceCollection()->getSize());
         Bolt_Boltpay_OrderHelper::deleteDummyOrder($order);
     }
@@ -3537,6 +3537,7 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
      */
     private function createDummyOrder($quoteData = array())
     {
+        Bolt_Boltpay_Helper_Data::$fromHooks = true;
         $cart = Mage::getModel('checkout/cart', array('quote' => Mage::getModel('sales/quote')));
         $cart->addProduct(self::$productId, 1);
         $address = array(
@@ -3560,9 +3561,9 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
         $quote->getPayment()->importData(array('method' => Bolt_Boltpay_Model_Payment::METHOD_CODE));
         $quote->save();
         $service = Mage::getModel('sales/service_quote', $quote);
-        Bolt_Boltpay_Helper_Data::$fromHooks = true;
         $service->submitAll();
-        Bolt_Boltpay_Helper_Data::$fromHooks = false;
+        Bolt_Boltpay_Helper_Data::$boltOrderWasJustPlaced = false;
+        Bolt_Boltpay_Helper_Data::$canChangePreAuthStatus = true;
         /** @var Mage_Sales_Model_Order $order */
         $order = Mage::getModel('sales/order')->load($service->getOrder()->getId());
         return $order;


### PR DESCRIPTION
# Description
This more accurately implements the logic to safeguard Bolt pre-auth order status from being changed by other 3rd party plugins.  The previous attempt failed in production for a variety of reasons including order models not being loaded, and adding preventative steps after the problem had already occured 

Fixes: https://app.asana.com/0/941895179897714/1163546160576133
https://app.asana.com/0/941895179897714/1165390780167868

#changelog Safeguards Bolt Orders from 3rd Party code

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
