### PR TITLE
[M1P-29] Add minimum order amount support

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Catalog/Product/Boltpay.php
@@ -261,6 +261,27 @@ class Bolt_Boltpay_Block_Catalog_Product_Boltpay extends Bolt_Boltpay_Block_Chec
     }
 
     /**
+     * Get configuration options that can affect product page checkout
+     *
+     * @return string
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to get store
+     * @throws Zend_Currency_Exception if unable to convert amount to currency
+     */
+    public function getConfigJSON()
+    {
+        return Mage::helper('core')->jsonEncode(
+            array(
+                'minimum_order' => array(
+                    'enabled' => Mage::getStoreConfigFlag('sales/minimum_order/active'),
+                    'amount' => Mage::getStoreConfig('sales/minimum_order/amount'),
+                    'message' => $this->boltHelper()->getMinOrderDescriptionMessage(),
+                )
+            )
+        );
+    }
+
+    /**
      * Returns url to login page with current as referrer
      *
      * @return string

--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -231,6 +231,7 @@ JS;
             
             var resolvePromise;
             var rejectPromise;
+            var checkError;
             var get_json_cart = function() { return $jsonCart };
             var json_hints = \$hints_transform($jsonHints);
             var quote_id = '{$quote->getId()}';

--- a/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
+++ b/app/code/community/Bolt/Boltpay/Helper/ConfigTrait.php
@@ -236,4 +236,38 @@ trait Bolt_Boltpay_Helper_ConfigTrait
 
         return null;
     }
+
+    /**
+     * Returns message to be displayed to customer if attempting to checkout with order lower than minimum amount
+     *
+     * @return string
+     */
+    public function getMinOrderDescriptionMessage()
+    {
+        return Mage::getStoreConfig('sales/minimum_order/description')
+            ? Mage::getStoreConfig('sales/minimum_order/description')
+            : Mage::helper('checkout')->__(
+                'Minimum order amount is %s',
+                $this->getMinOrderAmountInStoreCurrency()
+            );
+    }
+
+    /**
+     * Return minimum order amount in current store currency
+     *
+     * @param int|null $storeId
+     *
+     * @return string
+     */
+    public function getMinOrderAmountInStoreCurrency($storeId = null)
+    {
+        $amount = Mage::getStoreConfig('sales/minimum_order/amount', $storeId);
+        try {
+            return Mage::app()->getLocale()
+                ->currency(Mage::app()->getStore($storeId)->getCurrentCurrencyCode())
+                ->toCurrency($amount);
+        } catch (Exception $e) {
+            return $amount;
+        }
+    }
 }

--- a/app/code/community/Bolt/Boltpay/Helper/Data.php
+++ b/app/code/community/Bolt/Boltpay/Helper/Data.php
@@ -159,6 +159,16 @@ class Bolt_Boltpay_Helper_Data extends Mage_Core_Helper_Abstract
                     ";
             case Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_PRODUCT_PAGE:
                 return /** @lang JavaScript */ 'if (!boltConfigPDP.validate()) return false;';
+            case Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE:
+                return /** @lang JavaScript */ <<<JS
+if (checkError){
+    if (typeof BoltPopup !== 'undefined' && typeof checkError === 'string') {
+        BoltPopup.setMessage(checkError);
+        BoltPopup.show();
+    }
+    return false;
+}
+JS;
             default:
                 return '';
         }

--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -752,6 +752,12 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
                 return json_decode('{"token" : "", "error": "'.$this->boltHelper()->__('Billing address is required.').'"}');
             }
         }
+        if ($isMultiPage && !$quote->validateMinimumAmount()) {
+            return (object)array(
+                'token' => '',
+                'error' => $this->boltHelper()->getMinOrderDescriptionMessage()
+            );
+        }
 
         // Generates order data for sending to Bolt create order API.
         $orderRequest = $this->buildOrder($quote, $isMultiPage);
