### PR TITLE
Unit Test: Implement uncovered methods and Remove False Positives

### DIFF
--- a/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/Checkout/BoltpayTest.php
@@ -1909,6 +1909,8 @@ SCSS;
      * @test
      * that getConfigSelectors returns config value for selectors in JSON format
      *
+     * @covers ::getConfigSelectors
+     *
      * @dataProvider getConfigSelectors_withVariousConfigsProvider
      *
      * @param string $selectors configuration value for selectors
@@ -2139,7 +2141,7 @@ SCSS;
      * @test
      * that getQuote returns quote from checkout/session singleton
      *
-     * @coves ::getQuote
+     * @covers ::getQuote
      */
     public function getQuote_always_returnsQuoteFromCheckoutSession()
     {

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/ConfigTraitTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/ConfigTraitTest.php
@@ -468,5 +468,18 @@ class Bolt_Boltpay_Helper_ConfigTraitTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @test
+     * that getExtraConfig will return extra config from mage model
+     *
+     * @covers Bolt_Boltpay_Helper_ConfigTrait::getExtraConfig
+     */
+    public function getExtraConfig_always_returns()
+    {
+        $extraConfigModel = Mage::getSingleton('boltpay/admin_extraConfig');
+        $result = $extraConfigModel->getExtraConfig('cloneOnClick');
 
+        $actual = $this->currentMock->getExtraConfig('cloneOnClick');
+        $this->assertEquals($result, $actual);
+    }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/DataDogTraitTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/DataDogTraitTest.php
@@ -26,6 +26,8 @@ class Bolt_Boltpay_Helper_DataDogTraitTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * logInfo succeeds
+     *
+     * @covers Bolt_Boltpay_Helper_DataDogTrait::logInfo
      */
     public function logInfo_succeedsAndSetsLastResponseStatusToTrue()
     {
@@ -36,6 +38,8 @@ class Bolt_Boltpay_Helper_DataDogTraitTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * logWarning succeeds
+     *
+     * @covers Bolt_Boltpay_Helper_DataDogTrait::logWarning
      */
     public function logWarning_succeedsAndSetsLastResponseStatusToTrue()
     {
@@ -45,9 +49,11 @@ class Bolt_Boltpay_Helper_DataDogTraitTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * logError succeeds
+     * logException succeeds
+     *
+     * @covers Bolt_Boltpay_Helper_DataDogTrait::logException
      */
-    public function logError_succeedsAndSetsLastResponseStatusToTrue()
+    public function logException_always_succeedsAndSetsLastResponseStatusToTrue()
     {
         $exception = new Exception(self::ERROR_MESSAGE);
         $errorLog = $this->datadogHelper->logException($exception);
@@ -57,6 +63,8 @@ class Bolt_Boltpay_Helper_DataDogTraitTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * init sets env to test if PHPUNIT_ENVIRONMENT is set
+     *
+     * @covers Bolt_Boltpay_Helper_DataDogTrait::init
      *
      * @throws ReflectionException
      */
@@ -73,6 +81,8 @@ class Bolt_Boltpay_Helper_DataDogTraitTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * init sets env to development if PHPUNIT_ENVIRONMENT is not set and payment/boltpay/test is true
+     *
+     * @covers Bolt_Boltpay_Helper_DataDogTrait::init
      *
      * @throws Mage_Core_Exception
      * @throws Mage_Core_Model_Store_Exception
@@ -92,6 +102,8 @@ class Bolt_Boltpay_Helper_DataDogTraitTest extends PHPUnit_Framework_TestCase
      * @test
      * init sets env to production if PHPUNIT_ENVIRONMENT is not set and payment/boltpay/test is not true
      *
+     * @covers Bolt_Boltpay_Helper_DataDogTrait::init
+     *
      * @throws Mage_Core_Exception
      * @throws Mage_Core_Model_Store_Exception
      * @throws ReflectionException
@@ -104,5 +116,40 @@ class Bolt_Boltpay_Helper_DataDogTraitTest extends PHPUnit_Framework_TestCase
         $actualEnv = TestHelper::getNonPublicProperty($this->datadogHelper, '_data')['env'];
         $this->assertEquals($expectedEnv, $actualEnv);
         TestHelper::restoreOriginals();
+    }
+
+    /**
+     * @test
+     * that getDataDog should return the {@see Bolt_Boltpay_Helper_DataDogTrait::_datadog}
+     *
+     * @covers Bolt_Boltpay_Helper_DataDogTrait::getDataDog
+     */
+    public function getDataDog_whenDataDogIsSet_returnsDataDog()
+    {
+        $dataDogMock = $this->getMockBuilder('Boltpay_DataDog_Client')->disableOriginalConstructor()->getMock();
+        TestHelper::setNonPublicProperty($this->datadogHelper, '_datadog', $dataDogMock);
+        $actualDataDog = TestHelper::callNonPublicFunction($this->datadogHelper, 'getDataDog');
+        $this->assertEquals($dataDogMock, $actualDataDog);
+    }
+
+    /**
+     * @test
+     * that getDataDog should call init method and set the {@see Bolt_Boltpay_Helper_DataDogTrait::_datadog}
+     * 
+     * @covers Bolt_Boltpay_Helper_DataDogTrait::getDataDog
+     */
+    public function getDataDog_whenDataDogIsNotSet_callsInitAndSetsDataDog()
+    {
+        $apiKey = '3dadasdasdas';
+        $this->datadogHelper = $this->getMockBuilder('Bolt_Boltpay_Helper_DataDogTrait')
+            ->setMethods(array('getApiKeyConfig', 'getSeverityConfig'))
+            ->getMockForTrait();
+        $this->datadogHelper->expects($this->once())->method('getApiKeyConfig')->willReturn($apiKey);
+        $this->datadogHelper->expects($this->once())->method('getSeverityConfig')->willReturn(array());
+        TestHelper::setNonPublicProperty($this->datadogHelper, '_datadog', null);
+        $actualDataDog = TestHelper::callNonPublicFunction($this->datadogHelper, 'getDataDog');
+
+        $this->assertEquals($apiKey, TestHelper::getNonPublicProperty($this->datadogHelper, '_apiKey'));
+        $this->assertAttributeEquals($actualDataDog, '_datadog', $this->datadogHelper);
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Helper/DataTest.php
@@ -154,6 +154,23 @@ JS
 
     /**
      * @test
+     * that buildOnCheckCallback returns default empty string when checkout type is one page
+     *
+     * @covers ::buildOnCheckCallback
+     */
+    public function buildOnCheckCallback_whenCheckoutTypeIsOnePage_returnsDefaultString()
+    {
+        $expected = '';
+        $trueResult = $this->currentMock->buildOnCheckCallback(
+            Bolt_Boltpay_Block_Checkout_Boltpay::CHECKOUT_TYPE_ONE_PAGE,
+            true
+        );
+
+        $this->assertEquals($expected, $trueResult);
+    }
+
+    /**
+     * @test
      *
      * @covers ::buildOnSuccessCallback
      */

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/Admin/ExtraConfigTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/Admin/ExtraConfigTest.php
@@ -473,6 +473,8 @@ class Bolt_Boltpay_Model_Admin_ExtraConfigTest extends PHPUnit_Framework_TestCas
      * @test
      * that save method will save previous value if current is not valid JSON
      *
+     * @covers ::save
+     *
      * @throws Exception when there is an error saving the extra config to the database
      */
     public function save_withInvalidJSONAsValue_savesOldValue()

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/FeatureSwitchTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/FeatureSwitchTest.php
@@ -422,6 +422,8 @@ class Bolt_Boltpay_Model_FeatureSwitchTest extends PHPUnit_Framework_TestCase
      * - make 10 attempt, 5000 calls in one attempt
      * - calculate tolerance for each attempt
      * - compare the smallest and the biggest tolerance with expected values
+     *
+     * @covers ::isMarkedForRollout
      */
     public function isMarkedForRollout_whenCalledManyTimes_shouldReturnExpectedDistribution()
     {

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/ObserverTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/ObserverTest.php
@@ -111,7 +111,7 @@ class Bolt_Boltpay_Model_ObserverTest extends PHPUnit_Framework_TestCase
      * @test
      * that Mage::getModel('boltpay/observer') returns instance of the observer
      *
-     * @coversNothing
+     * @covers ::__construct
      */
     public function __construct_always_createsInstanceOfTheModel()
     {
@@ -212,6 +212,30 @@ class Bolt_Boltpay_Model_ObserverTest extends PHPUnit_Framework_TestCase
         $this->updateFeatureSwitchesSetUp();
         Bolt_Boltpay_Model_FeatureSwitch::$shouldUpdateFeatureSwitches = false;
         $this->featureSwitchMock->expects($this->never())->method('updateFeatureSwitches');
+        $this->currentMock->updateFeatureSwitches();
+    }
+
+    /**
+     * @test
+     * that updateFeatureSwitches logs exception if thrown from 
+     * {@see Bolt_Boltpay_Model_FeatureSwitch::updateFeatureSwitches}
+     *
+     * @covers ::updateFeatureSwitches
+     *
+     * @throws Mage_Core_Exception if unable to stub or restore feature switch singleton
+     */
+    public function updateFeatureSwitches_whenUpdateFeatureSwitchesThrowException_logsException()
+    {
+        $this->updateFeatureSwitchesSetUp();
+        Bolt_Boltpay_Model_FeatureSwitch::$shouldUpdateFeatureSwitches = true;
+        $exception = new GuzzleHttp\Exception\RequestException('error', null);
+
+        $this->featureSwitchMock->expects($this->once())->method('updateFeatureSwitches')
+            ->willThrowException($exception);
+        
+        $this->boltHelperMock->expects($this->once())->method('notifyException')->with($exception);
+        $this->boltHelperMock->expects($this->once())->method('logException')->with($exception)->willReturnSelf();
+
         $this->currentMock->updateFeatureSwitches();
     }
 

--- a/tests/unit/testsuite/Bolt/Boltpay/OrderCreationExceptionTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/OrderCreationExceptionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Bolt_Boltpay_Controller_Interface as RESPONSE_CODE;
+use Bolt_Boltpay_TestHelper as TestHelper;
 
 /**
  * Class Bolt_Boltpay_OrderCreationExceptionTest
@@ -12,8 +13,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * JSON response for general error with default parameters
+     *
+     * @covers ::__construct
      */
-    public function initialize_withGeneralException_setsCorrectJsonAndHttpCode()
+    public function __construct_withGeneralException_setsCorrectJsonAndHttpCode()
     {
         $reason = 'test error';
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -38,8 +41,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * for correct data for existing order exception
+     *
+     * @covers ::__construct
      */
-    public function initialize_withExistingCartException_setsCorrectJsonAndHttpCode()
+    public function __construct_withExistingCartException_setsCorrectJsonAndHttpCode()
     {
         $dataValues = ['id_123', 'pending'];
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -59,8 +64,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * for correct data for various cart exceptions
+     *
+     * @covers ::__construct
      */
-    public function initialize_withCartException_setsCorrectJsonAndHttpCode()
+    public function __construct_withCartException_setsCorrectJsonAndHttpCode()
     {
         // Empty cart
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -185,8 +192,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * for correct data for item price has been updated exception
+     *
+     * @covers ::__construct
      */
-    public function initialize_withItemPriceException_setsCorrectJsonAndHttpCode()
+    public function __construct_withItemPriceException_setsCorrectJsonAndHttpCode()
     {
         $dataValues = [905, 100, 150];
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -207,8 +216,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * for correct data for out of inventory exception
+     *
+     * @covers ::__construct
      */
-    public function initialize_withCartInventoryException_setsCorrectJsonAndHttpCode()
+    public function __construct_withCartInventoryException_setsCorrectJsonAndHttpCode()
     {
         $dataValues = [905, 100, 150];
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -229,8 +240,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * for correct exception data when discount can not be applied
+     *
+     * @covers ::__construct
      */
-    public function initialize_withDiscountCanNotBeAppliedException_setsCorrectJsonAndHttpCode()
+    public function __construct_withDiscountCanNotBeAppliedException_setsCorrectJsonAndHttpCode()
     {
         // Generic exception
         $dataValues = ['Discount code too cool to be used', 'FREE_BEER_FOR_LIFE'];
@@ -265,8 +278,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * for correct exception data when discount code is invalid
+     *
+     * @covers ::__construct
      */
-    public function initialize_withInvalidDiscountCodeException_setsCorrectJsonAndHttpCode()
+    public function __construct_withInvalidDiscountCodeException_setsCorrectJsonAndHttpCode()
     {
         $dataValues = ['GIVE_ME_FREE'];
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -285,8 +300,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * for correct exception when shipping price or tax are changed
+     *
+     * @covers ::__construct
      */
-    public function initialize_withShippingPriceOrTaxChangedException_setsCorrectJsonAndHttpCode()
+    public function __construct_withShippingPriceOrTaxChangedException_setsCorrectJsonAndHttpCode()
     {
         $dataValues = [100, 150];
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -307,8 +324,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * In case when we pass string data instead of expected numbers, values in the response will be set to zero.
+     *
+     * @covers ::__construct
      */
-    public function initialize_withIncorrectData_setsValuesInResponseToZero()
+    public function __construct_withIncorrectData_setsValuesInResponseToZero()
     {
         $dataValues = ['hundred', 'hundred and fifty'];
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -335,7 +354,7 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
      *
      * @covers ::__construct
      */
-    public function initialize_withMinimumPriceNotMetException_setsCorrectJsonAndHttpCode()
+    public function __construct_withMinimumPriceNotMetException_setsCorrectJsonAndHttpCode()
     {
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
             Bolt_Boltpay_OrderCreationException::E_BOLT_MINIMUM_PRICE_NOT_MET,
@@ -355,8 +374,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * if OrderCreationException is keeping a reference to previous error
+     *
+     * @covers ::__construct
      */
-    public function initialize_withExceptionWithPreviousException_setsPreviousExceptionInResponse()
+    public function __construct_withExceptionWithPreviousException_setsPreviousExceptionInResponse()
     {
         $reason = 'test with previous error';
         $previousException = new Exception('This is previous error');
@@ -385,8 +406,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * if special characters are escaped in JSON response
+     *
+     * @covers ::__construct
      */
-    public function initialize_withEscapedSpecialCharacters_setsCorrectJsonAndHttpCode()
+    public function __construct_withEscapedSpecialCharacters_setsCorrectJsonAndHttpCode()
     {
         $reason = 'test "error" \path\example';
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
@@ -406,8 +429,10 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * If non-registered code is passed to a constructor it should generate generic exception.
+     *
+     * @covers ::__construct
      */
-    public function initialize_withNonRegisteredErrorCode_shouldGenerateGenericException()
+    public function __construct_withNonRegisteredErrorCode_shouldGenerateGenericException()
     {
 
         $errorMessage = 'test non-existing code';
@@ -440,8 +465,11 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * HTTP response code for general exception with default parameters
+     *
+     * @covers ::__construct
+     * @covers ::getHttpCode
      */
-    public function initialize_withDefaultParameters_shouldSetResponseCodeTo422()
+    public function __construct_withDefaultParameters_shouldSetResponseCodeTo422()
     {
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException();
         $this->assertEquals(RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY, $boltOrderCreationException->getHttpCode());
@@ -450,14 +478,151 @@ class Bolt_Boltpay_OrderCreationExceptionTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      * HTTP response code for general exception with invalid HMAC header
+     *
+     * @covers ::__construct
+     * @covers ::getHttpCode
      */
-    public function initialize_withInvalidHMACHeader_shouldSetResponseCodeTo401()
+    public function __construct_withInvalidHMACHeader_shouldSetResponseCodeTo401()
     {
         $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
             Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR,
             Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR_TMPL_HMAC
         );
         $this->assertEquals(RESPONSE_CODE::HTTP_UNAUTHORIZED, $boltOrderCreationException->getHttpCode());
+    }
+
+    /**
+     * @test
+     * that selectHttpCode should return HTTP conflict code when the input parameter code indicates an order already
+     * exists
+     *
+     * @covers ::selectHttpCode
+     */
+    public function selectHttpCode_whenOrderAlreadyExists_returns409()
+    {
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException();
+
+        $this->assertEquals(
+            RESPONSE_CODE::HTTP_CONFLICT,
+            $boltOrderCreationException->selectHttpCode(
+                Bolt_Boltpay_OrderCreationException::E_BOLT_ORDER_ALREADY_EXISTS,
+                ''
+            )
+        );
+    }
+
+    /**
+     * @test
+     * that selectHttpCode should return HTTP not found code when input parameter code indicates an cart has expired
+     * and template not found
+     *
+     * @covers ::selectHttpCode
+     */
+    public function selectHttpCode_whenCartIsNotFound_returns404()
+    {
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException();
+
+        $this->assertEquals(
+            RESPONSE_CODE::HTTP_NOT_FOUND,
+            $boltOrderCreationException->selectHttpCode(
+                Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+                Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_NOT_FOUND
+            )
+        );
+    }
+
+    /**
+     * @test
+     * that selectHttpCode should return HTTP gone code when input parameter code indicates an cart has expired and
+     * and template expired
+     *
+     * @covers ::selectHttpCode
+     */
+    public function selectHttpCode_whenCartHasExpired_returns410()
+    {
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException();
+
+        $this->assertEquals(
+            RESPONSE_CODE::HTTP_GONE,
+            $boltOrderCreationException->selectHttpCode(
+                Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED,
+                Bolt_Boltpay_OrderCreationException::E_BOLT_CART_HAS_EXPIRED_TMPL_EXPIRED
+            )
+        );
+    }
+
+    /**
+     * @test
+     * that selectHttpCode should return HTTP gone code when input parameter code indicates an cart has expired and
+     * template has expired
+     *
+     * @covers ::selectHttpCode
+     */
+    public function selectHttpCode_whenGeneralErrorOccur_returns401()
+    {
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException();
+
+        $this->assertEquals(
+            RESPONSE_CODE::HTTP_UNAUTHORIZED,
+            $boltOrderCreationException->selectHttpCode(
+                Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR,
+                Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR_TMPL_HMAC
+            )
+        );
+    }
+
+    /**
+     * @test
+     * that selectHttpCode should return HTTP unprocessable entity when input parameter code indicates an discount
+     * cannot apply
+     *
+     * @covers ::selectHttpCode
+     */
+    public function selectHttpCode_whenDiscountCannotApply_422()
+    {
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException();
+
+        $this->assertEquals(
+            RESPONSE_CODE::HTTP_UNPROCESSABLE_ENTITY,
+            $boltOrderCreationException->selectHttpCode(
+                Bolt_Boltpay_OrderCreationException::E_BOLT_DISCOUNT_CANNOT_APPLY,
+                ''
+            )
+        );
+    }
+
+    /**
+     * @test
+     * that createJson returns json data response
+     * 
+     * @covers ::createJson
+     */
+    public function createJson_always_returnsJsonString()
+    {
+        $actualResult = TestHelper::callNonPublicFunction(
+            new Bolt_Boltpay_OrderCreationException(),
+            'createJson',
+            [RESPONSE_CODE::HTTP_GONE, Bolt_Boltpay_OrderCreationException::E_BOLT_GENERAL_ERROR_TMPL_GENERIC]
+        );
+
+        $this->assertJson($actualResult);
+    }
+    
+    /**
+     * @test
+     * that getJson returns json response
+     *
+     * @covers ::getJson
+     */
+    public function getJson_always_returnsJsonString()
+    {
+        $dataValues = ['id_123', 'pending'];
+        $boltOrderCreationException = new Bolt_Boltpay_OrderCreationException(
+            Bolt_Boltpay_OrderCreationException::E_BOLT_ORDER_ALREADY_EXISTS,
+            Bolt_Boltpay_OrderCreationException::E_BOLT_ORDER_ALREADY_EXISTS_TMPL,
+            $dataValues);
+        
+        $this->assertJson($boltOrderCreationException->getJson());
     }
 
     /**

--- a/tests/unit/testsuite/Bolt/Boltpay/controllers/ConfigurationControllerTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/controllers/ConfigurationControllerTest.php
@@ -740,6 +740,8 @@ class Bolt_Boltpay_ConfigurationControllerTest extends PHPUnit_Framework_TestCas
      * @test
      * Setting response with error data
      *
+     * @covers ::setErrorResponseData
+     *
      * @dataProvider setErrorResponseData_withSpecificMessage_altersFirstParameterProvider
      *
      * @param string $message to be added to response messages


### PR DESCRIPTION
# Description
Codecov is falsely displaying 100% code coverage. 

This test update takes code coverage to 100% and removes false positives by adding the missing `@covers` annotation in test methods. 

Fixes: https://boltpay.atlassian.net/browse/M1P-55

#changelog Unit Test: Implement uncovered methods and Remove False Positives

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
