### PR TITLE
Add support for preventing not logged in users from using Bolt

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
+++ b/app/code/community/Bolt/Boltpay/Block/Checkout/Boltpay.php
@@ -486,13 +486,8 @@ JS;
      */
     private function isCustomerGroupDisabled($customerGroupId)
     {
-        $disabledCustomerGroups = Mage::getStoreConfig('payment/boltpay/bolt_disabled_customer_groups');
-        // Case of empty groups
-        if (empty($disabledCustomerGroups)) {
-            return false;
-        }
-        $disabledCustomerGroups = explode(',', $disabledCustomerGroups);
-        return in_array($customerGroupId, $disabledCustomerGroups);
+        $disabledCustomerGroups = explode(',', Mage::getStoreConfig('payment/boltpay/bolt_disabled_customer_groups'));
+        return in_array((string)$customerGroupId, $disabledCustomerGroups, true);
     }
 
     /**

--- a/app/code/community/Bolt/Boltpay/etc/system.xml
+++ b/app/code/community/Bolt/Boltpay/etc/system.xml
@@ -302,7 +302,7 @@
                   <config_path>payment/boltpay/bolt_disabled_customer_groups</config_path>
                   <frontend_type>multiselect</frontend_type>
                   <can_be_empty>1</can_be_empty>
-                  <source_model>adminhtml/system_config_source_customer_group_multiselect</source_model>
+                  <source_model>customer/resource_group_collection</source_model>
                   <sort_order>55</sort_order>
                   <show_in_default>1</show_in_default>
                   <show_in_website>1</show_in_website>

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -2015,15 +2015,25 @@ SCSS;
     public function isCustomerGroupDisabled_withVariousConfigsProvider()
     {
         return array(
+            'False disabled customer group ids config - should return false'                       => array(
+                'customerGroupId'          => 0,
+                'disabledCustomerGroupIds' => false,
+                'expectedResult'           => false,
+            ),
+            'Null disabled customer group ids config - should return false'                        => array(
+                'customerGroupId'          => 0,
+                'disabledCustomerGroupIds' => null,
+                'expectedResult'           => false,
+            ),
             'Empty disabled customer group ids config - should return false'                       => array(
                 'customerGroupId'          => 0,
                 'disabledCustomerGroupIds' => '',
                 'expectedResult'           => false,
             ),
-            'Zero for disabled customer group ids - should return false'                           => array(
+            'Guest customer group and disabled - should return true'                               => array(
                 'customerGroupId'          => 0,
                 'disabledCustomerGroupIds' => '0',
-                'expectedResult'           => false,
+                'expectedResult'           => true,
             ),
             'General customer group with empty disabled customer groups - should return false'     => array(
                 'customerGroupId'          => 1,
@@ -2039,6 +2049,11 @@ SCSS;
                 'customerGroupId'          => 0,
                 'disabledCustomerGroupIds' => '1,2',
                 'expectedResult'           => false,
+            ),
+            'Not logged in customer group with group id in disabled ids - should return true'      => array(
+                'customerGroupId'          => 0,
+                'disabledCustomerGroupIds' => '1,2,0,4,6',
+                'expectedResult'           => true,
             ),
         );
     }


### PR DESCRIPTION
# Description
Bolt configuration currently doesn't provide an option to prevent NOT LOGGED IN users from using Bolt Checkout. This PR extends existing Disabled Customer Groups configuration to include NOT LOGGED IN as option, updates detection logic to properly handle new group id (beause it is 0).

Fixes: https://boltpay.atlassian.net/browse/M1P-52

#changelog Add support for preventing not logged in users from using Bolt

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