@@ -768,19 +774,26 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
      * @return string javascript Promise string used for initializing BoltCheckout
      */
     public function getBoltOrderTokenPromise($checkoutType) {
-
+        $onError = /** @lang JavaScript */<<<JS
+if (typeof BoltPopup !== 'undefined' && typeof response.responseJSON.error_messages === 'string') {
+    BoltPopup.setMessage(response.responseJSON.error_messages);
+    BoltPopup.addOnCloseCallback(function() {location.reload();});
+    BoltPopup.show();
+}
+JS;
+        $checkoutTokenUrl = $this->boltHelper()->getMagentoUrl("boltpay/order/create/checkoutType/$checkoutType");
+        $parameters = "''";
         if ( $checkoutType === Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_FIRECHECKOUT ) {
             $checkoutTokenUrl = $this->boltHelper()->getMagentoUrl('boltpay/order/firecheckoutcreate');
             $parameters = 'checkout.getFormData ? checkout.getFormData() : Form.serialize(checkout.form, true)';
         } else if ( $checkoutType === Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ADMIN ) {
             $checkoutTokenUrl = $this->boltHelper()->getMagentoUrl("adminhtml/sales_order_create/create/checkoutType/$checkoutType", array(), true);
             $parameters = "''";
-        } else {
-            $checkoutTokenUrl = $this->boltHelper()->getMagentoUrl("boltpay/order/create/checkoutType/$checkoutType");
-            $parameters = "''";
+        } else if($checkoutType === Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE){
+            $onError = /** @lang JavaScript */ "checkError = response.responseJSON.error_messages;";
         }
 
-        return <<<PROMISE
+        return /** @lang JavaScript */ <<<PROMISE
                     new Promise( 
                         function (resolve, reject) {
                             new Ajax.Request('$checkoutTokenUrl', {
@@ -791,8 +804,7 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
                                         reject(response.responseJSON.error_messages);
                                         
                                         // BoltCheckout is currently not doing anything reasonable to alert the user of a problem, so we will do something as a backup
-                                        alert(response.responseJSON.error_messages);
-                                        location.reload();
+                                        $onError
                                     } else {                                     
                                         resolve(response.responseJSON.cart_data);
                                     }                   

--- a/app/code/community/Bolt/Boltpay/Model/Order.php
+++ b/app/code/community/Bolt/Boltpay/Model/Order.php
@@ -417,6 +417,15 @@ class Bolt_Boltpay_Model_Order extends Bolt_Boltpay_Model_Abstract
             }
         }
 
+        if (!$immutableQuote->validateMinimumAmount()) {
+            throw new Bolt_Boltpay_OrderCreationException(
+                OCE::E_BOLT_MINIMUM_PRICE_NOT_MET,
+                OCE::E_BOLT_MINIMUM_PRICE_NOT_MET_TMPL,
+                array(
+                    $this->boltHelper()->getMinOrderAmountInStoreCurrency($immutableQuote->getStoreId())
+                )
+            );
+        }
     }
 
     /**

--- a/app/code/community/Bolt/Boltpay/OrderCreationException.php
+++ b/app/code/community/Bolt/Boltpay/OrderCreationException.php
@@ -89,6 +89,12 @@ class Bolt_Boltpay_OrderCreationException extends Bolt_Boltpay_BoltException
     const E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED_TMPL      = '{"reason": "Shipping total has changed", "old_value": "%d", "new_value": "%d"}';
 
     /**
+     * Minimum price amount not met
+     */
+    const E_BOLT_MINIMUM_PRICE_NOT_MET = 2001011;
+    const E_BOLT_MINIMUM_PRICE_NOT_MET_TMPL = '{"reason": "The minimum order amount of %s has not been met"}';
+
+    /**
      * @var int http response code that is to be returned
      */
     protected $httpCode;
@@ -109,7 +115,8 @@ class Bolt_Boltpay_OrderCreationException extends Bolt_Boltpay_BoltException
         self::E_BOLT_OUT_OF_INVENTORY,
         self::E_BOLT_DISCOUNT_CANNOT_APPLY,
         self::E_BOLT_DISCOUNT_DOES_NOT_EXIST,
-        self::E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED
+        self::E_BOLT_SHIPPING_PRICE_HAS_BEEN_UPDATED,
+        self::E_BOLT_MINIMUM_PRICE_NOT_MET,
     );
 
     /**

--- a/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
@@ -19,9 +19,19 @@
 ?>
 <?php if ($this->isEnabledProductPageCheckout() && $this->isSupportedProductType()): ?>
 <script type="text/javascript">
+/**
+ * @namespace
+ * @property {{minimum_order:{enabled:bool,amount:number,message:string}}} config
+ */
 var boltConfigPDP = {
+    config: <?php echo $this->getConfigJSON(); ?>,
     product: <?php echo $this->getProductJSON(); ?>,
     customer: <?php echo $this->getCustomerJSON(); ?>,
+    validateMinOrderAmount: function () {
+        if (this.config.minimum_order.enabled && this.getTotalAmount() < this.config.minimum_order.amount) {
+            throw this.config.minimum_order.message;
+        }
+    },
     /**
      * Initializes BoltCheckout
      */
@@ -105,6 +115,7 @@ var boltConfigPDP = {
             if (this.product.stock.manage && (!this.product.stock.status || this.product.stock.qty < this.getQty())) {
                 throw '<?php echo $this->__("The requested quantity is not available."); ?>';
             }
+            this.validateMinOrderAmount();
             //TODO: support file type custom options
             //currently not supported because it would require custom upload and expiration logic
             document.querySelectorAll("#product_addtocart_form input[type='file']").forEach(function(fileInput) {
@@ -178,6 +189,21 @@ var boltConfigPDP = {
             currency: '<?php echo Mage::app()->getStore()->getCurrentCurrencyCode(); ?>'
         };
     },
+    /**
+     * Get items total amount
+     * @returns {number}
+     */
+    getTotalAmount: function () {
+        var itemData = this.getItemData();
+        var totalAmount = 0;
+        for (var i in itemData) {
+            if (!itemData.hasOwnProperty(i) || !itemData[i]) {
+                continue;
+            }
+            totalAmount += itemData[i].price * itemData[i].quantity;
+        }
+        return totalAmount;
+    }
 };
 
 document.addEventListener("DOMContentLoaded", function() {

--- a/app/design/frontend/base/default/template/boltpay/popup.phtml
+++ b/app/design/frontend/base/default/template/boltpay/popup.phtml
@@ -33,6 +33,7 @@
     var BoltPopup = {
         popupElmId: 'bolt-popup',
         popupElm: null,
+        onCloseCallbacks: [],
         init: function() {
             this.popupElm = document.getElementById(this.popupElmId);
             this.initPopupEvents()
@@ -54,6 +55,12 @@
         close: function() {
             this.popupElm.classList.remove('active');
             this.fade();
+            for (var i = 0; i < this.onCloseCallbacks.length; i++) {
+                if(typeof this.onCloseCallbacks[i] === 'function'){
+                    this.onCloseCallbacks[i].call(this);
+                }
+            }
+            this.onCloseCallbacks = [];
         },
         show: function() {
             this.popupElm.classList.add('active');
@@ -91,7 +98,10 @@
                 elms[0].innerHTML = title;
             }
             return this;
-        }
+        },
+        addOnCloseCallback: function (callback) {
+            this.onCloseCallbacks.push(callback);
+        },
     };
     BoltPopup.init();
 </script>
@@ -103,7 +113,7 @@
         height: 100vh;
         position: fixed;
         width: 100%;
-        z-index: 99;
+        z-index: 1000;
         left: 0;
         top: 0;
     }

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Catalog/Product/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Catalog/Product/BoltpayTest.php
@@ -73,6 +73,7 @@ class Bolt_Boltpay_Block_Catalog_Product_BoltpayTest extends PHPUnit_Framework_T
     {
         Mage::unregister('current_product');
         Mage::unregister('_helper/boltpay');
+        Mage::app()->setCurrentStore(self::$originalStore);
         TestHelper::restoreOriginals();
     }
 
@@ -568,6 +569,34 @@ class Bolt_Boltpay_Block_Catalog_Product_BoltpayTest extends PHPUnit_Framework_T
                 array('id' => 456, 'name' => 'Test Product 3', 'price' => 321.12),
             ),
             $productData['associated_products']
+        );
+    }
+
+    /**
+     * @test
+     * that getConfigJSON returns minimum order amount config
+     *
+     * @covers ::getConfigJSON
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     * @throws Zend_Currency_Exception from tested method
+     */
+    public function getConfigJSON_always_returnsConfigurationInJSON()
+    {
+        TestHelper::stubConfigValue('sales/minimum_order/active', true);
+        TestHelper::stubConfigValue('sales/minimum_order/amount', 123);
+        TestHelper::stubConfigValue('sales/minimum_order/description', 'Minimum order amount is $123');
+        $result = $this->currentMock->getConfigJSON();
+        $this->assertJson($result);
+        $this->assertEquals(
+            array(
+                'minimum_order' => array(
+                    'enabled' => true,
+                    'amount'  => 123,
+                    'message' => 'Minimum order amount is $123'
+                )
+            ),
+            json_decode($result, true)
         );
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/ConfigTraitTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/ConfigTraitTest.php
@@ -378,4 +378,95 @@ class Bolt_Boltpay_Helper_ConfigTraitTest extends PHPUnit_Framework_TestCase
             )
         );
     }
