### PR TITLE
[M1P-30] Empty response body after sending to avoid duplicate response

### DIFF
--- a/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
+++ b/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
@@ -145,6 +145,8 @@ trait Bolt_Boltpay_Controller_Traits_WebHookTrait {
         # Send the prepared output
         $this->getResponse()->sendResponse();
         @flush();
+        # empty the body to prevent duplicate output
+        $this->getResponse()->setBody('');
         ///////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////

--- a/tests/unit/testsuite/Bolt/Boltpay/Controller/Traits/WebHookTraitTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Controller/Traits/WebHookTraitTest.php
@@ -364,12 +364,14 @@ class Bolt_Boltpay_Controller_Traits_WebHookTraitTest extends PHPUnit_Framework_
     {
         $tearDownData = $this->sendResponseSetup($responseCode);
         $expectedResponse = is_string($responseData) ? $responseData : json_encode($responseData);
-        $this->response->expects($this->once())->method('setBody')->with($expectedResponse)->willReturnCallback(
-            function ($content) {
-                $this->proxyResponse->setBody($content);
-                return $this->response;
-            }
-        );
+        $this->response->expects($this->exactly(2))->method('setBody')
+            ->withConsecutive(array($expectedResponse), array(''))
+            ->willReturnCallback(
+                function ($content) {
+                    $this->proxyResponse->setBody($content);
+                    return $this->response;
+                }
+            );
 
         TestHelper::callNonPublicFunction(
             $this->currentMock,
@@ -445,12 +447,14 @@ class Bolt_Boltpay_Controller_Traits_WebHookTraitTest extends PHPUnit_Framework_
     public function sendResponse_whenUsedOnFPM_shouldCallPlatformSpecificMethod()
     {
         $expectedResponse = json_encode(array("something" => "that can be verified"));
-        $this->response->expects($this->once())->method('setBody')->with($expectedResponse)->willReturnCallback(
-            function ($content) {
-                $this->proxyResponse->setBody($content);
-                return $this->response;
-            }
-        );
+        $this->response->expects($this->exactly(2))->method('setBody')
+            ->withConsecutive(array($expectedResponse), array(''))
+            ->willReturnCallback(
+                function ($content) {
+                    $this->proxyResponse->setBody($content);
+                    return $this->response;
+                }
+            );
 
         if (function_exists('fastcgi_finish_request')) {
             $this->markTestSkipped('Test not available with the Ngnix/PHP-FPM environment');


### PR DESCRIPTION
# Description
When not exiting immediately, the Magento's controller dispatch method will always call again sendResponse, which can result duplicate replies to Bolt.  This can be prevented by emptying the response body after and call to sendResponse is sent.

Fixes: https://boltpay.atlassian.net/browse/M1P-30

#changelog [M1P-30] Empty response body after sending to avoid duplicate response

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
