### PR TITLE
Update shipping and tax request ApplePay detection

### DIFF
--- a/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
+++ b/app/code/community/Bolt/Boltpay/controllers/ShippingController.php
@@ -379,21 +379,17 @@ class Bolt_Boltpay_ShippingController
     }
 
     /**
-     * Checks whether this is an Apple Pay request.  Currently, Apple Pay request are populated with
-     * "n/a" in several required address fields, particularly the "name" field, which is Bolt defined,
-     *  not customer defined.  Additionally, the "phone" field will be null.
+     * Checks whether this is an Apple Pay request.  Currently, Apple Pay requests have "request_source"
+     * field set to "applePay". Shipping address data is populated with "tbd" in several required address
+     * fields, particularly the "name" field, which is Bolt defined, not customer defined.
+     * Additionally, the "phone" field will be "8005550111" and "email" will be "na@bolt.com".
      *
      * Standard Bolt request leave the "name" field as null while forcing the user to populate
      * the phone field, and therefore is never null.
      *
-     * We do anticipate Bolt server-side refinement for indicating Apple Pay request, likely via User-Agent
-     * or a custom HTTP request header.  For now, we'll rely on sentinel value detection.
+     * @return bool true if the request was made in the ApplePay context, otherwise false
      */
     private function isApplePayRequest() {
-        $requestData = $this->getRequestData();
-        $shippingAddress = $requestData->shipping_address;
-
-        // For a more strict check, we would enable verifying the phone number is null
-        return ($shippingAddress->name === 'n/a') /* && is_null($shippingAddress->phone) */;
+        return $this->getRequestData()->request_source === 'applePay';
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/controllers/ShippingControllerTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/controllers/ShippingControllerTest.php
@@ -878,7 +878,7 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
     public function isApplePayRequest_withAppleRedactedAddressName_returnsTrue()
     {
         $requestData = new stdClass();
-        $requestData->shipping_address->name = 'n/a';
+        $requestData->request_source = 'applePay';
         $this->currentMock->expects($this->once())->method('getRequestData')->willReturn($requestData);
         $this->assertTrue(TestHelper::callNonPublicFunction($this->currentMock, 'isApplePayRequest'));
     }
@@ -935,7 +935,9 @@ class Bolt_Boltpay_ShippingControllerTest extends PHPUnit_Framework_TestCase
                 'expectedResult' => true
             ),
             'Apple pay request - should not validate' => array(
-                'requestData'    => (object)array('shipping_address' => (object)array('name' => 'n/a')),
+                'requestData'    => (object)array(
+                    'request_source'   => 'applePay'
+                ),
                 'expectedResult' => false
             ),
         );


### PR DESCRIPTION
# Description
Bolt core code has changed the address values in the Apple Pay request for the shipping and tax call which requires us to change our Apple Pay pseudo-address detection logic.

Old detection code: 
https://github.com/BoltApp/bolt-magento1/blob/master/app/code/community/Bolt/Boltpay/controllers/ShippingController.php#L381-L398

New format of JSON:
{
  "reference": "5470883",
  ...
  "shipping_address": {
    "street_address1": "tbd",
    "street_address2": null,
    "street_address3": null,
    "street_address4": null,
    "locality": "Goodyear",
    "region": "Arizona",
    "postal_code": "85338",
    "country_code": "US",
    "country": "United States",
    **"name": "tbd",   //value has been changed from “n/a” which we used**
    "first_name": "tbd",
    "last_name": "tbd",
    "company": null,
    "phone": "8005550111",
    "email": "na@bolt.com"
  },
  ...
  **"request_source": "applePay", // value has been added since initial implementation, which we should now rely on**
...
}

Fixes: (link Asana Task)

#changelog Update shipping and tax request ApplePay detection

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
