### PR TITLE
[ENG-518] Check container exists before calling configureProductCheckout

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -212,7 +212,7 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
                 $jsonCart = /** @lang JavaScript */ 'boltConfigPDP.getCartData();';
 
                 $boltConfigureCall = <<<JS
-var containers = document.getElementsByClassName('bolt-checkout-button-product');
+var containers = document.getElementsByClassName('bolt-product-checkout-button');
 if (containers.length > 0) {
     console.log('bolt button container found');
     BoltCheckout.configureProductCheckout(

--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -212,12 +212,16 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
                 $jsonCart = /** @lang JavaScript */ 'boltConfigPDP.getCartData();';
 
                 $boltConfigureCall = <<<JS
-BoltCheckout.configureProductCheckout(
-    get_json_cart(),
-    json_hints,
-    {$callbacks},
-    { checkoutButtonClassName: 'bolt-product-checkout-button' }
-);
+var containers = document.getElementsByClassName('bolt-checkout-button-product');
+if (containers.length > 0) {
+    console.log('bolt button container found');
+    BoltCheckout.configureProductCheckout(
+        get_json_cart(),
+        json_hints,
+        {$callbacks},
+        { checkoutButtonClassName: 'bolt-product-checkout-button' }
+    );
+}
 JS;
                 break;
         }

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -1810,7 +1810,7 @@ SCSS;
                         $this->assertContains('var order_completed = false;', $js);
                         $windowBoltModal = explode('window.BoltModal = ', $js)[1];
                         $this->assertContains(
-                            "varcontainers=document.getElementsByClassName('bolt-checkout-button-product');if(containers.length>0){console.log('boltbuttoncontainerfound');",
+                            "varcontainers=document.getElementsByClassName('bolt-product-checkout-button');if(containers.length>0){console.log('boltbuttoncontainerfound');",
                             preg_replace('/\s*/', '', $windowBoltModal)
                         );
                         $this->assertContains(

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -1810,6 +1810,10 @@ SCSS;
                         $this->assertContains('var order_completed = false;', $js);
                         $windowBoltModal = explode('window.BoltModal = ', $js)[1];
                         $this->assertContains(
+                            "varcontainers=document.getElementsByClassName('bolt-checkout-button-product');if(containers.length>0){console.log('boltbuttoncontainerfound');",
+                            preg_replace('/\s*/', '', $windowBoltModal)
+                        );
+                        $this->assertContains(
                             "BoltCheckout.configureProductCheckout(get_json_cart(),json_hints,/*BOLT-CALLBACKS*/,{checkoutButtonClassName:'bolt-product-checkout-button'});",
                             preg_replace('/\s*/', '', $windowBoltModal)
                         );


### PR DESCRIPTION
[ENG-518] Check container exists before calling configureProductCheckout

Fixes: https://app.asana.com/0/1133951978134395/1167936044773634

#changelog [ENG-518] Check container exists before calling configureProductCheckout

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.


[ENG-518]: https://boltpay.atlassian.net/browse/ENG-518