### PR TITLE
[WIP] Discount API minimum order amount validation

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Coupon.php
+++ b/app/code/community/Bolt/Boltpay/Model/Coupon.php
@@ -421,6 +421,19 @@ class Bolt_Boltpay_Model_Coupon extends Bolt_Boltpay_Model_Abstract
                 422
             );
         }
+
+        if (!$immutableQuote->validateMinimumAmount()) {
+            $this->applyCouponToQuote($immutableQuote, '');
+            $this->applyCouponToQuote($this->getParentQuote(), '');
+            $this->setErrorResponseAndThrowException(
+                self::ERR_MINIMUM_CART_AMOUNT_REQUIRED,
+                $this->boltHelper()->__(
+                    "The minimum order amount of %s has not been met",
+                    $this->boltHelper()->getMinOrderAmountInStoreCurrency($immutableQuote->getStoreId())
+                ),
+                422
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
# Description
Error is returned if discount applied via the Bolt modal drops price below minimum order amount but is not displayed in an elegant way in the front-end.  The discount API provides a means to handle this

Resolution:
![image](https://user-images.githubusercontent.com/973856/78582271-51407500-7835-11ea-98e0-afe42566100f.png)

Fixes: 
https://app.asana.com/0/544708310157130/1169776517444409
https://app.asana.com/0/544708310157130/1169757710813673

#changelog Discount API minimum order amount validation

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