+
+    /**
+     * @test
+     * that getMinOrderDescriptionMessage returns description from config if present
+     *
+     * @covers Bolt_Boltpay_Helper_ConfigTrait::getMinOrderDescriptionMessage
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config
+     */
+    public function getMinOrder_withCustomDescription_returnsDescriptionFromConfig()
+    {
+        TestHelper::stubConfigValue('sales/minimum_order/description', 'Minimum order amount is $123');
+        $this->assertEquals('Minimum order amount is $123', $this->currentMock->getMinOrderDescriptionMessage());
+    }
+
+    /**
+     * @test
+     * that getMinOrderDescriptionMessage returns default description if one is not configured
+     *
+     * @covers Bolt_Boltpay_Helper_ConfigTrait::getMinOrderDescriptionMessage
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config
+     */
+    public function getMinOrder_withoutCustomDescription_returnsDefaultDescription()
+    {
+        TestHelper::stubConfigValue('sales/minimum_order/amount', 123);
+        TestHelper::stubConfigValue('sales/minimum_order/description', '');
+        $this->assertRegExp(
+            '/Minimum order amount is \$?123(\.|,)00(.+\$)?/', # Supports American and European locale
+            $this->currentMock->getMinOrderDescriptionMessage()
+        );
+    }
+
+    /**
+     * @test
+     * that getMinOrderAmountInStoreCurrency returns minimum order amount in default store currency
+     * if no store id is provided
+     *
+     * @covers Bolt_Boltpay_Helper_ConfigTrait::getMinOrderAmountInStoreCurrency
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getMinOrderAmountInStoreCurrency_withoutStoreId_returnsMinOrderAmountInDefaultStoreCurrency()
+    {
+        TestHelper::stubConfigValue('sales/minimum_order/amount', 123);
+        $this->assertRegExp(
+            '/\$?123(\.|,)00(.+\$)?/', # Supports American and European locale
+            $this->currentMock->getMinOrderAmountInStoreCurrency())
+        ;
+    }
+
+    /**
+     * @test
+     * that getMinOrderAmountInStoreCurrency returns minimum order amount in store currency if store id is provided
+     *
+     * @covers Bolt_Boltpay_Helper_ConfigTrait::getMinOrderAmountInStoreCurrency
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getMinOrderAmountInStoreCurrency_withStoreId_returnsAmountInProvidedStoreCurrency()
+    {
+        TestHelper::stubConfigValue('sales/minimum_order/amount', 123);
+        $this->assertRegExp(
+            '/\$?123(\.|,)00(.+\$)?/', # Supports American and European locale
+            $this->currentMock->getMinOrderAmountInStoreCurrency(
+                Mage::app()->getStore()->getId()
+            )
+        );
+    }
+
+    /**
+     * @test
+     * that getMinOrderAmountInStoreCurrency returns plain minimum order amount if an exception occurs
+     * when converting to currency
+     *
+     * @covers Bolt_Boltpay_Helper_ConfigTrait::getMinOrderAmountInStoreCurrency
+     *
+     * @throws Mage_Core_Model_Store_Exception if unable to stub config value
+     */
+    public function getMinOrderAmountInStoreCurrency_withInvalidStore_returnsAmountWithoutCurrency()
+    {
+        TestHelper::stubConfigValue('sales/minimum_order/amount', 'non number value that fails validation');
+        $this->assertEquals(
+            'non number value that fails validation',
+            $this->currentMock->getMinOrderAmountInStoreCurrency(
+                Mage::app()->getStore()->getId()
+            )
+        );
+    }
+
+
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
@@ -25,14 +25,27 @@ class Bolt_Boltpay_Helper_DataTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * that buildOnCheckCallback returns expected callback for multi-page checkout
      *
      * @covers ::buildOnCheckCallback
      */
