### PR TITLE
Gate admin notifications when Bolt is updated behind a feature switch

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Adminhtml/Notification.php
+++ b/app/code/community/Bolt/Boltpay/Block/Adminhtml/Notification.php
@@ -53,10 +53,14 @@ class Bolt_Boltpay_Block_Adminhtml_Notification extends Mage_Adminhtml_Block_Tem
      * 5. Notifications are not disabled for non critical updates (only for minor updates)
      *
      * @return bool true if all conditions are met, otherwise false
+     *
+     * @throws Exception if M1_BOLT_NEW_RELEASE_NOTIFICATIONS feature switch default value is not defined
      */
     protected function shouldDisplay()
     {
-        return $this->boltHelper()->isModuleEnabled('Mage_AdminNotification')
+        return Mage::getSingleton("boltpay/featureSwitch")
+                ->isSwitchEnabled(Bolt_Boltpay_Model_FeatureSwitch::BOLT_NEW_RELEASE_NOTIFICATIONS_SWITCH_NAME)
+            && $this->boltHelper()->isModuleEnabled('Mage_AdminNotification')
             && $this->isOutputEnabled('Mage_AdminNotification')
             && $this->_getSession()->isAllowed('admin/system/adminnotification/show_toolbar')
             && $this->getUpdater()->isUpdateAvailable()

--- a/app/code/community/Bolt/Boltpay/Model/FeatureSwitch.php
+++ b/app/code/community/Bolt/Boltpay/Model/FeatureSwitch.php
@@ -35,6 +35,11 @@ class Bolt_Boltpay_Model_FeatureSwitch extends Bolt_Boltpay_Model_Abstract
     const ROLLOUT_KEY = 'rolloutPercentage';
 
     /**
+     * @var string Feature switch that determines whether notifications should be displayed for available updates
+     */
+    const BOLT_NEW_RELEASE_NOTIFICATIONS_SWITCH_NAME = 'M1_BOLT_NEW_RELEASE_NOTIFICATIONS';
+
+    /**
      * @var string Feature switch that determines whether Git should be used as source for updates instead of Magento Connect
      */
     const BOLT_UPDATE_USE_GIT_SWITCH_NAME = 'M1_BOLT_UPDATE_USE_GIT';
@@ -73,6 +78,11 @@ class Bolt_Boltpay_Model_FeatureSwitch extends Bolt_Boltpay_Model_Abstract
                 self::VAL_KEY => true,
                 self::DEFAULT_VAL_KEY => false,
                 self::ROLLOUT_KEY => 0
+            ),
+            self::BOLT_NEW_RELEASE_NOTIFICATIONS_SWITCH_NAME => array(
+                self::VAL_KEY => true,
+                self::DEFAULT_VAL_KEY => false,
+                self::ROLLOUT_KEY => 100
             ),
         );
     }

--- a/app/code/community/Bolt/Boltpay/Model/Observer.php
+++ b/app/code/community/Bolt/Boltpay/Model/Observer.php
@@ -437,9 +437,15 @@ class Bolt_Boltpay_Model_Observer
      * Adds admin notification if an update is available
      *
      * event: admin_session_user_login_success
+     *
+     * @throws Exception if M1_BOLT_NEW_RELEASE_NOTIFICATIONS feature switch default value is not defined
      */
     public function addAdminUpdateNotification()
     {
+        if (!Mage::getSingleton("boltpay/featureSwitch")
+            ->isSwitchEnabled(Bolt_Boltpay_Model_FeatureSwitch::BOLT_NEW_RELEASE_NOTIFICATIONS_SWITCH_NAME)) {
+            return;
+        }
         /** @var Bolt_Boltpay_Model_Updater $updater */
         $updater = Mage::getSingleton('boltpay/updater');
         if ($updater->isUpdateAvailable()) {

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/FeatureSwitchTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/FeatureSwitchTest.php
@@ -96,6 +96,11 @@ class Bolt_Boltpay_Model_FeatureSwitchTest extends PHPUnit_Framework_TestCase
                 'defaultValue' => false,
                 'rolloutPercentage' => 0
             ),
+            'M1_BOLT_NEW_RELEASE_NOTIFICATIONS' => array(
+                'value' => true,
+                'defaultValue' => false,
+                'rolloutPercentage' => 100
+            ),
         );
     }
 


### PR DESCRIPTION
# Description
Like all new massive features, we gate admin notifications behind a feature switch

Fixes: https://boltpay.atlassian.net/browse/M1P-66

#changelog Gate admin notifications when Bolt is updated behind a feature switch

# Type of change

- [ ] Bug fix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have created or modified unit tests to sufficiently cover my changes.
- [x] I have added my Asana task link and provided a changelog message if applicable.
