### PR TITLE
Remove Inventory handling from merchant dashboard refunds

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -573,6 +573,17 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
         }
     }
 
+    /**
+     * Handles refund transaction initiated from Bolt Merchant Dashboard
+     *
+     * @param Mage_Payment_Model_Info $payment
+     * @param string                  $newTransactionStatus
+     * @param string                  $prevTransactionStatus
+     * @param float                   $transactionAmount
+     * @param object                  $transaction
+     *
+     * @throws Exception if unexpected error occurs
+     */
     public function handleRefundTransactionUpdate(
         Mage_Payment_Model_Info $payment,
         $newTransactionStatus,
@@ -581,6 +592,15 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
         $transaction
     ) {
         try {
+
+            if (Bolt_Boltpay_Helper_Data::$fromHooks) {
+                //disable observer responsible for returning products to stock
+                Mage::app()->getConfig()->setNode(
+                    'global/events/sales_order_creditmemo_save_after/observers/inventory/type',
+                    'disabled'
+                );
+            }
+
             /** @var Mage_Sales_Model_Order $order */
             $order             = $payment->getOrder();
             $transactionAmount = Mage::app()->getStore()->roundPrice($transactionAmount);


### PR DESCRIPTION
# Description
When applying refunds from the Bolt merchant dashboard, it is currently impossible to tell if and which inventory items should be returned. Magento provides a directive for this in the native admin as shown below.

![image](https://user-images.githubusercontent.com/973856/79835302-c459f780-83ae-11ea-9650-b8267d7e25d3.png)

Because of this, we should not attempt to handle inventory if the refund is issued from the Bolt merchant dashboard.

Fixes: https://boltpay.atlassian.net/browse/M1P-44

#changelog Remove Inventory handling from merchant dashboard refunds

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
