### PR TITLE
MA-50 Use old version of n98-magerun for PHP5.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           steps:
             - run:
                 name: PHP 5.5 Magento 1.8
-                command: MAGENTO_VERSION=magento-mirror-1.8.1.0 PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar tests/scripts/setup_and_test.sh nocov
+                command: PHP_VERSION=5.5 MAGENTO_VERSION=magento-mirror-1.8.1.0 PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar tests/scripts/setup_and_test.sh nocov
             - notify-buildcop
   unit-php55-mage19:
     docker:
@@ -71,7 +71,7 @@ jobs:
           steps:
             - run:
                 name: PHP 5.5 Magento 1.9
-                command: MAGENTO_VERSION=magento-mirror-1.9.3.6 PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar tests/scripts/setup_and_test.sh nocov
+                command: PHP_VERSION=5.5 MAGENTO_VERSION=magento-mirror-1.9.3.6 PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar tests/scripts/setup_and_test.sh nocov
             - notify-buildcop
   unit-php56-mage18:
     docker:
@@ -85,7 +85,7 @@ jobs:
                 name: PHP 5.6 Magento 1.8
                 command: |
                   mkdir ./artifacts
-                  MAGENTO_VERSION=magento-mirror-1.8.1.0 PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar tests/scripts/setup_and_test.sh withcov
+                  PHP_VERSION=5.6 MAGENTO_VERSION=magento-mirror-1.8.1.0 PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar tests/scripts/setup_and_test.sh withcov
             - store_artifacts:
                 path: ./artifacts
             - notify-buildcop
@@ -101,7 +101,7 @@ jobs:
                 name: PHP 5.6 Magento 1.9
                 command: |
                   mkdir ./artifacts
-                  MAGENTO_VERSION=magento-mirror-1.9.3.6 PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar tests/scripts/setup_and_test.sh withcov
+                  PHP_VERSION=5.6 MAGENTO_VERSION=magento-mirror-1.9.3.6 PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar tests/scripts/setup_and_test.sh withcov
             - store_artifacts:
                 path: ./artifacts
             - notify-buildcop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           steps:
             - run:
                 name: PHP 5.5 Magento 1.9
-                command: PHP_VERSION=5.5 MAGENTO_VERSION=magento-mirror-1.9.3.6 PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar tests/scripts/setup_and_test.sh nocov
+                command: PHP_VERSION=5.5 MAGENTO_VERSION=magento-mirror-1.9.4.1 PHPUNIT_PHAR=tests/unit/phpunit-4.8.36.phar tests/scripts/setup_and_test.sh nocov
             - notify-buildcop
   unit-php56-mage18:
     docker:
@@ -101,7 +101,7 @@ jobs:
                 name: PHP 5.6 Magento 1.9
                 command: |
                   mkdir ./artifacts
-                  PHP_VERSION=5.6 MAGENTO_VERSION=magento-mirror-1.9.3.6 PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar tests/scripts/setup_and_test.sh withcov
+                  PHP_VERSION=5.6 MAGENTO_VERSION=magento-mirror-1.9.4.5 PHPUNIT_PHAR=tests/unit/phpunit-5.7.9.phar tests/scripts/setup_and_test.sh withcov
             - store_artifacts:
                 path: ./artifacts
             - notify-buildcop
@@ -118,7 +118,7 @@ jobs:
       - run:
           name: Integration test
           command: |
-            MAGENTO_VERSION=magento-mirror-1.9.3.6 tests/scripts/setup_integration.sh
+            MAGENTO_VERSION=magento-mirror-1.9.4.5 tests/scripts/setup_integration.sh
             echo "Running integration test"
             git clone git@github.com:BoltApp/integration-tests.git
             cd integration-tests

--- a/tests/scripts/setup_and_test.sh
+++ b/tests/scripts/setup_and_test.sh
@@ -5,7 +5,11 @@ set -u
 set -x
 
 echo "Installing magento..."
-curl -O https://files.magerun.net/n98-magerun.phar
+if [ "${PHP_VERSION}" == "5.5" ]; then
+  curl -o  n98-magerun.phar https://files.magerun.net/n98-magerun-1.98.0.phar
+else
+ curl -O https://files.magerun.net/n98-magerun.phar
+fi
 chmod +x n98-magerun.phar
 MAGENTO_DIR='./magento'
 php -d memory_limit=512M n98-magerun.phar install --magentoVersionByName=$MAGENTO_VERSION \

--- a/tests/scripts/setup_and_test.sh
+++ b/tests/scripts/setup_and_test.sh
@@ -6,7 +6,7 @@ set -x
 
 echo "Installing magento..."
 if [ "${PHP_VERSION}" == "5.5" ]; then
-  curl -o  n98-magerun.phar https://files.magerun.net/n98-magerun-1.98.0.phar
+  curl -o  n98-magerun.phar https://files.magerun.net/n98-magerun-1.103.3.phar
 else
  curl -O https://files.magerun.net/n98-magerun.phar
 fi

--- a/tests/scripts/setup_and_test.sh
+++ b/tests/scripts/setup_and_test.sh
@@ -8,7 +8,7 @@ echo "Installing magento..."
 if [ "${PHP_VERSION}" == "5.5" ]; then
   curl -o  n98-magerun.phar https://files.magerun.net/n98-magerun-1.103.3.phar
 else
- curl -O https://files.magerun.net/n98-magerun.phar
+  curl -O https://files.magerun.net/n98-magerun.phar
 fi
 chmod +x n98-magerun.phar
 MAGENTO_DIR='./magento'


### PR DESCRIPTION
The tool n98-magerun we use for M1 installing doesn't support PHP5.5 from its version 2.0
So we need to use previous tool version for PHP5.5 workflow.

Fixes: [MA-50]

#changelog MA-50 Use old version of n98-magerun for PHP5.5

# Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Test

# How Has This Been Tested?
Please validate that you have tested your change in at least one of the following areas:

- [x] Successfully tested locally (or docker image)
- [ ] Successfully tested on a staging or sandbox server
- [ ] Successfully tested on a merchant's staging server


# Checklist:

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have created or modified unit tests to sufficiently cover my changes.
- [ ] I have added my Asana task link and provided a changelog message if applicable.


[MA-50]: https://boltpay.atlassian.net/browse/MA-50