### PR TITLE
[M1P-26] Updates cloned quote to correctly address commented issue

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -855,35 +855,13 @@ PROMISE;
                 ->save();
         }
 
-        //////////////////////////////////////////////////////////////////////////////////////////////////
-        // Attempting to reset some of the values already set by merge affects the totals passed to
-        // Bolt in such a way that the grand total becomes 0.  Since we do not need to reset these values
-        // we ignore them all.
-        //////////////////////////////////////////////////////////////////////////////////////////////////
-        $fieldsSetByMerge = array(
-            'coupon_code',
-            'subtotal',
-            'base_subtotal',
-            'subtotal_with_discount',
-            'base_subtotal_with_discount',
-            'grand_total',
-            'base_grand_total',
-            'auctaneapi_discounts',
-            'applied_rule_ids',
-            'items_count',
-            'items_qty',
-            'virtual_items_qty',
+        /////////////////////////////////////////////////////////////////////
+        /// Exclude fields that we are not interested in copying that will
+        /// cause the cloned quote to be misinterpreted as the parent quote.
+        /////////////////////////////////////////////////////////////////////
+        $fieldsToIgnore = array(
             'trigger_recollect',
-            'can_apply_msrp',
             'totals_collected_flag',
-            'global_currency_code',
-            'base_currency_code',
-            'store_currency_code',
-            'quote_currency_code',
-            'store_to_base_rate',
-            'store_to_quote_rate',
-            'base_to_global_rate',
-            'base_to_quote_rate',
             'is_changed',
             'created_at',
             'updated_at',
@@ -892,7 +870,7 @@ PROMISE;
 
         // Add all previously saved data that may have been added by other plugins
         foreach ($sourceQuote->getData() as $key => $value) {
-            if (!in_array($key, $fieldsSetByMerge)) {
+            if (!in_array($key, $fieldsToIgnore)) {
                 $clonedQuote->setData($key, $value);
             }
         }

--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -855,6 +855,11 @@ PROMISE;
                 ->save();
         }
 
+        $clonedQuote->getBillingAddress()->setBaseSubtotal($sourceQuote->getBillingAddress()->getBaseSubtotal());
+        $clonedQuote->getShippingAddress()->setBaseSubtotal($sourceQuote->getShippingAddress()->getBaseSubtotal());
+        $clonedQuote->getBillingAddress()->setBaseDiscountAmount($sourceQuote->getBillingAddress()->getBaseDiscountAmount());
+        $clonedQuote->getShippingAddress()->setBaseDiscountAmount($sourceQuote->getShippingAddress()->getBaseDiscountAmount());
+
         /////////////////////////////////////////////////////////////////////
         /// Exclude fields that we are not interested in copying that will
         /// cause the cloned quote to be misinterpreted as the parent quote.


### PR DESCRIPTION
# Description
-- from inline code comment --
Attempting to reset some of the values already set by merge affects the totals passed to
Bolt in such a way that the grand total becomes 0. Since we do not need to reset these values we ignore them all.

Fixes: https://app.asana.com/0/941895179897714/1168370828754618

#changelog Updates cloned quote to correctly address commented issue

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