-    public function buildOnCheckCallback_whenCheckoutTypeIsMultiPage_returnsEmptyString()
+    public function buildOnCheckCallback_whenCheckoutTypeIsMultiPage_returnsCheckCallback()
     {
         $checkoutType = Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_MULTI_PAGE;
         $result = $this->currentMock->buildOnCheckCallback($checkoutType);
-        $this->assertEquals('', $result);
+        $this->assertEquals(
+            <<<JS
+if (checkError){
+    if (typeof BoltPopup !== 'undefined' && typeof checkError === 'string') {
+        BoltPopup.setMessage(checkError);
+        BoltPopup.show();
+    }
+    return false;
+}
+JS
+            ,
+            $result
+        );
     }
 
     /**

--- a/tests/unit/testsuite/Bolt/Boltpay/OrderCreationExceptionTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/OrderCreationExceptionTest.php
@@ -4,6 +4,8 @@ use Bolt_Boltpay_Controller_Interface as RESPONSE_CODE;
 
 /**
  * Class Bolt_Boltpay_OrderCreationExceptionTest
+ *
+ * @coversDefaultClass Bolt_Boltpay_OrderCreationException
  */
 class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
 {
@@ -323,6 +325,30 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
         $this->assertNotEquals($dataValues[1], $exception->error[0]->data[0]->new_value);
         $this->assertEquals(0, $exception->error[0]->data[0]->old_value);
         $this->assertEquals(0, $exception->error[0]->data[0]->new_value);
+        $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * @test
+     * that correct JSON and HTTP response code is set when throwing exception with
+     * @see Bolt_Boltpay_OrderCreationException::E_BOLT_MINIMUM_PRICE_NOT_MET code
+     *
+     * @covers ::__construct
+     */
+    public function initialize_withMinimumPriceNotMetException_setsCorrectJsonAndHttpCode()
+    {
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_MINIMUM_PRICE_NOT_MET,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_MINIMUM_PRICE_NOT_MET_TMPL,
+            array(
+                '$123.45'
+            )
+        );
+        $exceptionJson = $boltOrderCreationException->getJson();
+        $exception = json_decode($exceptionJson);
+
+        $this->assertExceptionProperties($exception, Bolt_Boltpay_OrderCreationException::E_BOLT_MINIMUM_PRICE_NOT_MET);
+        $this->assertEquals('The minimum order amount of $123.45 has not been met', $exception->error[0]->data[0]->reason);
         $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
     }
 


### PR DESCRIPTION
# Description
If we enable Minimum Order Amount in M1 (Admin dashboard -> Store -> Configuration -> Sales -> Sales -> Minimum Order Amount ) and set a Minimum Amount, in the frontend shop, even when the cart subtotal is less than the minimum amount, the customer can still open Bolt modal and process to payment, and eventually will get an error for the restriction.

The Minimum Order Amount is a native setting in M1, so the Bolt plugin should support it.

Fixes: https://app.asana.com/0/941895179897714/1166832552917026

#changelog Add minimum order amount support

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
