### PR TITLE
Update Apple Pay sentinels for hints prefill exclusion

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -324,7 +324,7 @@ JS;
         }
 
         // Skip pre-fill for Apple Pay related data.
-        if (!(@$prefill['email'] == 'fake@email.com' || @$prefill['phone'] == '1111111111')) {
+        if (!(@$prefill['email'] == 'na@bolt.com' || @$prefill['phone'] == '8005550111' || @$prefill['addressLine1'] == 'tbd')) {
             $hints['prefill'] = $prefill;
         }
 

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -546,16 +546,18 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
      * that getAddressHints doesn't return pre-fill data when quote address is Apple Pay related
      *
      * @covers ::getAddressHints
-     * @throws ReflectionException if getAddressHints method doesn't exist
+     * @dataProvider getAddressHints_withApplePayRelatedDataProvider
+     *
+     * @param array $shippingAddressData containing Apple Pay data
+     *
      * @throws Mage_Core_Exception from test setup if unable to stub customer session singleton
+     * @throws ReflectionException if getAddressHints method doesn't exist
      */
-    public function getAddressHints_withApplePayRelatedData_returnsArrayWithoutPrefill()
+    public function getAddressHints_withApplePayRelatedData_returnsArrayWithoutPreFill($shippingAddressData)
     {
         $checkoutType = BoltpayCheckoutBlock::CHECKOUT_TYPE_MULTI_PAGE;
         $shippingAddress = Mage::getModel('sales/quote_address');
-        $shippingAddress
-            ->setEmail('fake@email.com')
-            ->setTelephone('1111111111');
+        $shippingAddress->setData($shippingAddressData);
         $quote = $this->getAddressHintsSetUp(null, $shippingAddress);
 
         $result = TestHelper::callNonPublicFunction(
@@ -565,6 +567,20 @@ class Bolt_Boltpay_Block_Checkout_BoltpayTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertArrayNotHasKey('prefill', $result);
+    }
+
+    /**
+     * Data provider for {@see getAddressHints_withApplePayRelatedData_returnsArrayWithoutPreFill}
+     *
+     * @return string[][][] containing shipping address data related to Apple Pay
+     */
+    public function getAddressHints_withApplePayRelatedDataProvider()
+    {
+        return array(
+            array('shippingAddressData' => array('email' => 'na@bolt.com')),
+            array('shippingAddressData' => array('telephone' => '8005550111')),
+            array('shippingAddressData' => array('street' => 'tbd')),
+        );
     }
 
     /**


### PR DESCRIPTION
# Description
Bolt core code has changed the address values for Apple Pay which requires us to change our Apple Pay address detection logic to exclude in prefills.

old sentinels:

email - fake@email.com
phone - 1111111111

new sentinels

email - na@bolt.com
phone - 8005550111
addressLine1 - tbd

Fixes: https://boltpay.atlassian.net/browse/M1P-43

#changelog Update Apple Pay sentinels for hints prefill exclusion

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
