### PR TITLE
[M1P-36] PPC javascript error in Bolt configure call

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -212,16 +212,19 @@ class Bolt_Boltpay_Block_Checkout_Boltpay extends Mage_Checkout_Block_Onepage_Re
                 $jsonCart = /** @lang JavaScript */ 'boltConfigPDP.getCartData();';
 
                 $boltConfigureCall = <<<JS
-var containers = document.getElementsByClassName('bolt-product-checkout-button');
-if (containers.length > 0) {
-    console.log('bolt button container found');
-    BoltCheckout.configureProductCheckout(
-        get_json_cart(),
-        json_hints,
-        {$callbacks},
-        { checkoutButtonClassName: 'bolt-product-checkout-button' }
-    );
-}
+function() {
+    var containers = document.getElementsByClassName('bolt-product-checkout-button');
+    if (containers.length > 0) {
+        console.log('bolt button container found');
+        return BoltCheckout.configureProductCheckout(
+            get_json_cart(),
+            json_hints,
+            {$callbacks},
+            { checkoutButtonClassName: 'bolt-product-checkout-button' }
+        );
+    }
+    return null;
+}();
 JS;
                 break;
         }


### PR DESCRIPTION
# Description
https://github.com/GuaranteedNetwork/bolt-magento1/blob/6b1d76bd8c1590622c9e74fb29d49611c1a9005f/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php#L215

breaks the PPC code because there is a syntax error where a  `var` declaration is being attempted to be used as an expression of an assignment statement for window.BoltModal

https://github.com/GuaranteedNetwork/bolt-magento1/blob/6b1d76bd8c1590622c9e74fb29d49611c1a9005f/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php#L239

Fixes: https://boltpay.atlassian.net/browse/M1P-36

#changelog [M1P-36] PPC javascript error in Bolt configure call

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Jira task link and provided a changelog message if applicable.
