### PR TITLE
M1P-67 Fix display of APM/PayPal Transactions within Magento 1 Dashboard

### DIFF
--- a/app/code/community/Bolt/Boltpay/Block/Info.php
+++ b/app/code/community/Bolt/Boltpay/Block/Info.php
@@ -16,14 +16,17 @@
  */
 
 /**
- * This generated Bolt Payment information
+ * This generates the Bolt Payment information
  * Its primarily used in sending out order confirmation
- * emails from the merchant
+ * emails from the merchant and what is used on invoices
  */
 class Bolt_Boltpay_Block_Info extends Mage_Payment_Block_Info
 {
     use Bolt_Boltpay_BoltGlobalTrait;
-    
+
+    /**
+     * Assigns a default template to be used
+     */
     protected function _construct()
     {
         parent::_construct();
@@ -31,7 +34,9 @@ class Bolt_Boltpay_Block_Info extends Mage_Payment_Block_Info
     }
 
     /**
-     * @param null $transport
+     * Gets the credit card data and adds it to what will be displayed for Bolt payments
+     *
+     * @param Varien_Object|array|null $transport
      * @return Varien_Object|null
      */
     protected function _prepareSpecificInformation($transport = null)
@@ -39,9 +44,9 @@ class Bolt_Boltpay_Block_Info extends Mage_Payment_Block_Info
         $transport = parent::_prepareSpecificInformation($transport);
         $info = $this->getInfo();
         $data = [];
-        $boltProcessor = $info->getAdditionalInformation('bolt_processor');
+        $paymentProcessor = $info->getAdditionalInformation('bolt_payment_processor');
         
-        if ( empty($boltProcessor) || $boltProcessor == Bolt_Boltpay_Model_Payment::TP_VANTIV ) {
+        if ( empty($paymentProcessor) || $paymentProcessor == Bolt_Boltpay_Model_Payment::PROCESSOR_VANTIV ) {
             if ($ccType = $info->getCcType()){
                 $data['Credit Card Type'] = strtoupper($ccType);
             }
@@ -57,18 +62,27 @@ class Bolt_Boltpay_Block_Info extends Mage_Payment_Block_Info
 
         return $transport;
     }
-    
+
+    /**
+     * Displays Bolt and any auxiliary payment services in the title used for emails and invoices.
+     * This also applies to store-front (frontend) customer checkouts, particularly one-page-checkout.
+     * In this frontend, since the payment processor has not yet been added to additional information,
+     *
+     *
+     * @return string  A string indicating Bolt was used as a payment.  If an auxiliary method was
+     *                 used, it is appended as a hyphenated string
+     */
     public function displayPaymentMethodTitle()
     {
         $info = $this->getInfo();
-        $boltProcessor = $info->getAdditionalInformation('bolt_processor');
+        $paymentProcessor = $info->getAdditionalInformation('bolt_payment_processor');
         
-        if ( empty($boltProcessor) || $boltProcessor == Bolt_Boltpay_Model_Payment::TP_VANTIV ) {
+        if ( empty($paymentProcessor) || $paymentProcessor == Bolt_Boltpay_Model_Payment::PROCESSOR_VANTIV ) {
             $paymentTitle = $this->getMethod()->getTitle();
         } else {
-            $paymentTitle = array_key_exists( $boltProcessor, Bolt_Boltpay_Model_Payment::$_tpMethodDisplay )
-                ? 'Bolt-' . Bolt_Boltpay_Model_Payment::$_tpMethodDisplay[ $boltProcessor ]
-                : 'Bolt-' . strtoupper( $boltProcessor );
+            $paymentTitle = array_key_exists( $paymentProcessor, Bolt_Boltpay_Model_Payment::$_processorDisplayNames )
+                ? 'Bolt-' . Bolt_Boltpay_Model_Payment::$_processorDisplayNames[ $paymentProcessor ]
+                : 'Bolt-' . strtoupper( $paymentProcessor );
         }
         
         return $paymentTitle;

--- a/app/code/community/Bolt/Boltpay/Model/Payment.php
+++ b/app/code/community/Bolt/Boltpay/Model/Payment.php
@@ -58,9 +58,9 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
 
     const CAPTURE_TYPE = 'online';
     
-    const TP_VANTIV = 'vantiv';
-    const TP_PAYPAL = 'paypal';
-    const TP_AFTERPAY = 'afterpay';
+    const PROCESSOR_VANTIV = 'vantiv';
+    const PROCESSOR_PAYPAL = 'paypal';
+    const PROCESSOR_AFTERPAY = 'afterpay';
 
     protected $_code               = self::METHOD_CODE;
     protected $_formBlockType      = 'boltpay/form';
@@ -107,7 +107,7 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
         self::HOOK_TYPE_REFUND => self::TRANSACTION_REFUND
     );
     
-    public static $_tpMethodDisplay = array(
+    public static $_processorDisplayNames = array(
         'paypal' => 'PayPal',
         'afterpay' => 'Afterpay',
     );
@@ -168,8 +168,6 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
         if ($field == 'title') {
             if ($this->isAdminArea()) {
                 return self::TITLE_ADMIN;
-            } else {
-                return self::TITLE;
             }
         }
 
@@ -597,7 +595,7 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
             if (empty($transaction)) {
                 $transaction = $this->boltHelper()->fetchTransaction($reference);
             }
-            if (empty($transaction->processor) || $transaction->processor == self::TP_VANTIV) {
+            if (empty($transaction->processor) || $transaction->processor == self::PROCESSOR_VANTIV) {
                 if (empty($payment->getCcLast4()) && ! empty($transaction->from_credit_card->last4)) {
                     $payment->setCcLast4($transaction->from_credit_card->last4);
                 }
@@ -605,8 +603,8 @@ class Bolt_Boltpay_Model_Payment extends Mage_Payment_Model_Method_Abstract
                     $payment->setCcType($transaction->from_credit_card->network);
                 }    
             }
-            if (empty($payment->getAdditionalInformation('bolt_processor'))) {
-                $payment->setAdditionalInformation('bolt_processor', $transaction->processor);
+            if (empty($payment->getAdditionalInformation('bolt_payment_processor'))) {
+                $payment->setAdditionalInformation('bolt_payment_processor', $transaction->processor);
             }
             
         }catch (\Exception $e){

--- a/app/code/community/Bolt/Boltpay/etc/config.xml
+++ b/app/code/community/Bolt/Boltpay/etc/config.xml
@@ -299,7 +299,7 @@
   min-width: max-content !important;
 }
         </additional_css>
-        <title>Credit card</title>
+        <title>Credit &amp; Debit Card</title>
         <button_classes>with-cards</button_classes>
         <selector_styles>
 .btn-proceed-checkout {

--- a/app/design/adminhtml/default/default/template/boltpay/info/default.phtml
+++ b/app/design/adminhtml/default/default/template/boltpay/info/default.phtml
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    design
+ * @package     default_default
+ * @copyright   Copyright (c) 2006-2018 Magento, Inc. (http://www.magento.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+?>
+<?php
+/**
+ * @see Mage_Payment_Block_Info
+ */
+?>
+<?php echo $this->escapeHtml($this->displayPaymentMethodTitle()) ?>
+
+<?php if ($_specificInfo = $this->getSpecificInformation()):?>
+<table>
+<?php foreach ($_specificInfo as $_label => $_value):?>
+    <tr>
+        <td><?php echo $this->escapeHtml($_label)?>:</td>
+        <td><?php echo nl2br(implode($this->getValueAsArray($_value, true), "\n"))?></td>
+    </tr>
+<?php endforeach; ?>
+</table>
+<?php endif;?>
+
+<?php echo $this->getChildHtml()?>

--- a/app/design/frontend/base/default/template/boltpay/info/default.phtml
+++ b/app/design/frontend/base/default/template/boltpay/info/default.phtml
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magento.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magento.com for more information.
+ *
+ * @category    design
+ * @package     base_default
+ * @copyright   Copyright (c) 2006-2018 Magento, Inc. (http://www.magento.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+?>
+<?php
+/**
+ * @see Mage_Payment_Block_Info
+ */
+?>
+<p><strong><?php echo $this->escapeHtml($this->displayPaymentMethodTitle()) ?></strong></p>
+
+<?php if ($_specificInfo = $this->getSpecificInformation()):?>
+<table>
+    <tbody>
+    <?php foreach ($_specificInfo as $_label => $_value):?>
+        <tr>
+            <th><strong><?php echo $this->escapeHtml($_label)?>:</strong></th>
+        </tr>
+        <tr>
+            <td><?php echo nl2br(implode($this->getValueAsArray($_value, true), "\n"))?></td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+<?php endif;?>
+
+<?php echo $this->getChildHtml()?>

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/InfoTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/InfoTest.php
@@ -76,15 +76,16 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
      * 
      * @covers ::displayPaymentMethodTitle
      */
-    public function displayPaymentMethodTitle_ifOrderPaidWithCreditCard_returnDefaultTitle()
+    public function displayPaymentMethodTitle_ifOrderPaidWithCreditCardFromFrontend_returnConfigTitle()
     {
+        Mage::app()->getStore()->setId(1);
         $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
         $this->currentMock->expects(self::any())->method('getMethod')->willReturn($this->paymentMock);
         $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_payment_processor')
             ->willReturn('vantiv');
-        $this->paymentMock->expects(self::once())->method('getTitle')->willReturn('Credit and Debit Card (Powered by Bolt)');
+        $this->paymentMock->expects(self::once())->method('getTitle')->willReturn(Mage::getStoreConfig('payment/boltpay/title'));
         $this->assertEquals(
-            'Credit and Debit Card (Powered by Bolt)',
+            Mage::getStoreConfig('payment/boltpay/title'),
             $this->currentMock->displayPaymentMethodTitle()
         );
     }
@@ -94,14 +95,55 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
      * 
      * @covers ::displayPaymentMethodTitle
      */
-    public function displayPaymentMethodTitle_ifOrderPaidWithPaypal_returnPaypalTitle()
+    public function displayPaymentMethodTitle_ifOrderPaidWithCreditCardFromAdminArea_returnDefaultTitle()
+    {
+        $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
+        $this->currentMock->expects(self::any())->method('getMethod')->willReturn($this->paymentMock);
+        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_payment_processor')
+            ->willReturn('vantiv');
+        $this->paymentMock->expects(self::once())->method('getTitle')->willReturn(Bolt_Boltpay_Model_Payment::TITLE);
+        $this->assertEquals(
+            Bolt_Boltpay_Model_Payment::TITLE,
+            $this->currentMock->displayPaymentMethodTitle()
+        );
+    }
+    
+    /**
+     * @test
+     * 
+     * @covers ::displayPaymentMethodTitle
+     */
+    public function displayPaymentMethodTitle_ifOrderPaidWithAPM_returnProperTitle($boltPaymentProcessor, $expectedResult)
     {
         $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
         $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_payment_processor')
-            ->willReturn('paypal');
+            ->willReturn($boltPaymentProcessor);
         $this->assertEquals(
-            'Bolt-PayPal',
+            $expectedResult,
             $this->currentMock->displayPaymentMethodTitle()
+        );
+    }
+    
+    /**
+     * Data provider for {@see displayPaymentMethodTitle_ifOrderPaidWithAPM_returnProperTitle}
+     *
+     * @return array containing available payment gateways
+     */
+    public function displayPaymentMethodTitle_ifOrderPaidWithAPM_Provider()
+    {
+        return array(
+            array(
+                'boltPaymentProcessor'  => 'paypal',
+                'expectedResult'        => 'Bolt-PayPal'
+            ),
+            array(
+                'boltPaymentProcessor'  => 'afterpay',
+                'expectedResult'        => 'Bolt-Afterpay'
+            ),
+            array(
+                'newTransactionStatus'  => 'newapm',
+                'expectedResult'        => 'Bolt-NEWAPM'
+            ),
         );
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/InfoTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/InfoTest.php
@@ -17,6 +17,11 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
      * @var PHPUnit_Framework_MockObject_MockObject|Mage_Payment_Block_Info
      */
     private $infoMock;
+    
+    /**
+     * @var MockObject|Mage_Sales_Model_Order_Payment Mocked instance of Magento order payment object
+     */
+    private $paymentMock;
 
     /**
      * Setup test dependencies, called before each test
@@ -25,19 +30,24 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
     {
         Mage::app('default');
         $this->currentMock = $this->getMockBuilder('Bolt_Boltpay_Block_Info')
-            ->setMethods(array('getInfo'))
+            ->setMethods(array('getInfo','getMethod'))
             ->disableOriginalConstructor()
             ->disableOriginalClone()
             ->disableArgumentCloning()
             ->getMock();
 
         $this->infoMock = $this->getMockBuilder('Mage_Payment_Block_Info')
-            ->setMethods(array('getCcType','getCcLast4'))
+            ->setMethods(array('getCcType','getCcLast4','getAdditionalInformation'))
             ->disableOriginalConstructor()
             ->disableOriginalClone()
             ->disableArgumentCloning()
             ->getMock();
-
+        $this->paymentMock = $this->getMockBuilder('Mage_Sales_Model_Order_Payment')
+            ->setMethods(array('getTitle'))
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
     }
 
     /**
@@ -50,12 +60,48 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
         $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
         $this->infoMock->expects(self::once())->method('getCcType')->willReturn('visa');
         $this->infoMock->expects(self::once())->method('getCcLast4')->willReturn('1111');
+        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_processor')
+            ->willReturn('vantiv');
         $data = TestHelper::callNonPublicFunction($this->currentMock, '_prepareSpecificInformation', [null]);
         $this->assertEquals(
             [
                 'Credit Card Type' => 'VISA',
                 'Credit Card Number' => 'xxxx-1111'
             ], $data->getData()
+        );
+    }
+    
+    /**
+     * @test
+     * 
+     * @covers ::displayPaymentMethodTitle
+     */
+    public function displayPaymentMethodTitle_ifOrderPaidWithCreditCard_returnDefaultTitle()
+    {
+        $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
+        $this->currentMock->expects(self::any())->method('getMethod')->willReturn($this->paymentMock);
+        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_processor')
+            ->willReturn('vantiv');
+        $this->paymentMock->expects(self::once())->method('getTitle')->willReturn('Credit and Debit Card (Powered by Bolt)');
+        $this->assertEquals(
+            'Credit and Debit Card (Powered by Bolt)',
+            $this->currentMock->displayPaymentMethodTitle()
+        );
+    }
+    
+    /**
+     * @test
+     * 
+     * @covers ::displayPaymentMethodTitle
+     */
+    public function displayPaymentMethodTitle_ifOrderPaidWithPaypal_returnPaypalTitle()
+    {
+        $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
+        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_processor')
+            ->willReturn('paypal');
+        $this->assertEquals(
+            'Bolt-PayPal',
+            $this->currentMock->displayPaymentMethodTitle()
         );
     }
 }

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/InfoTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/InfoTest.php
@@ -60,7 +60,7 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
         $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
         $this->infoMock->expects(self::once())->method('getCcType')->willReturn('visa');
         $this->infoMock->expects(self::once())->method('getCcLast4')->willReturn('1111');
-        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_processor')
+        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_payment_processor')
             ->willReturn('vantiv');
         $data = TestHelper::callNonPublicFunction($this->currentMock, '_prepareSpecificInformation', [null]);
         $this->assertEquals(
@@ -80,7 +80,7 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
     {
         $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
         $this->currentMock->expects(self::any())->method('getMethod')->willReturn($this->paymentMock);
-        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_processor')
+        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_payment_processor')
             ->willReturn('vantiv');
         $this->paymentMock->expects(self::once())->method('getTitle')->willReturn('Credit and Debit Card (Powered by Bolt)');
         $this->assertEquals(
@@ -97,7 +97,7 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
     public function displayPaymentMethodTitle_ifOrderPaidWithPaypal_returnPaypalTitle()
     {
         $this->currentMock->expects(self::any())->method('getInfo')->willReturn($this->infoMock);
-        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_processor')
+        $this->infoMock->expects(self::once())->method('getAdditionalInformation')->with('bolt_payment_processor')
             ->willReturn('paypal');
         $this->assertEquals(
             'Bolt-PayPal',

--- a/tests/unit/testsuite/Bolt/Boltpay/Block/InfoTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Block/InfoTest.php
@@ -110,6 +110,8 @@ class Bolt_Boltpay_Block_InfoTest extends PHPUnit_Framework_TestCase
     
     /**
      * @test
+     *
+     * @dataProvider displayPaymentMethodTitle_ifOrderPaidWithAPM_Provider
      * 
      * @covers ::displayPaymentMethodTitle
      */

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
@@ -278,21 +278,22 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * that getConfigData returns {@see Bolt_Boltpay_Model_Payment::TITLE} constant for title if not in admin area
+     * that getConfigData returns the defined config for 'title' if not in the admin area
      *
      * @covers ::getConfigData
      *
      * @throws Mage_Core_Model_Store_Exception if unable to stub config value
      */
-    public function getConfigData_notAdminAreaWithFieldTitle_returnsTitleConstant()
+    public function getConfigData_notAdminAreaWithFieldTitle_returnsConfigValue()
     {
         Bolt_Boltpay_TestHelper::stubConfigValue('payment/boltpay/skip_payment', 1);
+        Bolt_Boltpay_TestHelper::stubConfigValue('payment/boltpay/title', 'Mock Bolt Title');
 
         $this->currentMock->expects($this->once())->method('isAdminArea')->willReturn(false);
 
         $result = $this->currentMock->getConfigData('title');
 
-        $this->assertEquals(Bolt_Boltpay_Model_Payment::TITLE, $result, 'TITLE field does not match');
+        $this->assertEquals('Mock Bolt Title', $result, 'TITLE field does not match');
     }
 
     /**
@@ -3735,8 +3736,8 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
         $transaction->processor = 'vantiv';
         $this->paymentMock->expects($this->once())->method('setCcLast4')->with($this->equalTo('1111'))->willReturnSelf();
         $this->paymentMock->expects($this->once())->method('setCcType')->with($this->equalTo('visa'))->willReturnSelf();
-        $this->paymentMock->expects($this->once())->method('getAdditionalInformation')->with($this->equalTo('bolt_processor'))->willReturn(false);
-        $this->paymentMock->expects($this->once())->method('setAdditionalInformation')->with('bolt_processor', 'vantiv')->willReturnSelf();
+        $this->paymentMock->expects($this->once())->method('getAdditionalInformation')->with($this->equalTo('bolt_payment_processor'))->willReturn(false);
+        $this->paymentMock->expects($this->once())->method('setAdditionalInformation')->with('bolt_payment_processor', 'vantiv')->willReturnSelf();
 
         Bolt_Boltpay_TestHelper::callNonPublicFunction($this->currentMock, 'setOrderPaymentInfoData', [$this->paymentMock, 'TEST-BOLT-TRNX', $transaction]);
     }
@@ -3752,8 +3753,8 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
         $transaction->processor = 'paypal';
         $this->paymentMock->expects($this->never())->method('setCcLast4');
         $this->paymentMock->expects($this->never())->method('setCcType');
-        $this->paymentMock->expects($this->once())->method('getAdditionalInformation')->with($this->equalTo('bolt_processor'))->willReturn(false);
-        $this->paymentMock->expects($this->once())->method('setAdditionalInformation')->with('bolt_processor', 'paypal')->willReturnSelf();
+        $this->paymentMock->expects($this->once())->method('getAdditionalInformation')->with($this->equalTo('bolt_payment_processor'))->willReturn(false);
+        $this->paymentMock->expects($this->once())->method('setAdditionalInformation')->with('bolt_payment_processor', 'paypal')->willReturnSelf();
 
         Bolt_Boltpay_TestHelper::callNonPublicFunction($this->currentMock, 'setOrderPaymentInfoData', [$this->paymentMock, 'TEST-BOLT-TRNX', $transaction]);
     }

--- a/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
+++ b/tests/unit/testsuite/Bolt/Boltpay/Model/PaymentTest.php
@@ -56,7 +56,7 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
         $this->boltHelperMock = $this->getClassPrototype('Bolt_Boltpay_Helper_Data')
             ->setMethods(array('transmit', 'canUseBolt', 'notifyException', 'logWarning', 'fetchTransaction'))
             ->getMock();
-        $this->paymentMock = $this->getTestClassPrototype()->setMethods(array('getAdditionalInformation', 'getOrder','setCcLast4','setCcType'))
+        $this->paymentMock = $this->getTestClassPrototype()->setMethods(array('getAdditionalInformation','setAdditionalInformation','getOrder','setCcLast4','setCcType'))
             ->getMock();
         $this->orderMock = $this->getClassPrototype('Mage_Sales_Model_Order')
             ->setMethods(array())->getMock();
@@ -3730,10 +3730,30 @@ class Bolt_Boltpay_Model_PaymentTest extends PHPUnit_Framework_TestCase
      *
      * @covers ::setOrderPaymentInfoData
      */
-    public function setOrderPaymentInfoData_withTransaction() {
+    public function setOrderPaymentInfoData_withTransaction_ProcessorCreditCard() {
         $transaction = $this->generateTestTransactionObject();
+        $transaction->processor = 'vantiv';
         $this->paymentMock->expects($this->once())->method('setCcLast4')->with($this->equalTo('1111'))->willReturnSelf();
         $this->paymentMock->expects($this->once())->method('setCcType')->with($this->equalTo('visa'))->willReturnSelf();
+        $this->paymentMock->expects($this->once())->method('getAdditionalInformation')->with($this->equalTo('bolt_processor'))->willReturn(false);
+        $this->paymentMock->expects($this->once())->method('setAdditionalInformation')->with('bolt_processor', 'vantiv')->willReturnSelf();
+
+        Bolt_Boltpay_TestHelper::callNonPublicFunction($this->currentMock, 'setOrderPaymentInfoData', [$this->paymentMock, 'TEST-BOLT-TRNX', $transaction]);
+    }
+    
+    /**
+     * @test
+     * that setOrderPaymentInfoData with transaction
+     *
+     * @covers ::setOrderPaymentInfoData
+     */
+    public function setOrderPaymentInfoData_withTransaction_ProcessorPaypal() {
+        $transaction = $this->generateTestTransactionObject();
+        $transaction->processor = 'paypal';
+        $this->paymentMock->expects($this->never())->method('setCcLast4');
+        $this->paymentMock->expects($this->never())->method('setCcType');
+        $this->paymentMock->expects($this->once())->method('getAdditionalInformation')->with($this->equalTo('bolt_processor'))->willReturn(false);
+        $this->paymentMock->expects($this->once())->method('setAdditionalInformation')->with('bolt_processor', 'paypal')->willReturnSelf();
 
         Bolt_Boltpay_TestHelper::callNonPublicFunction($this->currentMock, 'setOrderPaymentInfoData', [$this->paymentMock, 'TEST-BOLT-TRNX', $transaction]);
     }


### PR DESCRIPTION
# Description
There is no way to identify that an order was a PayPal/APM purchase through Bolt within M1.
So we need to add support for displaying info Paypal/APM info in the order details.

Fixes: https://boltpay.atlassian.net/browse/M1P-67

#changelog Fix display of APM/PayPal Transactions within Magento 1 Dashboard

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [ ] Successfully tested locally (or docker image)
- [x] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.
