### PR TITLE
Replaces forEach method to be compatible with IE11

### DIFF
--- a/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
+++ b/app/design/frontend/base/default/template/boltpay/catalog/product/configure_checkout.phtml
@@ -116,9 +116,12 @@ var boltConfigPDP = {
                 throw '<?php echo $this->__("The requested quantity is not available."); ?>';
             }
             this.validateMinOrderAmount();
+
             //TODO: support file type custom options
             //currently not supported because it would require custom upload and expiration logic
-            document.querySelectorAll("#product_addtocart_form input[type='file']").forEach(function(fileInput) {
+            var fileInputs = document.querySelectorAll("#product_addtocart_form input[type='file']");
+            for ( var i = 0; i < fileInputs.length; i++ ) {
+                var fileInput = fileInputs[i];
                 if (fileInput.value) {
                     var name = 'file-upload-not-supported-bolt';
                     var advice = Validation.getAdvice(name, fileInput);
@@ -129,11 +132,14 @@ var boltConfigPDP = {
                     fileInput.focus();
                     throw '<?php echo $this->__('Files not supported with Product Page BoltCheckout. Please add product to cart and then use Bolt from the cart page to checkout.'); ?>';
                 }
-            });
+            }
+
         } catch (e) {
             if (typeof BoltPopup !== 'undefined' && typeof e === 'string') {
                 BoltPopup.setMessage(e);
                 BoltPopup.show();
+            } else {
+                alert(e);
             }
             return false;
         }
@@ -226,9 +232,11 @@ document.addEventListener("DOMContentLoaded", function() {
         }, 50
     );
 
-    document.querySelectorAll(('input[name=qty], input[name*=super_group], input[name*=qty]')).forEach(function (input) {
-        input.addEventListener('input', boltConfigPDP.init.bind(boltConfigPDP));
-    });
+    var quantityInputs = document.querySelectorAll(('input[name=qty], input[name*=super_group], input[name*=qty]'));
+    for ( var i = 0; i < quantityInputs.length; i++ ) {
+        quantityInputs[i].addEventListener('input', boltConfigPDP.init.bind(boltConfigPDP));
+    }
+
     if (typeof spConfig !== 'undefined') {
         spConfig.configureSubscribe(boltConfigPDP.init.bind(boltConfigPDP));
     }


### PR DESCRIPTION
# Description
Unable to open PPC checkout in IE 11 due to the use of the method `forEach` which is not supported in this browser.

Fixes: https://boltpay.atlassian.net/browse/M1P-49

#changelog Replaces forEach method to be compatible with IE11

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my task link and provided a changelog message if applicable.
