### PR TITLE
Adds character limit to user note to match Bolt restriction

### DIFF
--- a/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
+++ b/app/code/community/Bolt/Boltpay/Model/BoltOrder.php
@@ -769,6 +769,10 @@ class Bolt_Boltpay_Model_BoltOrder extends Bolt_Boltpay_Model_Abstract
         // Generates order data for sending to Bolt create order API.
         $orderRequest = $this->buildOrder($quote, $isMultiPage);
 
+        if (isset($orderRequest['user_note']) && strlen($orderRequest['user_note']) > 1024) {
+            $orderRequest['user_note'] = substr($orderRequest['user_note'], 0, 1024);
+        }
+
         // Calls Bolt create order API
         return $this->boltHelper()->transmit('orders', $orderRequest);
     }


### PR DESCRIPTION
# Description
There are errors with the user note being too long, exceeding the Bolt defined 1024 character limit.  This will truncate the note if it exceeds that limit 

Fixes: https://boltpay.atlassian.net/browse/M1P-31

#changelog Adds character limit to user note to match Bolt restriction

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
