### PR TITLE
Add missing event parameter for controller_front_send_response_after

### DIFF
--- a/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
+++ b/app/code/community/Bolt/Boltpay/Controller/Traits/WebHookTrait.php
@@ -130,7 +130,10 @@ trait Bolt_Boltpay_Controller_Traits_WebHookTrait {
 
         if ($exitImmediately) {
             $this->getResponse()->sendResponse();
-            Mage::dispatchEvent('controller_front_send_response_after');
+            Mage::dispatchEvent(
+                'controller_front_send_response_after',
+                array('front' => Mage::app()->getFrontController())
+            );
             $this->setFlag('', Mage_Core_Controller_Varien_Action::FLAG_NO_POST_DISPATCH, 1);
             $this->getResponse()->sendHeadersAndExit(); # workaround to early exit.
         }


### PR DESCRIPTION
# Description
`controller_front_send_response_after` event is usually dispatched with front parameter pointing to a `Mage_Core_Controller_Varien_Front`.  Missing this can cause observers to fail, like `Mage_Persistent_Model_Observer_Session::synchronizePersistentInfo`

Fixes: https://boltpay.atlassian.net/browse/M1P-45

#changelog Add missing event parameter for controller_front_send_response_after

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [x] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
