### PR TITLE
Address Magento bug with HTTP/2 and Magento Connect request [M1P-63]

### DIFF
--- a/tests/unit/autoload.php
+++ b/tests/unit/autoload.php
@@ -27,7 +27,7 @@ spl_autoload_register(
         $classPathParts = preg_split("/[_\\\\]/", $name);
         $classFile = implode(DS, $classPathParts) . '.php';
 
-        $testClassPath = implode(DS, array(BP, 'tests', 'unit', 'testsuite')). DS . $classFile;
+        $testClassPath = implode(DS, array(BP, 'tests', 'unit', 'testsuite', $classFile));
         if (file_exists($testClassPath)) {
             require $testClassPath;
             return;


### PR DESCRIPTION
# Description
There is a known Magento 1 and 2 bug involving HTTP/2 and Magento Connect/Magento Marketplace where the header error detection is not correctly implemented. This pull request allows for graceful fallback to custom code if the Magento libraries fail.

see:
https://magento.stackexchange.com/questions/249737/magento-2-invalid-response-line-returned-from-server-http-2-200
https://community.magento.com/t5/Magento-2-x-Version-Upgrades/Sign-in-to-Magento-Marketplace-gt-quot-Invalid-response-line/td-p/111720

Fixes: https://boltpay.atlassian.net/browse/M1P-63

#changelog Address Magento bug with HTTP/2 and Magento Connect request

# Type of change

- [x] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
